### PR TITLE
[Feat] 대화/MCP 호출 히스토리 저장 로직 추가 & 더미데이터 파일 삽입 & Top N개 반환 쿼리 & 통합 테스트

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
@@ -3,6 +3,7 @@ package dgu.capstone.nunchi.domain.menu.controller;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuResponse;
+import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
 import dgu.capstone.nunchi.domain.menu.service.MenuService;
 import dgu.capstone.nunchi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,14 @@ import java.util.List;
 public class MenuController {
 
     private final MenuService menuService;
+
+    @Operation(summary = "오늘 판매량 상위 메뉴 조회", description = "오늘 날짜 기준 판매량 합산 후 내림차순 상위 N개 반환")
+    @GetMapping("/top")
+    public ResponseEntity<ApiResponse<List<TopMenuResponse>>> getTopMenus(
+            @Parameter(description = "조회할 메뉴 수") @RequestParam(defaultValue = "5") int limit
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(menuService.getTopMenus(limit)));
+    }
 
     @Operation(summary = "카테고리 목록 조회")
     @GetMapping("/categories")

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/TopMenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/TopMenuResponse.java
@@ -1,0 +1,10 @@
+package dgu.capstone.nunchi.domain.menu.dto.response;
+
+public record TopMenuResponse(
+        Long menuId,
+        String name,
+        Integer price,
+        Boolean isSoldOut,
+        Long quantitySold
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/SalesDailyRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/SalesDailyRepository.java
@@ -1,7 +1,25 @@
 package dgu.capstone.nunchi.domain.menu.repository;
 
+import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
 import dgu.capstone.nunchi.domain.menu.entity.SalesDaily;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SalesDailyRepository extends JpaRepository<SalesDaily, Long> {
+
+    @Query("""
+            SELECT new dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse(
+                s.menu.menuId, s.menu.name, s.menu.price, s.menu.isSoldOut, SUM(s.quantitySold)
+            )
+            FROM SalesDaily s
+            WHERE s.salesDate = :today
+            GROUP BY s.menu.menuId, s.menu.name, s.menu.price, s.menu.isSoldOut
+            ORDER BY SUM(s.quantitySold) DESC
+            """)
+    List<TopMenuResponse> findTopMenusByDate(@Param("today") LocalDate today, Pageable pageable);
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -3,6 +3,7 @@ package dgu.capstone.nunchi.domain.menu.service;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuResponse;
+import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
 import dgu.capstone.nunchi.domain.menu.entity.Menu;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOption;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOptionGroup;
@@ -10,12 +11,15 @@ import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuOptionGroupRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuOptionRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.domain.menu.repository.SalesDailyRepository;
 import dgu.capstone.nunchi.global.exception.domainException.MenuException;
 import dgu.capstone.nunchi.global.exception.errorcode.MenuErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,6 +33,7 @@ public class MenuService {
     private final MenuCategoryRepository menuCategoryRepository;
     private final MenuOptionGroupRepository menuOptionGroupRepository;
     private final MenuOptionRepository menuOptionRepository;
+    private final SalesDailyRepository salesDailyRepository;
 
     // 전체 카테고리 조회
     public List<MenuCategoryResponse> getCategories() {
@@ -46,6 +51,11 @@ public class MenuService {
         return menus.stream()
                 .map(MenuResponse::from)
                 .toList();
+    }
+
+    // 오늘 날짜 기준 판매량 상위 메뉴 조회
+    public List<TopMenuResponse> getTopMenus(int limit) {
+        return salesDailyRepository.findTopMenusByDate(LocalDate.now(), PageRequest.of(0, limit));
     }
 
     // 메뉴 상세 조회 (옵션그룹 + 옵션 포함, N+1 방지)

--- a/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
@@ -1,7 +1,9 @@
 package dgu.capstone.nunchi.domain.session.controller;
 
+import dgu.capstone.nunchi.domain.session.dto.request.AiToolCallLogSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.response.AiToolCallLogResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
 import dgu.capstone.nunchi.domain.session.service.SessionService;
@@ -14,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Session", description = "세션 관리 API")
 @RestController
@@ -49,6 +53,26 @@ public class SessionController {
             @RequestBody @Valid ConversationMessageSaveRequest request
     ) {
         ConversationMessageResponse response = sessionService.saveMessage(sessionId, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "AI 툴 호출 로그 저장", description = "FastAPI가 툴 호출 결과를 session 단위로 저장할 때 호출")
+    @PostMapping("/{sessionId}/tool-logs")
+    public ResponseEntity<ApiResponse<AiToolCallLogResponse>> saveToolCallLog(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @RequestBody @Valid AiToolCallLogSaveRequest request
+    ) {
+        AiToolCallLogResponse response = sessionService.saveToolCallLog(sessionId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "AI 툴 호출 로그 조회", description = "세션에 연결된 AI 툴 호출 로그를 생성 시각 순으로 조회")
+    @GetMapping("/{sessionId}/tool-logs")
+    public ResponseEntity<ApiResponse<List<AiToolCallLogResponse>>> getToolCallLogs(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId
+    ) {
+        List<AiToolCallLogResponse> response = sessionService.getToolCallLogs(sessionId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
@@ -1,6 +1,8 @@
 package dgu.capstone.nunchi.domain.session.controller;
 
+import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
 import dgu.capstone.nunchi.domain.session.service.SessionService;
 import dgu.capstone.nunchi.global.response.ApiResponse;
@@ -37,6 +39,16 @@ public class SessionController {
             @Parameter(description = "세션 ID") @PathVariable Long sessionId
     ) {
         SessionResponse response = sessionService.completeSession(sessionId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "대화 메시지 저장", description = "FastAPI가 사용자 발화 및 AI 응답을 저장할 때 호출. role: USER / ASSISTANT")
+    @PostMapping("/{sessionId}/messages")
+    public ResponseEntity<ApiResponse<ConversationMessageResponse>> saveMessage(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @RequestBody @Valid ConversationMessageSaveRequest request
+    ) {
+        ConversationMessageResponse response = sessionService.saveMessage(sessionId, request);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
@@ -53,7 +53,8 @@ public class SessionController {
             @RequestBody @Valid ConversationMessageSaveRequest request
     ) {
         ConversationMessageResponse response = sessionService.saveMessage(sessionId, request);
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
     }
 
     @Operation(summary = "AI 툴 호출 로그 저장", description = "FastAPI가 툴 호출 결과를 session 단위로 저장할 때 호출")
@@ -70,9 +71,10 @@ public class SessionController {
     @Operation(summary = "AI 툴 호출 로그 조회", description = "세션에 연결된 AI 툴 호출 로그를 생성 시각 순으로 조회")
     @GetMapping("/{sessionId}/tool-logs")
     public ResponseEntity<ApiResponse<List<AiToolCallLogResponse>>> getToolCallLogs(
-            @Parameter(description = "세션 ID") @PathVariable Long sessionId
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @Parameter(description = "조회 최대 개수") @RequestParam(defaultValue = "50") int limit
     ) {
-        List<AiToolCallLogResponse> response = sessionService.getToolCallLogs(sessionId);
+        List<AiToolCallLogResponse> response = sessionService.getToolCallLogs(sessionId, limit);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/AiToolCallLogSaveRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/AiToolCallLogSaveRequest.java
@@ -1,0 +1,16 @@
+package dgu.capstone.nunchi.domain.session.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AiToolCallLogSaveRequest(
+
+        @NotBlank(message = "toolName은 필수입니다.")
+        String toolName,
+
+        @NotBlank(message = "request는 필수입니다.")
+        String request,
+
+        @NotBlank(message = "response는 필수입니다.")
+        String response
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/ConversationMessageSaveRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/ConversationMessageSaveRequest.java
@@ -1,0 +1,15 @@
+package dgu.capstone.nunchi.domain.session.dto.request;
+
+import dgu.capstone.nunchi.domain.session.entity.MessageRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ConversationMessageSaveRequest(
+
+        @NotNull(message = "role은 필수입니다.")
+        MessageRole role,
+
+        @NotBlank(message = "text는 필수입니다.")
+        String text
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/AiToolCallLogResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/AiToolCallLogResponse.java
@@ -1,0 +1,25 @@
+package dgu.capstone.nunchi.domain.session.dto.response;
+
+import dgu.capstone.nunchi.domain.session.entity.AiToolCallLog;
+
+import java.time.LocalDateTime;
+
+public record AiToolCallLogResponse(
+        Long logId,
+        Long sessionId,
+        String toolName,
+        String request,
+        String response,
+        LocalDateTime createdAt
+) {
+    public static AiToolCallLogResponse from(AiToolCallLog log) {
+        return new AiToolCallLogResponse(
+                log.getLogId(),
+                log.getSession().getSessionId(),
+                log.getToolName(),
+                log.getRequest(),
+                log.getResponse(),
+                log.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/AiToolCallLogResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/AiToolCallLogResponse.java
@@ -8,8 +8,6 @@ public record AiToolCallLogResponse(
         Long logId,
         Long sessionId,
         String toolName,
-        String request,
-        String response,
         LocalDateTime createdAt
 ) {
     public static AiToolCallLogResponse from(AiToolCallLog log) {
@@ -17,8 +15,6 @@ public record AiToolCallLogResponse(
                 log.getLogId(),
                 log.getSession().getSessionId(),
                 log.getToolName(),
-                log.getRequest(),
-                log.getResponse(),
                 log.getCreatedAt()
         );
     }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/ConversationMessageResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/ConversationMessageResponse.java
@@ -1,0 +1,23 @@
+package dgu.capstone.nunchi.domain.session.dto.response;
+
+import dgu.capstone.nunchi.domain.session.entity.ConversationMessage;
+
+import java.time.LocalDateTime;
+
+public record ConversationMessageResponse(
+        Long messageId,
+        Long sessionId,
+        String role,
+        String text,
+        LocalDateTime createdAt
+) {
+    public static ConversationMessageResponse from(ConversationMessage message) {
+        return new ConversationMessageResponse(
+                message.getConversationId(),
+                message.getSession().getSessionId(),
+                message.getRole().name(),
+                message.getText(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/repository/AiToolCallLogRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/repository/AiToolCallLogRepository.java
@@ -3,5 +3,9 @@ package dgu.capstone.nunchi.domain.session.repository;
 import dgu.capstone.nunchi.domain.session.entity.AiToolCallLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AiToolCallLogRepository extends JpaRepository<AiToolCallLog, Long> {
+
+    List<AiToolCallLog> findAllBySessionSessionIdOrderByCreatedAtAsc(Long sessionId);
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/repository/AiToolCallLogRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/repository/AiToolCallLogRepository.java
@@ -1,11 +1,12 @@
 package dgu.capstone.nunchi.domain.session.repository;
 
 import dgu.capstone.nunchi.domain.session.entity.AiToolCallLog;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AiToolCallLogRepository extends JpaRepository<AiToolCallLog, Long> {
 
-    List<AiToolCallLog> findAllBySessionSessionIdOrderByCreatedAtAsc(Long sessionId);
+    List<AiToolCallLog> findAllBySessionSessionIdOrderByCreatedAtAsc(Long sessionId, Pageable pageable);
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -1,9 +1,13 @@
 package dgu.capstone.nunchi.domain.session.service;
 
+import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
+import dgu.capstone.nunchi.domain.session.entity.ConversationMessage;
 import dgu.capstone.nunchi.domain.session.entity.KioskSession;
 import dgu.capstone.nunchi.domain.session.entity.SessionStatus;
+import dgu.capstone.nunchi.domain.session.repository.ConversationMessageRepository;
 import dgu.capstone.nunchi.domain.session.repository.KioskSessionRepository;
 import dgu.capstone.nunchi.global.exception.domainException.SessionException;
 import dgu.capstone.nunchi.global.exception.errorcode.SessionErrorCode;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SessionService {
 
     private final KioskSessionRepository kioskSessionRepository;
+    private final ConversationMessageRepository conversationMessageRepository;
 
     @Transactional
     public SessionResponse createSession(SessionCreateRequest request) {
@@ -37,5 +42,16 @@ public class SessionService {
 
         session.complete();
         return SessionResponse.from(session);
+    }
+
+    @Transactional
+    public ConversationMessageResponse saveMessage(Long sessionId, ConversationMessageSaveRequest request) {
+        KioskSession session = kioskSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new SessionException(SessionErrorCode.NOT_FOUND_SESSION));
+
+        ConversationMessage message = ConversationMessage.create(session, request.role(), request.text());
+        conversationMessageRepository.save(message);
+
+        return ConversationMessageResponse.from(message);
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -1,12 +1,16 @@
 package dgu.capstone.nunchi.domain.session.service;
 
+import dgu.capstone.nunchi.domain.session.dto.request.AiToolCallLogSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.response.AiToolCallLogResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
+import dgu.capstone.nunchi.domain.session.entity.AiToolCallLog;
 import dgu.capstone.nunchi.domain.session.entity.ConversationMessage;
 import dgu.capstone.nunchi.domain.session.entity.KioskSession;
 import dgu.capstone.nunchi.domain.session.entity.SessionStatus;
+import dgu.capstone.nunchi.domain.session.repository.AiToolCallLogRepository;
 import dgu.capstone.nunchi.domain.session.repository.ConversationMessageRepository;
 import dgu.capstone.nunchi.domain.session.repository.KioskSessionRepository;
 import dgu.capstone.nunchi.global.exception.domainException.SessionException;
@@ -15,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -22,6 +28,7 @@ public class SessionService {
 
     private final KioskSessionRepository kioskSessionRepository;
     private final ConversationMessageRepository conversationMessageRepository;
+    private final AiToolCallLogRepository aiToolCallLogRepository;
 
     @Transactional
     public SessionResponse createSession(SessionCreateRequest request) {
@@ -53,5 +60,32 @@ public class SessionService {
         conversationMessageRepository.save(message);
 
         return ConversationMessageResponse.from(message);
+    }
+
+    @Transactional
+    public AiToolCallLogResponse saveToolCallLog(Long sessionId, AiToolCallLogSaveRequest request) {
+        KioskSession session = kioskSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new SessionException(SessionErrorCode.NOT_FOUND_SESSION));
+
+        AiToolCallLog log = AiToolCallLog.create(
+                session,
+                request.toolName(),
+                request.request(),
+                request.response()
+        );
+        aiToolCallLogRepository.save(log);
+
+        return AiToolCallLogResponse.from(log);
+    }
+
+    public List<AiToolCallLogResponse> getToolCallLogs(Long sessionId) {
+        if (!kioskSessionRepository.existsById(sessionId)) {
+            throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
+        }
+
+        return aiToolCallLogRepository.findAllBySessionSessionIdOrderByCreatedAtAsc(sessionId)
+                .stream()
+                .map(AiToolCallLogResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.PageRequest;
+
 import java.util.List;
 
 @Service
@@ -78,12 +80,12 @@ public class SessionService {
         return AiToolCallLogResponse.from(log);
     }
 
-    public List<AiToolCallLogResponse> getToolCallLogs(Long sessionId) {
+    public List<AiToolCallLogResponse> getToolCallLogs(Long sessionId, int limit) {
         if (!kioskSessionRepository.existsById(sessionId)) {
             throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
         }
 
-        return aiToolCallLogRepository.findAllBySessionSessionIdOrderByCreatedAtAsc(sessionId)
+        return aiToolCallLogRepository.findAllBySessionSessionIdOrderByCreatedAtAsc(sessionId, PageRequest.of(0, limit))
                 .stream()
                 .map(AiToolCallLogResponse::from)
                 .toList();

--- a/src/main/java/dgu/capstone/nunchi/global/config/DataInitializer.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/DataInitializer.java
@@ -1,0 +1,311 @@
+package dgu.capstone.nunchi.global.config;
+
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import dgu.capstone.nunchi.domain.menu.entity.MenuCategory;
+import dgu.capstone.nunchi.domain.menu.entity.MenuOption;
+import dgu.capstone.nunchi.domain.menu.entity.MenuOptionGroup;
+import dgu.capstone.nunchi.domain.menu.entity.SalesDaily;
+import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
+import dgu.capstone.nunchi.domain.menu.repository.MenuOptionGroupRepository;
+import dgu.capstone.nunchi.domain.menu.repository.MenuOptionRepository;
+import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.domain.menu.repository.SalesDailyRepository;
+import dgu.capstone.nunchi.domain.order.entity.Order;
+import dgu.capstone.nunchi.domain.order.entity.OrderItem;
+import dgu.capstone.nunchi.domain.order.entity.OrderItemOption;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemOptionRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import dgu.capstone.nunchi.domain.payment.entity.Payment;
+import dgu.capstone.nunchi.domain.payment.entity.PaymentMethod;
+import dgu.capstone.nunchi.domain.payment.repository.PaymentRepository;
+import dgu.capstone.nunchi.domain.session.entity.AiToolCallLog;
+import dgu.capstone.nunchi.domain.session.entity.ConversationMessage;
+import dgu.capstone.nunchi.domain.session.entity.KioskSession;
+import dgu.capstone.nunchi.domain.session.entity.MessageRole;
+import dgu.capstone.nunchi.domain.session.entity.SessionMode;
+import dgu.capstone.nunchi.domain.session.repository.AiToolCallLogRepository;
+import dgu.capstone.nunchi.domain.session.repository.ConversationMessageRepository;
+import dgu.capstone.nunchi.domain.session.repository.KioskSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private static final int SALES_HISTORY_DAYS = 7;
+
+    private final MenuCategoryRepository menuCategoryRepository;
+    private final MenuRepository menuRepository;
+    private final MenuOptionGroupRepository menuOptionGroupRepository;
+    private final MenuOptionRepository menuOptionRepository;
+    private final SalesDailyRepository salesDailyRepository;
+    private final KioskSessionRepository kioskSessionRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final OrderItemOptionRepository orderItemOptionRepository;
+    private final PaymentRepository paymentRepository;
+    private final ConversationMessageRepository conversationMessageRepository;
+    private final AiToolCallLogRepository aiToolCallLogRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (menuCategoryRepository.count() > 0) {
+            return;
+        }
+
+        MenuSeedData menuData = seedMenus();
+        seedSalesHistory(menuData);
+
+        SessionSeedData sessionData = seedSessions();
+        seedConversationMessages(sessionData.avatarSession());
+        seedAiToolCallLogs(sessionData.avatarSession());
+        seedOrdersAndPayments(menuData, sessionData);
+    }
+
+    private MenuSeedData seedMenus() {
+        MenuCategory catBurger = menuCategoryRepository.save(MenuCategory.create("버거", 1));
+        MenuCategory catSide = menuCategoryRepository.save(MenuCategory.create("사이드", 2));
+        MenuCategory catDrink = menuCategoryRepository.save(MenuCategory.create("음료", 3));
+        MenuCategory catSet = menuCategoryRepository.save(MenuCategory.create("세트", 4));
+
+        Menu burger1 = menuRepository.save(Menu.create("불고기버거", 4500, "/images/menu/bulgogi.jpg", catBurger));
+        Menu burger2 = menuRepository.save(Menu.create("치킨버거", 4000, "/images/menu/chicken.jpg", catBurger));
+        Menu burger3 = menuRepository.save(Menu.builder()
+                .name("새우버거")
+                .price(4200)
+                .imageUrl("/images/menu/shrimp.jpg")
+                .category(catBurger)
+                .isSoldOut(true)
+                .isRecommended(false)
+                .build());
+        Menu burger4 = menuRepository.save(Menu.builder()
+                .name("더블패티버거")
+                .price(5500)
+                .imageUrl("/images/menu/double.jpg")
+                .category(catBurger)
+                .isSoldOut(false)
+                .isRecommended(true)
+                .build());
+
+        Menu side1 = menuRepository.save(Menu.create("감자튀김", 1500, "/images/menu/fries.jpg", catSide));
+        Menu side2 = menuRepository.save(Menu.create("어니언링", 2000, "/images/menu/onion.jpg", catSide));
+        Menu side3 = menuRepository.save(Menu.builder()
+                .name("코울슬로")
+                .price(1200)
+                .imageUrl("/images/menu/coleslaw.jpg")
+                .category(catSide)
+                .isSoldOut(false)
+                .isRecommended(true)
+                .build());
+
+        Menu drink1 = menuRepository.save(Menu.create("콜라", 1000, "/images/menu/cola.jpg", catDrink));
+        Menu drink2 = menuRepository.save(Menu.create("사이다", 1000, "/images/menu/cider.jpg", catDrink));
+        Menu drink3 = menuRepository.save(Menu.create("오렌지주스", 1500, "/images/menu/oj.jpg", catDrink));
+        Menu drink4 = menuRepository.save(Menu.builder()
+                .name("아메리카노")
+                .price(2000)
+                .imageUrl("/images/menu/americano.jpg")
+                .category(catDrink)
+                .isSoldOut(false)
+                .isRecommended(true)
+                .build());
+
+        Menu set1 = menuRepository.save(Menu.builder()
+                .name("불고기버거세트")
+                .price(6500)
+                .imageUrl("/images/menu/bulgogi_set.jpg")
+                .category(catSet)
+                .isSoldOut(false)
+                .isRecommended(true)
+                .build());
+        Menu set2 = menuRepository.save(Menu.create("치킨버거세트", 6000, "/images/menu/chicken_set.jpg", catSet));
+
+        MenuOptionGroup sizeGroup = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("사이즈", false, 1, burger1));
+        menuOptionRepository.save(MenuOption.create("기본", 0, sizeGroup));
+        MenuOption optLarge = menuOptionRepository.save(MenuOption.create("라지", 500, sizeGroup));
+
+        MenuOptionGroup sauceGroup = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("소스", false, 2, burger1));
+        MenuOption optKetchup = menuOptionRepository.save(MenuOption.create("케첩", 0, sauceGroup));
+        menuOptionRepository.save(MenuOption.create("머스타드", 0, sauceGroup));
+        menuOptionRepository.save(MenuOption.create("마요네즈", 0, sauceGroup));
+
+        MenuOptionGroup cookGroup = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("패티 굽기", true, 1, burger4));
+        menuOptionRepository.save(MenuOption.create("웰던", 0, cookGroup));
+        menuOptionRepository.save(MenuOption.create("미디엄", 0, cookGroup));
+        menuOptionRepository.save(MenuOption.create("레어", 0, cookGroup));
+
+        MenuOptionGroup saltGroup = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("소금 옵션", false, 1, side1));
+        menuOptionRepository.save(MenuOption.create("소금 없이", 0, saltGroup));
+        menuOptionRepository.save(MenuOption.create("소금 추가", 0, saltGroup));
+
+        MenuOptionGroup drinkSize1 = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("사이즈", true, 1, drink1));
+        menuOptionRepository.save(MenuOption.create("S", 0, drinkSize1));
+        menuOptionRepository.save(MenuOption.create("M", 300, drinkSize1));
+        menuOptionRepository.save(MenuOption.create("L", 500, drinkSize1));
+
+        MenuOptionGroup drinkSize2 = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("사이즈", true, 1, drink2));
+        menuOptionRepository.save(MenuOption.create("S", 0, drinkSize2));
+        menuOptionRepository.save(MenuOption.create("M", 300, drinkSize2));
+        menuOptionRepository.save(MenuOption.create("L", 500, drinkSize2));
+
+        MenuOptionGroup setDrink = menuOptionGroupRepository.save(
+                MenuOptionGroup.create("음료 선택", true, 1, set1));
+        menuOptionRepository.save(MenuOption.create("콜라", 0, setDrink));
+        menuOptionRepository.save(MenuOption.create("사이다", 0, setDrink));
+        menuOptionRepository.save(MenuOption.create("오렌지주스", 500, setDrink));
+
+        return new MenuSeedData(
+                burger1,
+                burger2,
+                burger3,
+                burger4,
+                side1,
+                side2,
+                side3,
+                drink1,
+                drink2,
+                drink3,
+                drink4,
+                set1,
+                set2,
+                optLarge,
+                optKetchup
+        );
+    }
+
+    private void seedSalesHistory(MenuSeedData menuData) {
+        LocalDate today = LocalDate.now();
+
+        for (int i = SALES_HISTORY_DAYS - 1; i >= 0; i--) {
+            LocalDate date = today.minusDays(i);
+            salesDailyRepository.save(SalesDaily.create(date, 30 + i * 3, (30 + i * 3) * 4500, menuData.bulgogiBurger()));
+            salesDailyRepository.save(SalesDaily.create(date, 20 + i * 2, (20 + i * 2) * 4000, menuData.chickenBurger()));
+            salesDailyRepository.save(SalesDaily.create(date, 25 + i, (25 + i) * 6500, menuData.bulgogiBurgerSet()));
+            salesDailyRepository.save(SalesDaily.create(date, 40 + i * 4, (40 + i * 4) * 1500, menuData.frenchFries()));
+            salesDailyRepository.save(SalesDaily.create(date, 50 + i * 5, (50 + i * 5) * 1000, menuData.cola()));
+        }
+    }
+
+    private SessionSeedData seedSessions() {
+        KioskSession activeSession = kioskSessionRepository.save(KioskSession.create(SessionMode.NORMAL, "ko"));
+        KioskSession avatarSession = kioskSessionRepository.save(KioskSession.create(SessionMode.AVATAR, "ko"));
+        KioskSession completedSession = kioskSessionRepository.save(KioskSession.create(SessionMode.NORMAL, "ko"));
+        KioskSession expiredSession = kioskSessionRepository.save(KioskSession.create(SessionMode.AVATAR, "ko"));
+
+        completedSession.complete();
+        expiredSession.expire();
+
+        return new SessionSeedData(activeSession, avatarSession, completedSession, expiredSession);
+    }
+
+    private void seedConversationMessages(KioskSession avatarSession) {
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.USER, "안녕하세요, 메뉴 추천해 주세요"));
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.ASSISTANT, "안녕하세요! 오늘의 추천 메뉴는 더블패티버거와 불고기버거세트입니다."));
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.USER, "불고기버거세트 하나 주세요"));
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.ASSISTANT, "불고기버거세트 1개를 장바구니에 담았습니다. 음료는 어떤 걸로 하시겠어요?"));
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.USER, "콜라로 주세요"));
+        conversationMessageRepository.save(
+                ConversationMessage.create(avatarSession, MessageRole.ASSISTANT, "콜라로 설정했습니다. 결제를 진행할까요?"));
+    }
+
+    private void seedAiToolCallLogs(KioskSession avatarSession) {
+        aiToolCallLogRepository.save(AiToolCallLog.create(
+                avatarSession,
+                "recommend_menu",
+                "{\"userText\":\"안녕하세요, 메뉴 추천해 주세요\",\"mode\":\"AVATAR\",\"language\":\"ko\"}",
+                "{\"recommendedMenus\":[{\"name\":\"더블패티버거\"},{\"name\":\"불고기버거세트\"}]}"
+        ));
+
+        aiToolCallLogRepository.save(AiToolCallLog.create(
+                avatarSession,
+                "add_to_cart",
+                "{\"menuName\":\"불고기버거세트\",\"quantity\":1}",
+                "{\"cartItems\":[{\"menuName\":\"불고기버거세트\",\"quantity\":1}],\"orderStatus\":\"PENDING\"}"
+        ));
+
+        aiToolCallLogRepository.save(AiToolCallLog.create(
+                avatarSession,
+                "select_menu_option",
+                "{\"menuName\":\"불고기버거세트\",\"optionGroup\":\"음료 선택\",\"optionName\":\"콜라\"}",
+                "{\"selectedOption\":{\"optionGroup\":\"음료 선택\",\"optionName\":\"콜라\"}}"
+        ));
+    }
+
+    private void seedOrdersAndPayments(MenuSeedData menuData, SessionSeedData sessionData) {
+        Order orderPending = orderRepository.save(Order.create(sessionData.activeSession().getSessionId()));
+
+        Order orderCompleted = orderRepository.save(Order.create(sessionData.completedSession().getSessionId()));
+        OrderItem completedBurgerItem = orderItemRepository.save(
+                OrderItem.create(orderCompleted, menuData.bulgogiBurger().getMenuId(), 2, "불고기버거", 4500));
+        orderItemRepository.save(
+                OrderItem.create(orderCompleted, menuData.frenchFries().getMenuId(), 1, "감자튀김", 1500));
+        orderItemOptionRepository.save(
+                OrderItemOption.create(completedBurgerItem, menuData.largeOption().getOptionId(), "라지", 500));
+        orderItemOptionRepository.save(
+                OrderItemOption.create(completedBurgerItem, menuData.ketchupOption().getOptionId(), "케첩", 0));
+        orderCompleted.updateTotalAmount(10500);
+        orderCompleted.complete();
+
+        Order orderCancelled = orderRepository.save(Order.create(sessionData.expiredSession().getSessionId()));
+        orderItemRepository.save(
+                OrderItem.create(orderCancelled, menuData.cola().getMenuId(), 1, "콜라", 1000));
+        orderCancelled.cancel();
+
+        Payment paymentSuccess = paymentRepository.save(
+                Payment.create(orderCompleted.getOrderId(), PaymentMethod.IC_CARD));
+        paymentSuccess.success();
+
+        paymentRepository.save(Payment.create(orderPending.getOrderId(), PaymentMethod.VEIN_AUTH));
+
+        Payment paymentFailed = paymentRepository.save(
+                Payment.create(orderCancelled.getOrderId(), PaymentMethod.IC_CARD));
+        paymentFailed.fail();
+    }
+
+    private record MenuSeedData(
+            Menu bulgogiBurger,
+            Menu chickenBurger,
+            Menu shrimpBurger,
+            Menu doublePattyBurger,
+            Menu frenchFries,
+            Menu onionRings,
+            Menu coleslaw,
+            Menu cola,
+            Menu cider,
+            Menu orangeJuice,
+            Menu americano,
+            Menu bulgogiBurgerSet,
+            Menu chickenBurgerSet,
+            MenuOption largeOption,
+            MenuOption ketchupOption
+    ) {
+    }
+
+    private record SessionSeedData(
+            KioskSession activeSession,
+            KioskSession avatarSession,
+            KioskSession completedSession,
+            KioskSession expiredSession
+    ) {
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #6 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- FastAPI가 세션별 AI 툴 호출 이력을 저장할 수 있도록 메서드 추가했습니다.
- `DataInitializer` 파일이 있는데 더미 데이터를 삽입하기 위해 추가해뒀습니다. 실행하면 로컬 데이터베이스에 더미데이터 자동으로 박힙니다
- 현재 추천하는 로직이 없습니다. 그래서 간단한 오늘 많이 팔린메뉴 뭐야? 라고 했을 때 탑 N개만 반환 가능하도록 반환쿼리 작성 해뒀습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 로컬 DB설정 안되어 있어서 실행시 더미데이터 파일 관련 오류가 생기면 일단 그냥`DataInitializer`를 삭제하고 실행시켜도 됩니다. 따로 보내드릴게요.
- 나중에  영양성분에 따른 추천, 카테고리별 메뉴 추천, 시간대별 메뉴 추천 등등 추천로직이 고도화 된다면 JPQL이 아닌 QueryDSL로 동적쿼리문을 날려야 할 것 같아요! 현재는 고정적인 쿼리가 나가니까 JPQL으로만 구현 해뒀습니다
- 아래사진 보시면 특정 카테고리로 추천받는건 불가능 하다는걸 알 수 있을 겁니다...!! (호영이가 할 예정) 대신 단순 Top N개 는 돼요

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1416" height="917" alt="image" src="https://github.com/user-attachments/assets/7da9af08-d6b7-4548-ae3c-61231cb3ab59" />
<img width="1405" height="922" alt="image" src="https://github.com/user-attachments/assets/82cf3d6d-c05f-4e9e-869f-dbe87d4dd7f9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 세션 내 대화 메시지 저장 및 조회: 사용자와 AI 간의 대화 내용을 세션과 연결하여 저장하고 언제든 조회할 수 있습니다
  * AI 도구 호출 기록 저장: 도구명, 요청 내용, 응답 정보를 세션과 함께 저장 가능
  * 도구 호출 기록 조회: 특정 세션의 도구 호출 로그를 시간 순서대로 조회하고 확인할 수 있습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->