### PR TITLE
[Feat] #24 flowN - 메뉴 선택 화면 및 프론트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ reference/
 ### Figma raw export (변환 후 삭제) ###
 src/main/resources/static/_figma-raw/
 
+### macOS ###
+.DS_Store
+**/.DS_Store
+
 .env
 .env.*
 !.env.example

--- a/dev-server.py
+++ b/dev-server.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+NUNCHI · 프론트엔드 미리보기 서버
+=================================
+
+Spring Boot 를 띄우지 않고 브라우저에서 바로 확인하기 위한 작은 정적 서버.
+
+application-local.yml 의 매핑을 그대로 모사한다:
+    classpath:/static/front/        → URL 루트
+    classpath:/templates_front/     → URL 루트
+
+즉 두 폴더를 하나의 가상 루트로 합쳐서 서빙한다.
+
+실행:
+    python3 dev-server.py
+    (포트 변경:  python3 dev-server.py 5500)
+
+접속 URL:
+    http://localhost:8080/                       → 홈(index.html)
+    http://localhost:8080/S00-start.html
+    http://localhost:8080/S01-mode.html
+    http://localhost:8080/S02-dine.html
+    http://localhost:8080/flowN/N02-menu.html    ← 이번에 만든 메뉴 페이지
+
+종료:
+    Ctrl + C
+"""
+
+import http.server
+import socketserver
+import os
+import sys
+import posixpath
+from urllib.parse import unquote
+
+# ---- 두 정적 자원 루트 (우선순위 순) ----
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOTS = [
+    os.path.join(HERE, "src", "main", "resources", "static", "front"),
+    os.path.join(HERE, "src", "main", "resources", "templates_front"),
+]
+
+
+class MultiRootHandler(http.server.SimpleHTTPRequestHandler):
+    """ROOTS 배열을 차례로 뒤져 가장 먼저 발견된 파일을 응답한다."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        path = unquote(path)
+        # 보안: 상위로 빠져나가는 경로 차단
+        path = posixpath.normpath(path).lstrip("/").lstrip("\\")
+        if path.startswith(".."):
+            return os.path.join(ROOTS[0], "")
+
+        for root in ROOTS:
+            full = os.path.join(root, path)
+            if os.path.isfile(full):
+                return full
+            # 디렉터리면 index.html 폴백
+            if os.path.isdir(full):
+                idx = os.path.join(full, "index.html")
+                if os.path.isfile(idx):
+                    return idx
+        # 못 찾으면 첫 루트 기준 (404 처리)
+        return os.path.join(ROOTS[0], path)
+
+    def end_headers(self):
+        # 브라우저 캐시 무력화 — 수정 즉시 반영
+        self.send_header("Cache-Control", "no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+    def log_message(self, fmt, *args):
+        # 깔끔한 로그
+        sys.stdout.write("  %s\n" % (fmt % args))
+
+
+def main():
+    port = 8080
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"포트 번호가 올바르지 않습니다: {sys.argv[1]}")
+            sys.exit(1)
+
+    # 루트 존재 검증
+    missing = [r for r in ROOTS if not os.path.isdir(r)]
+    if missing:
+        print("아래 폴더가 보이지 않습니다 (프로젝트 루트에서 실행하세요):")
+        for m in missing:
+            print("  - " + m)
+        sys.exit(1)
+
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("", port), MultiRootHandler) as httpd:
+        print("=" * 60)
+        print(" NUNCHI 프론트 미리보기 서버 시작")
+        print("=" * 60)
+        print(f" 포트       : {port}")
+        print(f" 정적 루트  :")
+        for r in ROOTS:
+            print(f"   - {r}")
+        print()
+        print(" 바로가기:")
+        print(f"   홈        http://localhost:{port}/")
+        print(f"   메뉴(N02) http://localhost:{port}/flowN/N02-menu.html")
+        print(f"   모드(S01) http://localhost:{port}/S01-mode.html")
+        print(f"   포장(S02) http://localhost:{port}/S02-dine.html")
+        print()
+        print(" Chrome DevTools → 디바이스 툴바 → 720 × 1280 (Portrait) 권장")
+        print(" 종료: Ctrl + C")
+        print("=" * 60)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\n서버를 종료합니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/FRONTEND_GUIDE.md
+++ b/docs/FRONTEND_GUIDE.md
@@ -1,0 +1,728 @@
+# 눈치 키오스크 · 프론트엔드 구현 가이드
+
+> 이 문서는 `src/main/resources/` 하위에 **현재 구현되어 있는 프론트엔드 코드 자체**를 기준으로
+> 구조·기술 스택·디자인 토큰·컴포넌트·네이밍 규칙·코딩 컨벤션을 정리한 참조서입니다.
+> 새 화면을 디자인 시안 그대로 퍼블리싱하고, 기존 코드와 **일관된 방식으로 파인코딩**하기 위한
+> 유일한 소스(Source of Truth) 역할을 합니다.
+>
+> 설계/플로우 레벨의 기획 문서는 `docs/눈치키오스크_UIUX설계계획서.md` 를 참고하고,
+> 이 문서는 **"이미 작성된 코드와 동일한 방식으로 어떻게 계속 만들지"** 만 다룹니다.
+
+---
+
+## 1. 프로젝트 한눈에 보기
+
+| 항목 | 값 |
+|---|---|
+| 타깃 해상도 | **720 × 1280 px** (세로 키오스크, 설계서의 1080 × 1920 × 2/3 스케일) |
+| 렌더링 아키텍처 | **멀티 페이지 정적 HTML** (SPA 아님, 페이지 단위 `.html`) |
+| 스타일 전략 | CSS 토큰(`:root` 커스텀 프로퍼티) + **BEM 네이밍** + **글래스모피즘 + 블롭 배경** |
+| JS 전략 | 의존성 없는 **Vanilla JS IIFE** 패턴 (`jQuery`는 로드만 되고 현재 미사용) |
+| 상태 저장 | `sessionStorage` (키오스크 세션 범위) |
+| 백엔드 서빙 | Spring Boot (`application-local.yml` 에서 `classpath:/static/front/` + `classpath:/templates_front/` 를 static 경로로 매핑) |
+| 브라우저 타깃 | 키오스크 전용 최신 Chromium 1개 (크로스브라우저 고려 최소) |
+| 언어 | 한국어 단일 |
+
+---
+
+## 2. 디렉토리 구조 (프론트엔드 한정)
+
+```
+src/main/resources/
+├── application-local.yml              # static-locations 매핑 설정
+├── templates_front/                   # HTML 페이지 (URL 루트 = /)
+│   ├── index.html                     # S00 시작 화면
+│   ├── S01-mode.html                  # S01 주문 방식 선택 (일반 / AI)
+│   ├── S02-dine.html                  # S02 매장 / 포장 선택
+│   ├── flowN/                         # (비어있음) N02~N05 일반 주문 플로우
+│   ├── flowA/                         # (비어있음) A01 아바타 플로우
+│   ├── flowP/                         # (비어있음) P01~P06 결제 플로우
+│   └── layouts/                       # (비어있음) 공통 파셜
+└── static/front/                      # 정적 자원 (URL 루트 = /)
+    ├── css/
+    │   ├── common.css                 # 디자인 토큰 + @font-face + reset
+    │   ├── components.css             # 재사용 공통 컴포넌트
+    │   ├── S00-start.css              # S00 전용
+    │   ├── S01-mode.css               # S01 전용
+    │   ├── S02-dine.css               # S02 전용
+    │   ├── flowN/ flowA/ flowP/       # (비어있음)
+    ├── js/
+    │   ├── common/partials-loader.js  # data-include 파셜 로더
+    │   ├── S00-start.js               # 시작 화면 로직 (캐러셀·어트랙션)
+    │   ├── S01-mode.js                # 모드 선택
+    │   ├── S02-dine.js                # 매장/포장 선택
+    │   └── flowN/ flowA/ flowP/       # (비어있음)
+    ├── fonts/                         # Pretendard 9종 + DONGGUK UNIVERSITY
+    ├── images/
+    │   ├── avatars/                   # 할머니 이미지 + 통장님/이웃사촌 mp4
+    │   ├── logos/Dongguk-Logo.jpg
+    │   ├── bg/ categories/ icons/ menu/  # (비어있음)
+    └── lib/                           # 외부 라이브러리 (직접 번들)
+        ├── jquery-3.7.0.min.js
+        ├── reset-css@5.0.2_reset.min.css
+        ├── animate.min.css
+        ├── swal2/swal.js              # SweetAlert2 v11.14.1
+        └── fonts/XEIcon-2.2.0/        # XEIcon 아이콘 폰트
+```
+
+### 2.1 URL 매핑 규칙
+
+`application-local.yml` 에 다음이 있으므로 **절대 경로(`/`)로 참조**합니다.
+
+```yaml
+spring.web.resources.static-locations:
+  - classpath:/static/front/
+  - classpath:/templates_front/
+```
+
+- `templates_front/S01-mode.html`  →  `GET /S01-mode.html`
+- `static/front/css/S01-mode.css`  →  `GET /css/S01-mode.css`
+- `static/front/js/S01-mode.js`    →  `GET /js/S01-mode.js`
+- `static/front/images/...`        →  `GET /images/...`
+- `static/front/fonts/...`         →  `GET /fonts/...`
+- `static/front/lib/...`           →  `GET /lib/...`
+
+> 그래서 HTML 에서는 `<link href="/css/common.css">` 처럼 **슬래시로 시작하는 절대 경로**만 씁니다.
+> 상대 경로(`./`, `../`) 는 사용하지 않습니다.
+
+---
+
+## 3. 기술 스택 & 외부 라이브러리
+
+### 3.1 런타임 스택
+
+| 분류 | 기술 | 비고 |
+|---|---|---|
+| 마크업 | HTML5 | 각 페이지가 독립적. 템플릿 엔진 아직 미사용 |
+| 스타일 | CSS3 (커스텀 프로퍼티, `@keyframes`, `backdrop-filter`) | 전처리기 없음 |
+| 스크립트 | Vanilla JavaScript (ES2017+) | **IIFE** 로 전역 오염 차단 |
+| 선택자 라이브러리 | jQuery 3.7.0 | 모든 HTML 이 로드하지만 **현재 구현 코드에는 사용하지 않음**. 후속 작업 시 Vanilla 기조 유지 권장 |
+| 알림/모달 | SweetAlert2 11.14.1 (`/lib/swal2/swal.js`) | 아직 호출부 없음. 컨펌/에러 모달 용도 예정 |
+| 애니메이션 유틸 | Animate.css (`/lib/animate.min.css`) | 현재 코드엔 미사용. 사용 시 클래스 prefix 는 Animate.css 기본 |
+| 아이콘 | **XEIcon 2.2.0** (`/lib/fonts/XEIcon-2.2.0/xeicon.min.css`) | `<i class="xi xi-...">` 형태, 모든 아이콘을 이걸로 통일 |
+| 웹폰트 | Pretendard 9종 + DONGGUK UNIVERSITY | 로컬 번들 (`/fonts/`), CDN 미사용 |
+
+### 3.2 현재 사용 중인 XEIcon (인벤토리)
+
+| 아이콘 | 쓰임 |
+|---|---|
+| `xi-touch` | CTA 힌트, 일반 주문 카드 |
+| `xi-microphone` | AI 대화 주문 카드 |
+| `xi-home` | 좌하단 홈 버튼 |
+| `xi-angle-left-thin` | 좌하단 뒤로 버튼 |
+| `xi-angle-right-thin` | 카드 우하단 화살표 |
+| `xi-restaurant` | 매장 카드 (S02) |
+| `xi-package` | 포장 카드 (S02) |
+| `xi-fire` | 인기/HOT 뱃지 |
+| `xi-new` | NEW 뱃지 |
+| `xi-star` | 추천 뱃지 |
+| `xi-lightbulb-o` | 컨셉 뱃지 "눈치 있는 키오스크" |
+| `xi-chart-pie` | 눈치 추천 피처 |
+
+새 아이콘이 필요할 때는 `src/main/resources/static/front/lib/fonts/XEIcon-2.2.0/xeicon.css` 에서 클래스명을 찾아 그대로 사용합니다. **절대 이모지/SVG 를 아이콘 자리에 섞지 않습니다.** (단, 슬라이드 `s00__slide-emblem` 같은 **장식용 대형 심볼**은 예외로 이모지 허용.)
+
+### 3.3 백엔드 서버
+
+Spring Boot (Java)가 정적 리소스를 서빙합니다. REST API 는 `dgu.capstone.nunchi.domain.*.controller` 패키지에 정의되어 있지만, **현재 구현된 3개 페이지는 API 호출 없이 동작**합니다. 추후 `fetch('/api/...')` 방식으로 연동할 예정입니다.
+
+---
+
+## 4. 디자인 시스템 — `common.css`
+
+모든 페이지가 **반드시 이 순서**로 CSS 를 로드합니다.
+
+```html
+<link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+<link rel="stylesheet" href="/css/common.css">
+<link rel="stylesheet" href="/css/components.css">
+<link rel="stylesheet" href="/css/<페이지>.css">
+```
+
+### 4.1 웹폰트
+
+- 본문/UI: `--font-sans` = `"Pretendard"` (100~900 9단계 전부 번들)
+- 타이틀(한정): `--font-title` = `"DONGGUK UNIVERSITY"` — **상록원 로고 워드마크 느낌의 타이틀에만** 사용. 본문 절대 사용 금지.
+
+```css
+font-family: var(--font-sans);   /* 기본 */
+font-family: var(--font-title);  /* "상록원" 같은 매장명 브랜딩만 */
+```
+
+### 4.2 컬러 토큰
+
+색은 **직접 HEX 를 쓰지 않고 반드시 토큰으로 참조**합니다.
+
+#### Primary (Warm Orange · hsl 24 92% X%)
+- `--primary-50` ~ `--primary-900` 10단계 (배경틴트 → 극강조)
+- 주요 쓰임:
+  - CTA 기본: `--primary-500` (#E8600A)
+  - 버튼 hover: `--primary-400`, press: `--primary-600`
+  - 가격 강조(WCAG AA): `--primary-700`
+  - 블롭/배경 틴트: `--primary-100`, `--primary-200`
+
+#### Secondary (Amber · hsl 54 85% X%)
+- `--secondary-50/100/500/700`
+- 주요 쓰임: **아바타 모드 색(AI 대화)**, 정맥인증 포인트
+
+#### Neutral (Warm Grey, Hue ≈ 30)
+- `--neutral-0` (#FFFFFF) ~ `--neutral-900` (#1E1915) 10단계
+
+#### Semantic
+- `--semantic-error / warning / success / info` + 각 `*-bg`
+- 에러 기본 #DC3545 / 성공 #16A34A 등
+
+#### Contextual 별칭 (이쪽을 우선 사용)
+실제 컴포넌트에서는 원색 토큰 대신 **의미 기반 별칭**을 우선 사용합니다.
+
+```
+--color-bg-page / bg-card / bg-input / bg-overlay
+--color-text-heading / body / secondary / disabled / inverse / price
+--color-border-default / border-active
+--color-btn-primary / btn-hover / btn-press / btn-disabled
+--color-cart-badge / sold-out / nunchi-bg / nunchi-border / focus
+```
+
+### 4.3 글래스모피즘 토큰
+
+```css
+--glass-bg:       rgba(255, 255, 255, 0.55);
+--glass-bg-heavy: rgba(255, 255, 255, 0.75);
+--glass-border:   rgba(255, 255, 255, 0.7);
+--glass-shadow:   0 8px 32px rgba(30, 25, 21, 0.08);
+--glass-blur:     blur(20px);
+```
+
+글래스 표면은 항상 다음 3개 세트로 구성합니다.
+
+```css
+background: var(--glass-bg);
+backdrop-filter: var(--glass-blur);
+-webkit-backdrop-filter: var(--glass-blur);
+border: 1px solid var(--glass-border);
+```
+
+### 4.4 쉐도우
+
+| 토큰 | 값 | 용도 |
+|---|---|---|
+| `--shadow-sm` | `0 2px 8px rgba(30,25,21,.06)` | 홈/뒤로 버튼, 카드 아이콘 |
+| `--shadow-md` | `0 4px 16px rgba(30,25,21,.10)` | 글래스 카드 press, 기본 카드 |
+| `--shadow-lg` | `0 8px 32px rgba(30,25,21,.15)` | 모달, 팝업 |
+
+### 4.5 레이아웃 토큰 (720 × 1280 스케일 기준)
+
+```
+--screen-width:  720px
+--screen-height: 1280px
+--pad-top:    53px   /* 설계서 80 */
+--pad-side:   27px   /* 설계서 40 */
+--pad-footer: 67px   /* 설계서 100 */
+--touch-min:  53px   /* 터치 타깃 최소치 (설계서 80+) */
+--btn-height: 53px   /* 설계서 80 */
+--btn-radius: 11px   /* 설계서 16 */
+--card-radius:13px   /* 설계서 20 */
+```
+
+> 설계서가 1080×1920 기준이라면 **여기 값들이 이미 ×2/3 스케일로 맞춰져 있습니다**.
+> 새 토큰을 추가할 때도 같은 2/3 비율을 유지하세요.
+
+### 4.6 모션 토큰
+
+```
+--ease-out:      cubic-bezier(0.25, 0.46, 0.45, 0.94)
+--ease-bounce:   cubic-bezier(0.68, -0.55, 0.265, 1.55)
+--duration-fast: 200ms
+--duration-base: 350ms
+--duration-slow: 600ms
+```
+
+### 4.7 글로벌 베이스
+
+- Reset: `margin/padding: 0`, `box-sizing: border-box`, `button { all: unset; cursor: pointer; }`
+- `user-select: none`, `-webkit-tap-highlight-color: transparent` (키오스크라서)
+- `:focus-visible` → `outline: 2px solid var(--color-focus); outline-offset: 2px;`
+- `.sr-only` 스크린리더 전용 유틸 클래스 존재
+- `@media (prefers-reduced-motion: reduce)` 전역 대응 — 모션 민감 사용자용
+
+---
+
+## 5. 공통 컴포넌트 — `components.css`
+
+모든 컴포넌트는 **"토큰만 사용, 하드코딩 금지"** 원칙을 따릅니다.
+
+### 5.1 `.page-bg` — 페이지 배경 + 블롭
+
+**모든 페이지의 `<main>` 에 반드시 부여**하는 래퍼입니다.
+
+```html
+<main class="page-bg s01">
+  ...페이지 콘텐츠...
+</main>
+```
+
+- `position: relative; width: 720px; height: 1280px; overflow: hidden`
+- `::before` — 좌상단 주황 블롭 (480×480, `blur(80px)`, 20s 부유 애니메이션)
+- `::after` — 우하단 주황 블롭 (400×400, 24s reverse)
+- `.page-bg > *` 는 자동으로 `z-index: 1` (블롭 위)
+- 애니메이션 키프레임: `@keyframes float-blob`
+
+### 5.2 `.glass-card` — 글래스모피즘 카드
+
+```html
+<div class="glass-card">...</div>
+<div class="glass-card glass-card--heavy">...</div>  <!-- 불투명도 ↑ -->
+```
+
+- `:active` 에서 `transform: scale(0.98)` + `shadow-md`
+- 현재 S01/S02 카드는 이 클래스를 **상속 없이 수동으로** 쓰고 있음 → 동일 속성을 직접 선언.
+  향후 리팩터링 시 `.glass-card` 로 통합 가능.
+
+### 5.3 `.btn-cta` — CTA 버튼
+
+```html
+<button class="btn-cta btn-cta--primary">확인</button>
+<button class="btn-cta btn-cta--secondary">취소</button>
+<button class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block">주문 시작</button>
+<button class="btn-cta btn-cta--primary" disabled>...</button>
+```
+
+| 모디파이어 | 효과 |
+|---|---|
+| `--primary` | 주황 fill + 강한 쉐도우. 기본 액션 |
+| `--secondary` | 투명 + 2px primary 보더 |
+| `--disabled` / `:disabled` | 뉴트럴 배경, `pointer-events: none` |
+| `--lg` | min-height 67px, font-size 26px |
+| `--block` | `display: flex; width: 100%` (한 줄 차지) |
+
+기본 스펙: `min-height: 53px`, `font-size: 22px`, `font-weight: 700`, `radius: 11px`.
+
+### 5.4 `.btn-home` / `.btn-back` — 좌하단 네비 원형 버튼
+
+글래스 60×60 원형. `position: absolute; bottom: var(--pad-side)` 로 고정.
+
+```html
+<!-- 홈만 -->
+<button class="btn-home" onclick="location.href='/index.html'" aria-label="처음으로">
+  <i class="xi xi-home"></i>
+</button>
+
+<!-- 홈 + 뒤로 (뒤로가 오른쪽으로 76px 오프셋) -->
+<button class="btn-home" ...>...</button>
+<button class="btn-back" ...><i class="xi xi-angle-left-thin"></i></button>
+```
+
+- 첫 화면(S00) 에는 둘 다 없음
+- 2단계(S01) 에는 `btn-home` 만
+- 3단계 이후(S02 ~) 에는 `btn-home` + `btn-back` 둘 다
+
+### 5.5 `.fade-up` — 순차 등장 유틸리티
+
+```html
+<header class="s01__header fade-up" style="--delay: 0ms;">...</header>
+<div    class="s01__card   fade-up" style="--delay: 150ms;">...</div>
+<div    class="s01__card   fade-up" style="--delay: 300ms;">...</div>
+```
+
+- 초기 `opacity: 0; translateY(20px)` → `--delay` 지연 후 복귀
+- 지연 스테핑은 **150ms 단위** (0, 150, 300, 450...) 가 관례입니다
+
+---
+
+## 6. 페이지 구현 현황 & 패턴
+
+현재 `S00`, `S01`, `S02` 3개 페이지가 완성되어 있고 이들이 **모든 후속 페이지의 레퍼런스**입니다.
+
+### 6.1 HTML 스켈레톤 (모든 페이지 공통)
+
+```html
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=720, initial-scale=1" />
+  <title>화면 이름 · 눈치 키오스크</title>
+
+  <!-- 로드 순서 엄수 -->
+  <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+  <link rel="stylesheet" href="/css/common.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/<페이지 코드>.css">
+</head>
+<body>
+  <main class="page-bg <페이지 클래스>">
+    <!-- ① 헤더 (fade-up delay 0ms) -->
+    <!-- ② 본문 카드/리스트 (fade-up delay 150~) -->
+    <!-- ③ 좌하단 네비 버튼 (홈/뒤로) -->
+    <!-- ④ (선택) 하단 고정 CTA -->
+  </main>
+
+  <script src="/lib/jquery-3.7.0.min.js"></script>
+  <script src="/js/<페이지 코드>.js"></script>
+</body>
+</html>
+```
+
+### 6.2 S00 · `index.html` (시작 화면)
+
+**페이지 루트 클래스**: `.s00`
+**기능 요약**: 동국대 로고 / 매장 타이틀 "상록원" / 5장짜리 인기메뉴 슬라이더 / CTA / 30초 유휴 어트랙션 모드
+
+| 블록 | 주요 클래스 |
+|---|---|
+| 우상단 로고 (mix-blend-mode: multiply) | `.s00__dongguk-logo` |
+| 매장 타이틀 | `.s00__title-block` > `.s00__title-sub`, `.s00__title-main` |
+| 슬라이더 컨테이너 | `.s00__slider` > `.s00__slider-viewport` > `.s00__slider-track[data-slider-track]` |
+| 슬라이드 | `.s00__slide` + 베리언트 `.s00__slide--concept / --1 / --2 / --3 / --4` |
+| 슬라이드 미디어 | `.s00__slide-media`, `.s00__slide-overlay`, `.s00__slide-badge`, `.s00__slide-emblem`, `.s00__slide-meta`, `.s00__slide-name`, `.s00__slide-price` |
+| 컨셉 슬라이드 전용 | `.s00__slide-copy`, `.s00__slide-copy-main`, `.s00__slide-copy-sub`, `.s00__slide-features`, `.s00__slide-feature`, `.s00__slide-feature-label`, `.s00__slide-feature-desc` |
+| 통계 슬라이드 전용 | `.s00__slide-stats`, `.s00__slide-stats-row/info/label/desc/value`, `.s00__slide-progress`, `.s00__slide-progress-fill` |
+| 인디케이터 | `.s00__slider-dots[data-slider-dots]` > `.s00__slider-dot[data-idx]`, 활성 `.s00__slider-dot--active` |
+| CTA 영역 | `.s00__cta-wrap` > `.btn-cta.btn-cta--primary.s00__cta[data-action="start-order"]` + `.s00__cta-hint` |
+| 어트랙션 모드 | `.s00.s00--attract` (JS가 토글) → `@keyframes breathe` 로 숨쉬기 효과 |
+
+**JS 담당 (`/js/S00-start.js`)**:
+- 세션 초기화: `sessionStorage.setItem("sessionId", "sess_" + Date.now())`, `currentStep = "S00"`
+- 슬라이드 캐러셀: `[data-slider-track]` 을 `translateX(-idx * 100%)` 로 이동, 4초 자동 회전, 도트 클릭 시 `startSlideTimer()` 재시작
+- 어트랙션 모드: 30초 미활동 → `.s00--attract` 추가, `click/touchstart/keydown/pointerdown` 감지 시 해제
+- CTA 클릭: `sessionStorage.setItem("currentStep", "S01")` 후 `/S01-mode.html` 로 이동
+
+### 6.3 S01 · `S01-mode.html` (주문 방식 선택)
+
+**페이지 루트 클래스**: `.s01`
+**레이아웃**: 세로 flex (`padding: 200px 56px var(--pad-footer)`)
+- 헤더(타이틀+서브타이틀) → 카드 2개 가로 배치(`gap: 32px`) → 좌하단 홈 버튼
+
+| 블록 | 주요 클래스 |
+|---|---|
+| 헤더 | `.s01__header` > `.s01__title`, `.s01__subtitle` |
+| 카드 컨테이너 | `.s01__cards` |
+| 카드 공통 | `.s01__card` (width 280, min-height 480, radius 28, 내부 블롭 ::before/::after) |
+| 카드 베리언트 | `.s01__card--normal` (Primary 보더/블롭), `.s01__card--avatar` (Secondary 보더/블롭) |
+| 카드 내부 | `.s01__card-icon`, `.s01__card-body` > `.s01__card-subtitle / -title / -desc`, `.s01__card-arrow` |
+| 액션 훅 | `[data-mode="normal"]` / `[data-mode="avatar"]` |
+
+**JS 담당 (`/js/S01-mode.js`)**:
+- `[data-mode]` 카드 클릭 시 `sessionStorage.setItem("mode", "normal" | "avatar")` + `currentStep="S02"` → **둘 다 `/S02-dine.html`** 로 이동
+- 분기는 S02 에서 수행
+
+### 6.4 S02 · `S02-dine.html` (매장 / 포장)
+
+**페이지 루트 클래스**: `.s02`
+**구조**: S01 과 **완전히 동일한 레이아웃 스펙** (px 값, 그룹 구조, 카드 스타일). 달라지는 건 클래스 prefix 와 아이콘/문구/데이터 속성.
+
+| 블록 | 주요 클래스 |
+|---|---|
+| 헤더 | `.s02__header` > `.s02__title`, `.s02__subtitle` |
+| 카드 컨테이너 | `.s02__cards` |
+| 카드 공통 | `.s02__card` |
+| 베리언트 | `.s02__card--dine-in` (Primary), `.s02__card--takeout` (Secondary) |
+| 내부 구성 | `.s02__card-icon`, `.s02__card-body`, `.s02__card-subtitle`, `.s02__card-title`, `.s02__card-desc`, `.s02__card-arrow` |
+| 액션 훅 | `[data-dine="dine_in"]` / `[data-dine="take_out"]` |
+| 하단 네비 | `.btn-home` + `.btn-back` 둘 다 |
+
+**JS 담당 (`/js/S02-dine.js`)**:
+- `[data-dine]` 클릭 → `sessionStorage.setItem("dineOption", "dine_in" | "take_out")`
+- 이전 단계의 `mode` 에 따라 분기:
+  - `mode === "avatar"` → `/flowA/A01-avatar.html`
+  - `mode === "normal"` → `/flowN/N02-menu.html`
+  - 그 외 → `/S01-mode.html` (복귀)
+
+---
+
+## 7. 네이밍 & 코딩 컨벤션
+
+### 7.1 CSS 클래스 — BEM + 페이지 prefix
+
+```
+<페이지코드>__<블록>[-<요소>][--<모디파이어>]
+```
+
+- 페이지 코드 소문자: `s00`, `s01`, `s02`, 향후 `n02`, `n03`, `a01`, `p01` ...
+- 구분자는 **BEM 규칙 고수**: `__` = 요소, `--` = 모디파이어
+- 공통 컴포넌트는 prefix 없음 (`btn-cta`, `btn-home`, `glass-card`, `fade-up`, `page-bg`)
+- 예:
+  - `.s01__card` → `.s01__card--normal` ✅
+  - `.s01-card-normal` ❌ (BEM 위반)
+  - `.primary-card` ❌ (prefix 누락)
+
+### 7.2 CSS 작성 규칙
+
+1. **하드코딩 금지**. 색·간격·반경·쉐도우·모션은 전부 `var(--token-name)` 로만.
+2. 한 곳에서만 쓰이는 스타일 → `pages/S0X-xxx.css`. 두 곳 이상 → `components.css` 승격 대상.
+3. 파일 헤더 주석에 **파일명 / 용도 / 관련 요구사항 번호** 3줄 기재 (기존 파일 동일 패턴).
+4. `::before`, `::after` 는 **장식용 블롭/오버레이** 전용.
+5. `backdrop-filter` 는 항상 `-webkit-backdrop-filter` 페어로 작성.
+6. `will-change` 는 애니메이션 실제 대상에만 부여하고, `@media (prefers-reduced-motion)` 에서 `auto` 로 복원.
+7. 하드 px 값이 필요하면 **주석으로 "설계서 원본 값 / 2/3 스케일 결과" 병기** (예: `padding: 53px; /* 설계서 80 */`).
+
+### 7.3 HTML 작성 규칙
+
+1. `lang="ko"`, viewport 는 `width=720, initial-scale=1` **고정** (반응형 아님).
+2. 모든 인터랙션 루트 `<main class="page-bg sXX">` 로 시작.
+3. 장식 아이콘에는 `aria-hidden="true"`, 의미있는 아이콘/이미지에는 `aria-label` 또는 `alt`.
+4. 액션 훅은 **`onclick` 직접 바인딩 대신 `data-*` 속성 + JS 에서 queryselector 로 위임**.
+   - 예외: 홈/뒤로 버튼은 로직이 자명해 `onclick="location.href=..."` 인라인 허용.
+5. `fade-up` 등장 순서는 `--delay: 0ms, 150ms, 300ms, 450ms ...` 스테핑.
+6. 한국어 텍스트 줄바꿈은 `<br>` 로 명시 (설계 의도 보존).
+
+### 7.4 JS 작성 규칙
+
+1. **IIFE 스코프** 로 감싸 전역 오염 차단:
+   ```js
+   (function () {
+       // ...
+   })();
+   ```
+2. 상수는 상단에 `const UPPER_SNAKE_CASE` 로 선언.
+3. DOM 참조는 `$` prefix 변수명 (`$track`, `$dots`, `$cta`) — jQuery 가 아니라 **단순 네이밍 컨벤션**.
+4. 페이지 로직은 `document.addEventListener("DOMContentLoaded", () => {...})` 에서 부트.
+5. 저장/읽기는 **sessionStorage 만** 사용. 예외는 `try/catch` + `console.warn("[SXX] ...")` 로 방어.
+6. 로그 prefix 는 `[SXX]`, `[N02]` 처럼 **페이지 코드 대괄호**로 통일.
+7. jQuery 는 필요해지기 전까지 쓰지 않는다. 새 페이지 추가 시에도 vanilla 유지 권장.
+
+### 7.5 세션(sessionStorage) 키 명세
+
+| 키 | 설정 시점 | 값 |
+|---|---|---|
+| `sessionId` | S00 진입 시 초기화 | `"sess_" + Date.now()` |
+| `currentStep` | 각 페이지 진입/이탈 시 | `"S00" \| "S01" \| "S02" \| ...` |
+| `mode` | S01 카드 클릭 | `"normal" \| "avatar"` |
+| `dineOption` | S02 카드 클릭 | `"dine_in" \| "take_out"` |
+
+> 새 키를 추가할 때는 이 표를 함께 업데이트 해주세요.
+
+### 7.6 파일 네이밍
+
+- HTML: `<페이지코드 대문자>-<케밥명>.html` → `S01-mode.html`, `N02-menu.html`
+- 페이지별 CSS/JS: HTML 파일명과 **1:1 매칭** (`S01-mode.css`, `S01-mode.js`)
+- 공통: `common.css`, `components.css`, `js/common/*.js`
+
+---
+
+## 8. 공통 유틸리티
+
+### 8.1 `partials-loader.js`
+
+`data-include="/layouts/_xxx.html"` 속성을 만나면 해당 HTML 을 fetch 해 **요소를 교체**합니다.
+로드 완료 후 `document` 에 `partials:ready` 커스텀 이벤트를 발생시켜 후속 JS 가 훅 가능합니다.
+
+```html
+<div data-include="/layouts/_help-button.html"></div>
+
+<script src="/js/common/partials-loader.js"></script>
+<script>
+  document.addEventListener("partials:ready", () => {
+    // 파셜 로딩 완료 후 초기화
+  });
+</script>
+```
+
+- 타임아웃 5초 (`PARTIAL_TIMEOUT_MS`)
+- 실패 시 `console.error("[partials-loader] ... 로드 실패", err)`
+- **현재 사용 중인 페이지 없음**. 공통 레이아웃 파셜(헤더/푸터/AI 채팅 패널 등)을 도입할 때 즉시 활용.
+
+### 8.2 SweetAlert2
+
+전역 `Swal` 로 사용 가능하지만 현재 호출부는 없습니다. 사용 시 권장 패턴:
+
+```js
+Swal.fire({
+  icon: "warning",
+  title: "주문을 취소할까요?",
+  showCancelButton: true,
+  confirmButtonText: "네, 취소할게요",
+  cancelButtonText: "계속 주문하기",
+  confirmButtonColor: "var(--primary-500)", // 혹은 HEX 로 변환해서 전달
+});
+```
+
+> Swal 은 내부적으로 style 주입을 하므로 `confirmButtonColor` 등 **일부 스타일은 CSS 변수가 해석되지 않을 수 있습니다**. 필요시 `common.css` 톤에 맞춘 override CSS 를 나중에 추가.
+
+### 8.3 Animate.css
+
+현재 미사용. 도입 시 `<html class="animate__animated animate__fadeIn">` 같은 방식 대신
+이미 정의된 `.fade-up` 등 **프로젝트 고유 유틸을 우선** 사용하고, Animate.css 는 "한 번만 쓰는 특수 효과" 에 한정합니다.
+
+---
+
+## 9. 에셋 관리
+
+### 9.1 이미지 구조
+
+```
+images/
+├── avatars/          # AI 아바타 자원
+│   ├── 할머니_아바타.jpg
+│   ├── 통장님_대기.mp4 / 통장님_대화중.mp4
+│   └── 이웃사촌_대기.mp4 / 이웃사촌_대화중.mp4
+├── logos/Dongguk-Logo.jpg
+├── menu/             # (비어있음) 메뉴 사진 예정
+├── categories/       # (비어있음) 카테고리 썸네일 예정
+├── icons/            # (비어있음) 커스텀 SVG 가 생길 경우
+└── bg/               # (비어있음) 배경용 이미지
+```
+
+### 9.2 파일 네이밍 규칙
+
+- **한글 파일명 허용** (현재 아바타 파일들이 한글): 키오스크 전용 환경이라 인코딩 이슈가 없다면 유지
+- 공식 로고/브랜드는 원본 명 유지: `Dongguk-Logo.jpg`
+- 메뉴 썸네일 추가 시 권장 포맷: `<메뉴ID>-<menu-name>.webp` (예: `101-bulgogi.webp`)
+- 아이콘은 **XEIcon 우선**, 커스텀 SVG 는 `/images/icons/` 에 kebab-case 로 저장
+
+### 9.3 비디오(아바타)
+
+- `.mp4` 는 `<video autoplay muted loop playsinline>` 로 재생. 오토플레이 정책 때문에 **`muted` 필수**.
+- "대기" 상태와 "대화중" 상태 2벌로 설계 → JS 에서 `<source>` 를 갈아 끼우거나 두 `<video>` 를 교차 페이드.
+
+---
+
+## 10. 접근성 (A11y) 가이드라인
+
+현재 코드에 이미 반영되어 있는 항목 — **새 페이지도 반드시 준수**:
+
+| 항목 | 구현 방법 |
+|---|---|
+| 스크린리더 라벨 | 의미있는 버튼/링크는 `aria-label="..."` |
+| 장식 요소 | `aria-hidden="true"` (아이콘, 블롭, emoji emblem) |
+| 섹션 라벨 | `<section aria-label="...">` |
+| 프로그레스바 | `role="progressbar" aria-valuenow/min/max` |
+| 포커스 링 | `button:focus-visible { outline: 2px solid var(--color-focus); }` |
+| 모션 축소 | `@media (prefers-reduced-motion: reduce)` 글로벌 대응 |
+| 터치 최소치 | 버튼 높이 ≥ `--touch-min` (53px = 설계서 80) |
+| 색 대비 | 가격은 `--primary-700` (WCAG AA) |
+| 한국어 | `<html lang="ko">` |
+
+---
+
+## 11. 새 페이지 추가 체크리스트 (파인코딩 워크플로우)
+
+새 화면(예: `N02-menu.html`) 을 **기존 코드와 똑같은 품질로** 추가할 때 이 순서로 진행합니다.
+
+### 11.1 파일 3종 생성
+
+```
+templates_front/flowN/N02-menu.html
+static/front/css/flowN/N02-menu.css
+static/front/js/flowN/N02-menu.js
+```
+
+### 11.2 HTML 뼈대 작성
+
+- [ ] 위 §6.1 스켈레톤 복사
+- [ ] `<title>XXX · 눈치 키오스크</title>` 세팅
+- [ ] `<main class="page-bg nN2">` (페이지 코드 prefix 지정)
+- [ ] 헤더 `fade-up --delay:0ms` + 본문 `150ms/300ms/...`
+- [ ] 좌하단 `btn-home` + `btn-back` (필요 시)
+- [ ] 하단 CTA 는 `.btn-cta.btn-cta--primary` 기반으로 구성
+- [ ] 아이콘은 XEIcon (`xi xi-...`) 만 사용
+- [ ] 모든 장식 요소 `aria-hidden="true"`
+
+### 11.3 CSS 작성
+
+- [ ] 파일 헤더 주석 3줄 (파일명 / 용도 / 요구사항 번호)
+- [ ] 페이지 루트 셀렉터(`.n02 { ... }`) 로 스코프 한정
+- [ ] 색/간격/반경/쉐도우/모션 **100% 토큰화**
+- [ ] px 값이 필요하면 주석으로 "설계서 원본 / 2/3 스케일" 병기
+- [ ] hover 는 데스크탑 미리보기 용으로만, 실제 터치 피드백은 `:active { transform: scale(0.98); }`
+- [ ] 재사용 가능한 블록은 바로 `components.css` 로 승격 제안
+
+### 11.4 JS 작성
+
+- [ ] IIFE 로 감싸기
+- [ ] 상수는 `const UPPER_SNAKE` 상단 선언
+- [ ] DOM 변수는 `$xxx` prefix
+- [ ] `DOMContentLoaded` 후 바인딩
+- [ ] `sessionStorage` 접근은 `try/catch` 로 방어
+- [ ] 로그는 `console.warn("[N02] ...")`
+- [ ] 페이지 이동 직전 `sessionStorage.setItem("currentStep", "다음 페이지 코드")`
+
+### 11.5 시각 QA
+
+- [ ] 720 × 1280 창에서 스크롤 없이 한 뷰 안에 다 들어오는지
+- [ ] 블롭이 잘리지 않고, 글래스 모피즘 `backdrop-filter` 가 크롬에서 적용되는지
+- [ ] `fade-up` 이 순차로 떨어지는지
+- [ ] `prefers-reduced-motion` 강제 설정 시 치명적 레이아웃 깨짐이 없는지
+- [ ] 터치 타깃이 53px 이상인지
+- [ ] 홈/뒤로 버튼이 다른 요소를 가리지 않는지 (항상 `z-index: 10`)
+
+### 11.6 세션/플로우 검증
+
+- [ ] 이전 페이지 → 현재 페이지로 들어왔을 때 `sessionStorage` 에 필요한 키가 모두 존재하는지
+- [ ] 키가 없을 때 **안전한 fallback 경로**(예: `/S01-mode.html` 복귀)를 구현했는지
+- [ ] "홈" 은 `/index.html`, "뒤로" 는 **해당 플로우 상 직전 페이지** 로 정확히 가는지
+
+---
+
+## 12. 알려진 기술 부채 / 개선 예정
+
+| 항목 | 설명 |
+|---|---|
+| jQuery 로드 | `<script src="/lib/jquery-3.7.0.min.js">` 모든 페이지에 있으나 실제로 사용 안 함. 완전히 제거하거나 쓴다면 일관되게 써야 함. |
+| 공통 파셜 | `templates_front/layouts/` 가 비어있음. `partials-loader.js` 로 로딩할 `_head.html / _scripts.html / _home-back.html` 을 도입하면 각 페이지 중복 마크업을 걷어낼 수 있음. |
+| `.glass-card` 사용률 | S01/S02 카드는 `.glass-card` 를 상속하지 않고 같은 속성을 재선언. 리팩터링 여지. |
+| XEIcon CDN vs 로컬 | 로컬 번들 유지 중 (오프라인 키오스크 대비). |
+| SweetAlert2 테마 | 브랜드 톤 맞춘 커스텀 CSS 필요. |
+| WebSocket / REST | 아바타/눈치엔진 도입 시 공용 API 클라이언트를 `js/common/` 에 추가 예정. |
+
+---
+
+## 13. 빠른 참조 (Cheat Sheet)
+
+### 디자인 토큰
+
+```css
+/* 주황 */
+var(--primary-50)  var(--primary-100) var(--primary-200) var(--primary-300)
+var(--primary-400) var(--primary-500) var(--primary-600) var(--primary-700)
+
+/* 중립 */
+var(--neutral-0)   ~  var(--neutral-900)
+
+/* 의미 별칭 */
+var(--color-text-heading|body|secondary|disabled|inverse|price)
+var(--color-bg-page|card|input|overlay)
+var(--color-btn-primary|hover|press|disabled)
+
+/* 레이아웃 */
+var(--screen-width)  720px
+var(--screen-height) 1280px
+var(--pad-top|side|footer)
+var(--btn-height)    53px
+var(--btn-radius)    11px
+var(--card-radius)   13px
+
+/* 모션 */
+var(--ease-out)
+var(--duration-fast|base|slow)
+```
+
+### 핵심 컴포넌트 한 줄 요약
+
+```html
+<main class="page-bg s0X">                     <!-- 배경+블롭 래퍼 -->
+<div  class="glass-card glass-card--heavy">    <!-- 글래스 카드 -->
+<button class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block">
+<button class="btn-home"><i class="xi xi-home"></i></button>
+<button class="btn-back"><i class="xi xi-angle-left-thin"></i></button>
+<div class="fade-up" style="--delay: 150ms;">  <!-- 순차 등장 -->
+```
+
+### 페이지 간 이동 패턴
+
+```js
+sessionStorage.setItem("currentStep", "다음 코드");
+location.href = "/다음_페이지.html";
+```
+
+### 세션 스냅샷 디버깅
+
+브라우저 콘솔에서:
+```js
+Object.fromEntries(Object.entries(sessionStorage));
+// { sessionId: "sess_...", currentStep: "S02", mode: "avatar", dineOption: "dine_in" }
+```
+
+---
+
+**문서 버전**: 2026-04-22 기준 (S00·S01·S02 구현 완료 시점)
+**다음 업데이트 트리거**: 새 페이지 추가, `components.css` 변경, 디자인 토큰 추가/변경, `sessionStorage` 키 추가

--- a/src/main/resources/static/front/css/common.css
+++ b/src/main/resources/static/front/css/common.css
@@ -132,6 +132,11 @@ img, svg {
     max-width: 100%;
 }
 
+/* [hidden] 속성이 page CSS 의 display:flex/grid 등에 의해 무시되지 않도록 강제 */
+[hidden] {
+    display: none !important;
+}
+
 /* ========================================================
    Design Tokens
    ======================================================== */

--- a/src/main/resources/static/front/css/common.css
+++ b/src/main/resources/static/front/css/common.css
@@ -262,6 +262,34 @@ body {
     user-select: none;
 }
 
+/* ========================================================
+   데스크톱 미리보기 프레임
+   - 실제 키오스크(뷰포트 720×1280) 에서는 아무 효과 없음
+   - 그보다 큰 창(개발용 데스크톱 브라우저)에서만
+     body 를 플렉스 센터링하고 어두운 배경을 깔아
+     .page-bg(720×1280) 가 키오스크 프레임처럼 보이게 함
+   ======================================================== */
+
+@media (min-width: 800px) {
+    html,
+    body {
+        min-height: 100vh;
+        height: auto;
+        background: #1E1915;            /* neutral-900 하드값 (페이지 배경과 분리) */
+    }
+    body {
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        padding: 24px 0;
+    }
+    .page-bg {
+        flex-shrink: 0;
+        border-radius: 28px;
+        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+    }
+}
+
 h1, h2, h3, h4, h5, h6 {
     color: var(--color-text-heading);
     font-weight: 700;

--- a/src/main/resources/static/front/css/components.css
+++ b/src/main/resources/static/front/css/components.css
@@ -214,3 +214,547 @@
         transform: translateY(0);
     }
 }
+
+/* ========================================================
+   .app-topbar — 공통 상단바 (좌: 뒤로/매장명, 우: 액션 버튼들)
+   flowN 모든 페이지 + 향후 flowA/P 에서 재사용
+   ======================================================== */
+
+.app-topbar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px;
+    z-index: 5;
+}
+
+.app-topbar__left {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+}
+
+/* 상단바 안의 뒤로가기 버튼 (좌하단 .btn-back 과 별개, 좌상단용) */
+.app-topbar__back {
+    flex-shrink: 0;
+    width: 52px;
+    height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--glass-bg-heavy);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--glass-border);
+    border-radius: 50%;
+    color: var(--color-text-body);
+    font-size: 22px;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
+}
+
+.app-topbar__back:active {
+    transform: scale(0.94);
+    background: var(--neutral-0);
+}
+
+.app-topbar__store {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.app-topbar__store-sub {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.2px;
+    line-height: 1;
+}
+
+.app-topbar__store-name {
+    font-size: 26px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    letter-spacing: -0.6px;
+    line-height: 1.15;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 360px;
+}
+
+.app-topbar__right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+/* 알약 액션 (예: "대화 기록") */
+.app-topbar__action-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    height: 44px;
+    padding: 0 18px;
+    background: var(--glass-bg-heavy);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--glass-border);
+    border-radius: 9999px;
+    color: var(--color-text-body);
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.app-topbar__action-pill i {
+    font-size: 16px;
+    color: var(--primary-500);
+}
+
+.app-topbar__action-pill:active {
+    transform: scale(0.96);
+}
+
+/* 원형 액션 (예: 마이크) */
+.app-topbar__action-icon {
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--glass-bg-heavy);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--glass-border);
+    border-radius: 50%;
+    color: var(--color-text-body);
+    font-size: 20px;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
+}
+
+.app-topbar__action-icon:active {
+    transform: scale(0.94);
+}
+
+/* 마이크 활성 상태 (펄스 + 주황) */
+.app-topbar__action-icon--mic-active {
+    background: var(--primary-500);
+    border-color: var(--primary-500);
+    color: var(--color-text-inverse);
+    animation: mic-pulse 1.4s var(--ease-out) infinite;
+}
+
+@keyframes mic-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(232, 96, 10, 0.45); }
+    50%      { box-shadow: 0 0 0 12px rgba(232, 96, 10, 0); }
+}
+
+/* ========================================================
+   .pill-tab — 알약형 탭 (예: 1층 / 2층 / 3층)
+   ======================================================== */
+
+.pill-tab-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.pill-tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    height: 44px;
+    padding: 0 22px;
+    background: var(--glass-bg-heavy);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--glass-border);
+    border-radius: 9999px;
+    color: var(--color-text-body);
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    box-shadow: var(--shadow-sm);
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.pill-tab:active {
+    transform: scale(0.96);
+}
+
+.pill-tab--active {
+    background: var(--primary-500);
+    border-color: var(--primary-500);
+    color: var(--color-text-inverse);
+    box-shadow: 0 6px 16px rgba(232, 96, 10, 0.3);
+}
+
+/* ========================================================
+   .qty-stepper — 수량 카운터 (- N +)
+   ======================================================== */
+
+.qty-stepper {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.qty-stepper__btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--primary-500);
+    color: var(--color-text-inverse);
+    font-size: 16px;
+    line-height: 1;
+    box-shadow: 0 2px 6px rgba(232, 96, 10, 0.3);
+    transition: transform var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
+}
+
+.qty-stepper__btn:active {
+    transform: scale(0.9);
+    background: var(--primary-600);
+}
+
+.qty-stepper__btn--minus {
+    background: var(--neutral-100);
+    color: var(--neutral-700);
+    box-shadow: none;
+}
+
+.qty-stepper__btn--minus:active {
+    background: var(--neutral-200);
+}
+
+.qty-stepper__value {
+    min-width: 22px;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    font-feature-settings: "tnum";
+}
+
+/* ========================================================
+   .origin-pill — 원산지 알약 (●국내산 / ●수입산)
+   ======================================================== */
+
+.origin-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 26px;
+    padding: 0 11px;
+    background: var(--semantic-success-bg);
+    border-radius: 9999px;
+    color: var(--semantic-success);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+}
+
+.origin-pill::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.origin-pill--imported {
+    background: var(--semantic-warning-bg);
+    color: var(--semantic-warning);
+}
+
+/* ========================================================
+   .ai-chat-panel — 우측 슬라이드 오버레이 (AI 대화 기록)
+   ======================================================== */
+
+/* .page-bg 내부에 고정되려면 부모가 position:relative 여야 함.
+   .page-bg 자체가 이미 position:relative 이므로 아래 absolute 는
+   키오스크 프레임(720×1280) 기준으로 배치된다. */
+.ai-chat-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 360px;
+    height: 100%;
+    background: var(--neutral-0);
+    box-shadow: -16px 0 48px rgba(30, 25, 21, 0.18);
+    transform: translateX(100%);
+    transition: transform var(--duration-base) var(--ease-out);
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+}
+
+.ai-chat-panel--open {
+    transform: translateX(0);
+}
+
+/* dim 배경 (오버레이 dimmer) */
+.ai-chat-dim {
+    position: absolute;
+    inset: 0;
+    background: var(--color-bg-overlay);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-base) var(--ease-out);
+    z-index: 99;
+}
+
+.ai-chat-dim--open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.ai-chat-panel__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--neutral-100);
+}
+
+.ai-chat-panel__header-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.ai-chat-panel__title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 16px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    letter-spacing: -0.3px;
+}
+
+.ai-chat-panel__title i {
+    color: var(--primary-500);
+    font-size: 18px;
+}
+
+.ai-chat-panel__session {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.1px;
+}
+
+.ai-chat-panel__close {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--neutral-100);
+    color: var(--neutral-600);
+    font-size: 16px;
+    transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.ai-chat-panel__close:active {
+    background: var(--neutral-200);
+}
+
+.ai-chat-panel__status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 12px 16px 0;
+    padding: 10px 14px;
+    background: var(--primary-50);
+    border: 1px solid var(--primary-100);
+    border-radius: 10px;
+}
+
+.ai-chat-panel__status-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 12px;
+    color: var(--neutral-700);
+    letter-spacing: -0.2px;
+    line-height: 1.3;
+}
+
+.ai-chat-panel__status-text strong {
+    font-weight: 700;
+    color: var(--neutral-800);
+    font-size: 12.5px;
+}
+
+.ai-chat-panel__live {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    background: var(--semantic-error);
+    border-radius: 9999px;
+    color: var(--color-text-inverse);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+}
+
+.ai-chat-panel__live::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-text-inverse);
+    animation: live-pulse 1.2s var(--ease-out) infinite;
+}
+
+@keyframes live-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.35; }
+}
+
+.ai-chat-panel__memory-note {
+    margin: 14px 16px 6px;
+    padding: 8px 12px;
+    background: var(--neutral-50);
+    border-radius: 8px;
+    color: var(--neutral-500);
+    font-size: 11px;
+    text-align: center;
+    letter-spacing: -0.2px;
+}
+
+.ai-chat-panel__messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ai-chat-bubble {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-width: 85%;
+}
+
+.ai-chat-bubble__body {
+    padding: 11px 14px;
+    border-radius: 14px;
+    font-size: 13px;
+    line-height: 1.45;
+    letter-spacing: -0.2px;
+    word-break: keep-all;
+}
+
+.ai-chat-bubble__time {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 10px;
+    color: var(--color-text-secondary);
+}
+
+.ai-chat-bubble__time i {
+    font-size: 11px;
+    color: var(--primary-500);
+}
+
+/* 시스템 메시지 (AI) — 우측 정렬, 주황 배경 */
+.ai-chat-bubble--system {
+    align-self: flex-end;
+    align-items: flex-end;
+}
+
+.ai-chat-bubble--system .ai-chat-bubble__body {
+    background: var(--primary-500);
+    color: var(--color-text-inverse);
+    border-bottom-right-radius: 4px;
+}
+
+.ai-chat-bubble--system .ai-chat-bubble__time {
+    flex-direction: row-reverse;
+}
+
+/* 사용자 메시지 — 좌측 정렬, 회색 배경 */
+.ai-chat-bubble--user {
+    align-self: flex-start;
+}
+
+.ai-chat-bubble--user .ai-chat-bubble__body {
+    background: var(--neutral-100);
+    color: var(--neutral-800);
+    border-bottom-left-radius: 4px;
+}
+
+/* 툴 호출 로그 — 좌측 정렬, primary outline 박스 */
+.ai-chat-bubble--tool {
+    align-self: flex-start;
+}
+
+.ai-chat-bubble--tool .ai-chat-bubble__body {
+    background: var(--primary-50);
+    border: 1px solid var(--primary-200);
+    color: var(--primary-700);
+    font-weight: 600;
+}
+
+.ai-chat-panel__footer {
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px;
+    border-top: 1px solid var(--neutral-100);
+}
+
+.ai-chat-panel__footer-btn {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 40px;
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+}
+
+.ai-chat-panel__footer-btn--save {
+    background: var(--neutral-100);
+    color: var(--neutral-700);
+}
+
+.ai-chat-panel__footer-btn--reset {
+    background: var(--semantic-error-bg);
+    color: var(--semantic-error);
+    border: 1px solid var(--semantic-error);
+}
+
+.ai-chat-panel__footer-btn:active {
+    transform: scale(0.97);
+}

--- a/src/main/resources/static/front/css/flowN/N02-menu.css
+++ b/src/main/resources/static/front/css/flowN/N02-menu.css
@@ -1,0 +1,912 @@
+/* ========================================================
+   N02-menu.css — 메뉴 목록 (목록 + 사이드바 + 카트 + 상세 오버레이)
+   요구사항: 1-2 ~ 1-5 (메뉴 탐색·선택·장바구니·상세)
+   레퍼런스: 720×1280 절대 레이아웃
+   ======================================================== */
+
+.n02 {
+    position: relative;        /* 카트 바 absolute 기준 */
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: var(--screen-height);
+    overflow: hidden;
+}
+
+/* ========================================================
+   ② 층 탭
+   ======================================================== */
+.n02__floor-tabs {
+    padding: 4px 20px 14px;
+    z-index: 4;
+}
+
+/* ========================================================
+   ③ 본문 — 사이드바 + 메뉴 그리드
+   ======================================================== */
+.n02__body {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 156px 1fr;
+    gap: 14px;
+    padding: 0 20px 0 20px;
+    min-height: 0;            /* flex/grid scroll 정상 동작 */
+    z-index: 3;
+}
+
+/* --- 좌측 식당 사이드바 --- */
+.n02__store-list {
+    overflow-y: auto;
+    padding-bottom: 240px;     /* 카트 바 가림 방지 */
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.n02__store-item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 14px 12px 14px 16px;
+    border-radius: 12px;
+    background: transparent;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.n02__store-item:active {
+    transform: scale(0.99);
+}
+
+.n02__store-item--active {
+    background: var(--primary-50);
+    box-shadow: inset 4px 0 0 var(--primary-500);
+}
+
+.n02__store-name {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    letter-spacing: -0.3px;
+    line-height: 1.2;
+}
+
+.n02__store-item--active .n02__store-name {
+    color: var(--primary-700);
+}
+
+.n02__store-hours {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.1px;
+    line-height: 1.3;
+}
+
+.n02__store-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--semantic-success);
+    letter-spacing: -0.1px;
+}
+
+.n02__store-status::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.n02__store-status--closed {
+    color: var(--neutral-400);
+}
+
+/* --- 우측 메뉴 영역 --- */
+.n02__menu-area {
+    overflow-y: auto;
+    padding: 0 4px 320px 4px; /* 카트 바 가림 방지 */
+}
+
+.n02__menu-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+}
+
+/* --- 메뉴 카드 --- */
+.n02__menu-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg-card);
+    border: 2px solid transparent;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: transform var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out);
+}
+
+.n02__menu-card:active {
+    transform: scale(0.98);
+}
+
+/* 카트 담겼을 때 강조 */
+.n02__menu-card--in-cart {
+    border-color: var(--primary-500);
+    box-shadow: 0 4px 14px rgba(232, 96, 10, 0.18);
+}
+
+/* 카드 썸네일 (사진 placeholder — 회색 솔리드 + 메뉴명) */
+.n02__menu-card-thumb {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    background: var(--neutral-100);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.n02__menu-card-thumb-text {
+    padding: 0 10px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--neutral-300);
+    text-align: center;
+    letter-spacing: -0.3px;
+    line-height: 1.3;
+    word-break: keep-all;
+}
+
+/* 우상단 "상세 >" 알약 */
+.n02__menu-card-detail-chip {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 4px 9px 4px 11px;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border-radius: 9999px;
+    color: var(--neutral-700);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    z-index: 2;
+}
+
+.n02__menu-card-detail-chip i {
+    font-size: 11px;
+}
+
+/* AI 추천 뱃지 (좌상단) */
+.n02__menu-card-ai-badge {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    background: var(--primary-500);
+    border-radius: 9999px;
+    color: var(--color-text-inverse);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.3px;
+    box-shadow: 0 4px 10px rgba(232, 96, 10, 0.35);
+    z-index: 2;
+}
+
+.n02__menu-card-ai-badge i {
+    font-size: 10px;
+}
+
+/* 한정판매 등 추가 뱃지 (좌하단) */
+.n02__menu-card-extra-badge {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    padding: 3px 9px;
+    background: var(--secondary-500);
+    border-radius: 9999px;
+    color: var(--color-text-inverse);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.2px;
+    z-index: 2;
+}
+
+/* 품절 오버레이 */
+.n02__menu-card--sold-out .n02__menu-card-thumb::after {
+    content: "품절";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 6px 16px;
+    background: rgba(220, 53, 69, 0.85);
+    border-radius: 9999px;
+    color: var(--color-text-inverse);
+    font-size: 14px;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    z-index: 3;
+}
+
+/* 수량 뱃지 (이미지 4 — 카드 우하단) */
+.n02__menu-card-qty-badge {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--primary-500);
+    border: 2px solid var(--color-text-inverse);
+    border-radius: 50%;
+    color: var(--color-text-inverse);
+    font-size: 13px;
+    font-weight: 800;
+    box-shadow: 0 4px 10px rgba(232, 96, 10, 0.35);
+    z-index: 3;
+}
+
+/* 카드 정보 영역 */
+.n02__menu-card-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px 8px;
+}
+
+.n02__menu-card-name {
+    font-size: 14px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    letter-spacing: -0.3px;
+    line-height: 1.25;
+    word-break: keep-all;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.n02__menu-card-origin {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.2px;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.n02__menu-card-price {
+    margin-top: 2px;
+    font-size: 16px;
+    font-weight: 800;
+    color: var(--primary-700);
+    letter-spacing: -0.3px;
+    font-feature-settings: "tnum";
+}
+
+/* 카드 하단 "+ 담기" 버튼 */
+.n02__menu-card-add {
+    margin: 0 12px 12px;
+    height: 38px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    background: var(--primary-500);
+    border-radius: 10px;
+    color: var(--color-text-inverse);
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    box-shadow: 0 4px 10px rgba(232, 96, 10, 0.25);
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.n02__menu-card-add:active {
+    background: var(--primary-600);
+    transform: scale(0.97);
+}
+
+.n02__menu-card-add i {
+    font-size: 14px;
+}
+
+/* 빈 메뉴 상태 */
+.n02__menu-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 320px;
+    gap: 12px;
+    color: var(--color-text-secondary);
+}
+
+.n02__menu-empty i {
+    font-size: 56px;
+    color: var(--neutral-300);
+}
+
+.n02__menu-empty p {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+/* ========================================================
+   ④ 하단 카트 바
+   ======================================================== */
+.n02__cart-bar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 16px 20px 22px;
+    background: var(--neutral-50);
+    border-top: 1px solid var(--neutral-100);
+    box-shadow: 0 -8px 24px rgba(30, 25, 21, 0.06);
+    z-index: 6;
+    transition: padding var(--duration-base) var(--ease-out);
+}
+
+.n02__cart-bar--empty {
+    background: var(--neutral-100);
+}
+
+/* --- 빈 상태 --- */
+.n02__cart-empty {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.n02__cart-empty-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--neutral-500);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.n02__cart-empty-head i {
+    font-size: 18px;
+}
+
+.n02__cart-empty-msg {
+    font-size: 12px;
+    color: var(--neutral-400);
+    letter-spacing: -0.2px;
+    margin-top: -4px;
+}
+
+/* --- 채워진 상태 --- */
+.n02__cart-filled {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.n02__cart-filled-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.n02__cart-filled-head-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--neutral-700);
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.n02__cart-filled-head-left i {
+    font-size: 18px;
+}
+
+.n02__cart-filled-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    background: var(--primary-500);
+    border-radius: 9999px;
+    color: var(--color-text-inverse);
+    font-size: 12px;
+    font-weight: 800;
+    font-feature-settings: "tnum";
+}
+
+.n02__cart-filled-head-right {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0;
+}
+
+.n02__cart-total-label {
+    font-size: 11px;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.2px;
+}
+
+.n02__cart-total-value {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--primary-700);
+    letter-spacing: -0.3px;
+    font-feature-settings: "tnum";
+}
+
+/* 카트 트랙 */
+.n02__cart-track-wrap {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    gap: 6px;
+}
+
+.n02__cart-arrow {
+    flex-shrink: 0;
+    width: 32px;
+    align-self: center;
+    height: 110px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--neutral-0);
+    border: 1px solid var(--neutral-200);
+    border-radius: 12px;
+    color: var(--neutral-500);
+    font-size: 22px;
+    transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.n02__cart-arrow:active {
+    background: var(--neutral-100);
+}
+
+.n02__cart-track {
+    flex: 1;
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+}
+
+.n02__cart-track::-webkit-scrollbar {
+    display: none;
+}
+
+/* 카트 아이템 */
+.n02__cart-item {
+    flex: 0 0 auto;
+    width: 168px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px;
+    background: var(--neutral-0);
+    border: 1px solid var(--neutral-100);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    scroll-snap-align: start;
+    position: relative;
+}
+
+.n02__cart-item-thumb {
+    width: 100%;
+    height: 50px;
+    background: var(--neutral-100);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--neutral-300);
+    font-size: 11px;
+    font-weight: 700;
+    text-align: center;
+    padding: 0 6px;
+    line-height: 1.2;
+    word-break: keep-all;
+}
+
+.n02__cart-item-name-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 4px;
+}
+
+.n02__cart-item-name {
+    flex: 1;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--neutral-800);
+    letter-spacing: -0.3px;
+    line-height: 1.25;
+    word-break: keep-all;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.n02__cart-item-remove {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--neutral-100);
+    color: var(--neutral-500);
+    font-size: 11px;
+}
+
+.n02__cart-item-remove:active {
+    background: var(--neutral-200);
+}
+
+.n02__cart-item-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+}
+
+.n02__cart-item-price {
+    font-size: 13px;
+    font-weight: 800;
+    color: var(--primary-700);
+    letter-spacing: -0.2px;
+    font-feature-settings: "tnum";
+}
+
+/* 결제 버튼 */
+.n02__cart-pay-btn {
+    height: 56px;
+    border-radius: 14px;
+    font-size: 18px;
+    gap: 8px;
+}
+
+.n02__cart-pay-btn[disabled] {
+    background: var(--neutral-200);
+    color: var(--neutral-400);
+    box-shadow: none;
+}
+
+.n02__cart-pay-btn i {
+    font-size: 18px;
+}
+
+.n02__cart-pay-amount {
+    font-feature-settings: "tnum";
+}
+
+/* ========================================================
+   ⑤ 메뉴 상세 풀스크린 오버레이
+   ======================================================== */
+.n02__detail {
+    position: absolute;    /* 키오스크 프레임(.page-bg) 기준 */
+    inset: 0;
+    z-index: 90;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    background: rgba(30, 25, 21, 0.4);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    animation: n02-detail-fade var(--duration-base) var(--ease-out);
+}
+
+/* hidden 속성 존중 — display:flex 이 hidden 의 기본 display:none 을 덮어버리는 문제 방지 */
+.n02__detail[hidden] {
+    display: none;
+}
+
+@keyframes n02-detail-fade {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.n02__detail-panel {
+    width: var(--screen-width);
+    height: var(--screen-height);
+    background: var(--color-bg-card);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: n02-detail-slide var(--duration-base) var(--ease-out);
+}
+
+@keyframes n02-detail-slide {
+    from { transform: translateY(20px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+}
+
+/* 히어로 (사진 자리 + 메뉴명/가격) */
+.n02__detail-hero {
+    position: relative;
+    width: 100%;
+    height: 320px;
+    background:
+        linear-gradient(135deg, var(--neutral-200), var(--neutral-300));
+    flex-shrink: 0;
+    overflow: hidden;
+}
+
+.n02__detail-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 0) 40%,
+        rgba(0, 0, 0, 0.55) 100%
+    );
+}
+
+.n02__detail-close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-radius: 50%;
+    color: var(--color-text-inverse);
+    font-size: 20px;
+    z-index: 4;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.n02__detail-close:active {
+    transform: scale(0.94);
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.n02__detail-hero-meta {
+    position: absolute;
+    bottom: 22px;
+    left: 26px;
+    right: 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 3;
+}
+
+.n02__detail-name {
+    font-size: 32px;
+    font-weight: 800;
+    color: var(--color-text-inverse);
+    letter-spacing: -0.6px;
+    line-height: 1.15;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    word-break: keep-all;
+}
+
+.n02__detail-price {
+    font-size: 22px;
+    font-weight: 800;
+    color: var(--color-text-inverse);
+    letter-spacing: -0.3px;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    font-feature-settings: "tnum";
+}
+
+/* 본문 (스크롤) */
+.n02__detail-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 22px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
+.n02__detail-desc {
+    padding: 12px 14px;
+    background: var(--neutral-100);
+    border-radius: 10px;
+    color: var(--neutral-700);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: -0.2px;
+    line-height: 1.5;
+    word-break: keep-all;
+}
+
+.n02__detail-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.n02__detail-section-title {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    letter-spacing: -0.3px;
+}
+
+.n02__detail-section-title i {
+    color: var(--primary-500);
+    font-size: 15px;
+}
+
+.n02__detail-section-sub {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.1px;
+}
+
+/* 메뉴 구성 칩 */
+.n02__detail-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.n02__detail-chip {
+    display: inline-flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 13px;
+    background: var(--primary-50);
+    border: 1px solid var(--primary-200);
+    border-radius: 9999px;
+    color: var(--primary-700);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+}
+
+/* 원재료 리스트 */
+.n02__detail-ingredients {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    background: var(--neutral-100);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.n02__detail-ingredient-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 14px;
+    background: var(--color-bg-card);
+}
+
+.n02__detail-ingredient-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--neutral-700);
+    letter-spacing: -0.2px;
+}
+
+/* 영양정보 4분할 */
+.n02__detail-nutrition {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+}
+
+.n02__detail-nutrition-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 14px 4px 12px;
+    background: var(--neutral-50);
+    border-radius: 12px;
+    text-align: center;
+}
+
+.n02__detail-nutrition-value {
+    font-size: 22px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    letter-spacing: -0.5px;
+    line-height: 1;
+    font-feature-settings: "tnum";
+}
+
+.n02__detail-nutrition-cell--kcal .n02__detail-nutrition-value {
+    color: var(--primary-600);
+}
+
+.n02__detail-nutrition-unit {
+    font-size: 11px;
+    color: var(--color-text-secondary);
+    letter-spacing: -0.1px;
+}
+
+.n02__detail-nutrition-label {
+    margin-top: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--neutral-700);
+    letter-spacing: -0.2px;
+}
+
+/* 하단 CTA */
+.n02__detail-cta-wrap {
+    flex-shrink: 0;
+    padding: 14px 22px 22px;
+    background: var(--color-bg-card);
+    box-shadow: 0 -6px 16px rgba(30, 25, 21, 0.06);
+}
+
+.n02__detail-cta {
+    height: 60px;
+    border-radius: 14px;
+    font-size: 18px;
+    gap: 8px;
+}
+
+.n02__detail-cta i {
+    font-size: 20px;
+}
+
+.n02__detail-cta-price {
+    font-feature-settings: "tnum";
+}
+
+/* ========================================================
+   접근성 — reduced-motion
+   ======================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .n02__detail,
+    .n02__detail-panel {
+        animation: none;
+    }
+}

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -1,0 +1,646 @@
+// ========================================================
+// N02-menu.js — 메뉴 목록 화면 통합 로직
+// 책임:
+//   - 층 탭 / 식당 사이드바 / 메뉴 그리드 렌더링
+//   - 운영시간 기반 자동 운영중·마감 표시
+//   - 카트 추가/수량/삭제 + 카드 강조 + 카트 바 갱신
+//   - 메뉴 상세 풀스크린 오버레이 오픈/클로즈
+//   - AI 대화 기록 패널 슬라이드 토글
+//   - 모든 액션을 ai-chat 메시지로 로깅
+//
+// 의존: window.MenuData (menu-data.js)
+// 세션 키: cart, currentFloor, currentStore (sessionStorage)
+// ========================================================
+
+(function () {
+    'use strict';
+
+    // ---------- 상수 / 상태 ----------
+    const PAY_NEXT_URL = "/flowP/P01-summary.html"; // 추후 페이지
+
+    const state = {
+        currentFloorId: null,
+        currentStoreId: null,
+        cart: [],            // [{ menuId, qty }]
+        chatLog: [],         // [{ role: "system"|"user"|"tool", text, ts }]
+        sessionId: null,
+        micActive: false,
+    };
+
+    // ---------- DOM 캐시 ----------
+    const $brand          = document.querySelector('[data-bind="brand"]');
+    const $storeName      = document.querySelector('[data-bind="storeName"]');
+    const $floorTabs      = document.querySelector('[data-floor-tabs]');
+    const $storeList      = document.querySelector('[data-store-list]');
+    const $menuGrid       = document.querySelector('[data-menu-grid]');
+    const $menuEmpty      = document.querySelector('[data-menu-empty]');
+
+    const $cartBar        = document.querySelector('[data-cart-bar]');
+    const $cartEmpty      = document.querySelector('[data-cart-empty]');
+    const $cartFilled     = document.querySelector('[data-cart-filled]');
+    const $cartCount      = document.querySelector('[data-cart-count]');
+    const $cartTotal      = document.querySelector('[data-cart-total]');
+    const $cartTrack      = document.querySelector('[data-cart-track]');
+    const $cartArrowPrev  = document.querySelector('[data-cart-arrow="prev"]');
+    const $cartArrowNext  = document.querySelector('[data-cart-arrow="next"]');
+    const $cartPayAmount  = document.querySelector('[data-cart-pay-amount]');
+
+    const $detail         = document.querySelector('[data-detail]');
+    const $detailHero     = document.querySelector('[data-detail-hero]');
+    const $detailName     = document.querySelector('[data-detail-name]');
+    const $detailPrice    = document.querySelector('[data-detail-price]');
+    const $detailDesc     = document.querySelector('[data-detail-desc]');
+    const $detailComps    = document.querySelector('[data-detail-components]');
+    const $detailIngs     = document.querySelector('[data-detail-ingredients]');
+    const $detailNutKcal  = document.querySelector('[data-detail-nut-kcal]');
+    const $detailNutP     = document.querySelector('[data-detail-nut-protein]');
+    const $detailNutC     = document.querySelector('[data-detail-nut-carb]');
+    const $detailNutF     = document.querySelector('[data-detail-nut-fat]');
+    const $detailCtaPrice = document.querySelector('[data-detail-cta-price]');
+
+    const $chatPanel      = document.querySelector('[data-chat-panel]');
+    const $chatDim        = document.querySelector('[data-chat-dim]');
+    const $chatMessages   = document.querySelector('[data-chat-messages]');
+    const $chatSession    = document.querySelector('[data-chat-session]');
+    const $micBtn         = document.querySelector('[data-action="toggle-mic"]');
+
+    let openDetailMenuId = null;
+
+    // ---------- 유틸 ----------
+    const fmt = window.MenuData.formatPrice;
+
+    function nowHHMM() {
+        const d = new Date();
+        const pad = (n) => String(n).padStart(2, "0");
+        return "오후 " + pad((d.getHours() + 11) % 12 + 1) + ":" + pad(d.getMinutes());
+    }
+
+    function generateSessionId() {
+        return Math.random().toString(36).slice(2, 10);
+    }
+
+    // ---------- 세션 로드/저장 ----------
+    function loadSession() {
+        try {
+            state.cart           = JSON.parse(sessionStorage.getItem("cart") || "[]");
+            state.currentFloorId = sessionStorage.getItem("currentFloor");
+            state.currentStoreId = sessionStorage.getItem("currentStore");
+            state.sessionId      = sessionStorage.getItem("aiSessionId");
+            if (!state.sessionId) {
+                state.sessionId = generateSessionId();
+                sessionStorage.setItem("aiSessionId", state.sessionId);
+            }
+        } catch (e) {
+            console.warn("[N02] 세션 로드 실패", e);
+        }
+    }
+
+    function persistCart() {
+        try {
+            sessionStorage.setItem("cart", JSON.stringify(state.cart));
+        } catch (e) {
+            console.warn("[N02] 카트 저장 실패", e);
+        }
+    }
+
+    function persistFloorStore() {
+        try {
+            sessionStorage.setItem("currentFloor", state.currentFloorId);
+            sessionStorage.setItem("currentStore", state.currentStoreId);
+        } catch (e) {
+            console.warn("[N02] 위치 저장 실패", e);
+        }
+    }
+
+    // ---------- 데이터 헬퍼 ----------
+    function getFloor(id) {
+        return window.MenuData.data.floors.find((f) => f.id === id);
+    }
+
+    function getStore(floorId, storeId) {
+        const f = getFloor(floorId);
+        if (!f) return null;
+        return f.stores.find((s) => s.id === storeId) || null;
+    }
+
+    function getCartQty(menuId) {
+        const item = state.cart.find((i) => i.menuId === menuId);
+        return item ? item.qty : 0;
+    }
+
+    function totalCartCount() {
+        return state.cart.reduce((sum, i) => sum + i.qty, 0);
+    }
+
+    function totalCartAmount() {
+        return state.cart.reduce((sum, i) => {
+            const found = window.MenuData.findMenuById(i.menuId);
+            return sum + (found ? found.menu.price * i.qty : 0);
+        }, 0);
+    }
+
+    // ---------- 렌더링: 층 탭 ----------
+    function renderFloorTabs() {
+        const html = window.MenuData.data.floors.map((f) => {
+            const active = f.id === state.currentFloorId;
+            return `<button class="pill-tab ${active ? "pill-tab--active" : ""}"
+                            type="button"
+                            data-floor="${f.id}">${f.label}</button>`;
+        }).join("");
+        $floorTabs.innerHTML = html;
+    }
+
+    // ---------- 렌더링: 식당 사이드바 ----------
+    function renderStoreList() {
+        const floor = getFloor(state.currentFloorId);
+        if (!floor) { $storeList.innerHTML = ""; return; }
+
+        const html = floor.stores.map((s) => {
+            const open   = window.MenuData.isOpenNow(s.hours);
+            const active = s.id === state.currentStoreId;
+            return `
+                <li class="n02__store-item ${active ? "n02__store-item--active" : ""}"
+                    data-store="${s.id}">
+                    <span class="n02__store-name">${s.name}</span>
+                    <span class="n02__store-hours">${s.hours}</span>
+                    <span class="n02__store-status ${open ? "" : "n02__store-status--closed"}">
+                        ${open ? "운영중" : "마감"}
+                    </span>
+                </li>`;
+        }).join("");
+        $storeList.innerHTML = html;
+    }
+
+    // ---------- 렌더링: 메뉴 그리드 ----------
+    function renderMenuGrid() {
+        const store = getStore(state.currentFloorId, state.currentStoreId);
+        if (!store) {
+            $menuGrid.innerHTML = "";
+            $menuEmpty.hidden = false;
+            return;
+        }
+
+        // 매장 이름을 상단바에 반영
+        $storeName.textContent = store.name;
+
+        if (!store.menus.length) {
+            $menuGrid.innerHTML = "";
+            $menuEmpty.hidden = false;
+            return;
+        }
+        $menuEmpty.hidden = true;
+
+        const html = store.menus.map((m) => {
+            const meta  = window.MenuData.buildMenuMeta(m);
+            const qty   = getCartQty(m.id);
+            const inCart = qty > 0;
+
+            // 원산지 한 줄 요약 (앞 2개 + 외)
+            const originSummary = meta.ingredients
+                .slice(0, 2)
+                .map((i) => `${i.name}(${i.origin})`)
+                .join(" · ") + (meta.ingredients.length > 2 ? " 외" : "");
+
+            return `
+                <li class="n02__menu-card ${inCart ? "n02__menu-card--in-cart" : ""} ${m.soldOut ? "n02__menu-card--sold-out" : ""}"
+                    data-menu="${m.id}">
+                    <div class="n02__menu-card-thumb" data-detail-trigger="${m.id}">
+                        ${m.aiPick ? `
+                            <span class="n02__menu-card-ai-badge">
+                                <i class="xi xi-lightning"></i>AI 추천
+                            </span>` : ""}
+                        ${m.badge ? `
+                            <span class="n02__menu-card-extra-badge">${m.badge}</span>` : ""}
+                        <span class="n02__menu-card-detail-chip">
+                            상세 <i class="xi xi-angle-right-thin"></i>
+                        </span>
+                        <span class="n02__menu-card-thumb-text">${m.name}</span>
+                        ${qty > 0 ? `
+                            <span class="n02__menu-card-qty-badge">${qty}</span>` : ""}
+                    </div>
+                    <div class="n02__menu-card-info">
+                        <span class="n02__menu-card-name">${m.name}</span>
+                        <span class="n02__menu-card-origin">${originSummary}</span>
+                        <span class="n02__menu-card-price">${fmt(m.price)}</span>
+                    </div>
+                    <button class="n02__menu-card-add"
+                            type="button"
+                            data-add="${m.id}"
+                            ${m.soldOut ? "disabled" : ""}>
+                        <i class="xi xi-plus-thin"></i>담기
+                    </button>
+                </li>`;
+        }).join("");
+        $menuGrid.innerHTML = html;
+    }
+
+    // ---------- 렌더링: 카트 바 ----------
+    function renderCartBar() {
+        const count = totalCartCount();
+
+        if (count === 0) {
+            $cartBar.classList.add("n02__cart-bar--empty");
+            $cartEmpty.hidden = false;
+            $cartFilled.hidden = true;
+            return;
+        }
+
+        $cartBar.classList.remove("n02__cart-bar--empty");
+        $cartEmpty.hidden = true;
+        $cartFilled.hidden = false;
+
+        $cartCount.textContent = count;
+        const total = totalCartAmount();
+        $cartTotal.textContent = fmt(total);
+        $cartPayAmount.textContent = "· " + fmt(total);
+
+        const html = state.cart.map((item) => {
+            const found = window.MenuData.findMenuById(item.menuId);
+            if (!found) return "";
+            const m = found.menu;
+            const lineTotal = m.price * item.qty;
+
+            return `
+                <li class="n02__cart-item" data-cart-item="${m.id}">
+                    <div class="n02__cart-item-thumb">${m.name}</div>
+                    <div class="n02__cart-item-name-row">
+                        <span class="n02__cart-item-name">${m.name}</span>
+                        <button class="n02__cart-item-remove"
+                                type="button"
+                                data-cart-remove="${m.id}"
+                                aria-label="삭제">
+                            <i class="xi xi-close-thin"></i>
+                        </button>
+                    </div>
+                    <div class="n02__cart-item-bottom">
+                        <span class="n02__cart-item-price">${fmt(lineTotal)}</span>
+                        <div class="qty-stepper">
+                            <button class="qty-stepper__btn qty-stepper__btn--minus"
+                                    type="button"
+                                    data-cart-qty="${m.id}"
+                                    data-delta="-1"
+                                    aria-label="수량 감소">−</button>
+                            <span class="qty-stepper__value">${item.qty}</span>
+                            <button class="qty-stepper__btn"
+                                    type="button"
+                                    data-cart-qty="${m.id}"
+                                    data-delta="1"
+                                    aria-label="수량 증가">+</button>
+                        </div>
+                    </div>
+                </li>`;
+        }).join("");
+        $cartTrack.innerHTML = html;
+
+        // 화살표는 아이템이 2개 이상일 때만 노출
+        const showArrows = state.cart.length > 2;
+        $cartArrowPrev.hidden = !showArrows;
+        $cartArrowNext.hidden = !showArrows;
+    }
+
+    // ---------- 메뉴 상세 오버레이 ----------
+    function openDetail(menuId) {
+        const found = window.MenuData.findMenuById(menuId);
+        if (!found) return;
+        const m = found.menu;
+        const meta = window.MenuData.buildMenuMeta(m);
+
+        openDetailMenuId = menuId;
+
+        $detailName.textContent  = m.name;
+        $detailPrice.textContent = fmt(m.price);
+        $detailDesc.textContent  = meta.description;
+
+        // 사진 placeholder — 메뉴명 텍스트
+        $detailHero.style.background =
+            "linear-gradient(135deg, var(--neutral-200), var(--neutral-300))";
+
+        // 메뉴 구성 칩
+        $detailComps.innerHTML = meta.components
+            .map((c) => `<span class="n02__detail-chip">${c}</span>`)
+            .join("");
+
+        // 원재료 + 원산지
+        $detailIngs.innerHTML = meta.ingredients.map((i) => `
+            <li class="n02__detail-ingredient-row">
+                <span class="n02__detail-ingredient-name">${i.name}</span>
+                <span class="origin-pill ${i.imported ? "origin-pill--imported" : ""}">
+                    ${i.origin}
+                </span>
+            </li>`).join("");
+
+        // 영양정보
+        $detailNutKcal.textContent = meta.nutrition.kcal;
+        $detailNutP.textContent    = meta.nutrition.protein;
+        $detailNutC.textContent    = meta.nutrition.carb;
+        $detailNutF.textContent    = meta.nutrition.fat;
+
+        // CTA 가격
+        $detailCtaPrice.textContent = "· " + fmt(m.price);
+
+        $detail.hidden = false;
+        $detail.setAttribute("aria-hidden", "false");
+    }
+
+    function closeDetail() {
+        openDetailMenuId = null;
+        $detail.hidden = true;
+        $detail.setAttribute("aria-hidden", "true");
+    }
+
+    // ---------- 카트 조작 ----------
+    function addToCart(menuId, opts) {
+        opts = opts || {};
+        const found = window.MenuData.findMenuById(menuId);
+        if (!found || found.menu.soldOut) return;
+
+        const existing = state.cart.find((i) => i.menuId === menuId);
+        if (existing) {
+            existing.qty += 1;
+        } else {
+            state.cart.push({ menuId: menuId, qty: 1 });
+        }
+        persistCart();
+        renderMenuGrid();
+        renderCartBar();
+
+        // AI 채팅에 로그 (사용자 액션 → 시스템 응답 + 툴 호출)
+        if (!opts.silent) {
+            pushChatBubble("system", `${found.menu.name}을(를) 장바구니에 담았어요! ${fmt(found.menu.price)}`);
+            pushChatBubble("tool",   `🛒 ${found.menu.name} 담기 실행`);
+        }
+    }
+
+    function changeCartQty(menuId, delta) {
+        const item = state.cart.find((i) => i.menuId === menuId);
+        if (!item) return;
+        item.qty += delta;
+        if (item.qty <= 0) {
+            removeFromCart(menuId, { silent: true });
+            return;
+        }
+        persistCart();
+        renderMenuGrid();
+        renderCartBar();
+    }
+
+    function removeFromCart(menuId, opts) {
+        opts = opts || {};
+        const idx = state.cart.findIndex((i) => i.menuId === menuId);
+        if (idx < 0) return;
+        const found = window.MenuData.findMenuById(menuId);
+        state.cart.splice(idx, 1);
+        persistCart();
+        renderMenuGrid();
+        renderCartBar();
+        if (!opts.silent && found) {
+            pushChatBubble("system", `${found.menu.name}을(를) 장바구니에서 뺐어요.`);
+        }
+    }
+
+    // ---------- AI 채팅 패널 ----------
+    function openChat() {
+        $chatPanel.classList.add("ai-chat-panel--open");
+        $chatPanel.setAttribute("aria-hidden", "false");
+        $chatDim.classList.add("ai-chat-dim--open");
+        $chatDim.setAttribute("aria-hidden", "false");
+        // 스크롤 맨 아래로
+        $chatMessages.scrollTop = $chatMessages.scrollHeight;
+    }
+
+    function closeChat() {
+        $chatPanel.classList.remove("ai-chat-panel--open");
+        $chatPanel.setAttribute("aria-hidden", "true");
+        $chatDim.classList.remove("ai-chat-dim--open");
+        $chatDim.setAttribute("aria-hidden", "true");
+    }
+
+    function pushChatBubble(role, text) {
+        const item = { role: role, text: text, ts: nowHHMM() };
+        state.chatLog.push(item);
+        renderChatBubble(item);
+        // 패널 열려 있으면 자동 스크롤
+        if ($chatPanel.classList.contains("ai-chat-panel--open")) {
+            $chatMessages.scrollTop = $chatMessages.scrollHeight;
+        }
+    }
+
+    function renderChatBubble(item) {
+        const cls = "ai-chat-bubble--" + item.role;
+        const iconHtml = item.role === "system"
+            ? '<i class="xi xi-message"></i>'
+            : (item.role === "tool"
+                ? '<i class="xi xi-lightning"></i>'
+                : '');
+        const node = document.createElement("div");
+        node.className = "ai-chat-bubble " + cls;
+        node.innerHTML = `
+            <div class="ai-chat-bubble__body">${item.text}</div>
+            <div class="ai-chat-bubble__time">${iconHtml}<span>${item.ts}</span></div>
+        `;
+        $chatMessages.appendChild(node);
+    }
+
+    function renderChatInitial() {
+        $chatSession.textContent = state.sessionId;
+        $chatMessages.innerHTML = "";
+        // 디폴트 인사말
+        pushChatBubble("system",
+            "안녕하세요! 상록원 AI 주문 도우미입니다. 음성으로 편하게 주문하세요 😊 핀 마이크가 항상 켜져 있어 버튼을 누르지 않아도 돼요.");
+    }
+
+    function exportChatJson() {
+        const blob = new Blob(
+            [JSON.stringify({ sessionId: state.sessionId, log: state.chatLog }, null, 2)],
+            { type: "application/json" }
+        );
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `nunchi-session-${state.sessionId}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function resetChat() {
+        state.chatLog = [];
+        state.sessionId = generateSessionId();
+        sessionStorage.setItem("aiSessionId", state.sessionId);
+        renderChatInitial();
+    }
+
+    // ---------- 마이크 토글 ----------
+    function toggleMic() {
+        state.micActive = !state.micActive;
+        $micBtn.classList.toggle("app-topbar__action-icon--mic-active", state.micActive);
+        if (state.micActive) {
+            pushChatBubble("system", "🎙️ 청취 시작 — 편하게 말씀해 주세요");
+        } else {
+            pushChatBubble("system", "🔇 청취 일시 정지");
+        }
+    }
+
+    // ---------- 결제 ----------
+    function gotoCheckout() {
+        if (!state.cart.length) return;
+        try {
+            sessionStorage.setItem("currentStep", "P01");
+        } catch (e) { /* noop */ }
+        // P01 페이지가 아직 없으면 안내
+        // location.href = PAY_NEXT_URL;
+        alert(
+            "결제 단계로 이동합니다.\n" +
+            "총 " + totalCartCount() + "개 · " + fmt(totalCartAmount()) +
+            "\n(P01 페이지는 아직 구현 전입니다)"
+        );
+    }
+
+    // ---------- 이벤트 위임 ----------
+    function bindEvents() {
+        // 층 탭
+        $floorTabs.addEventListener("click", (e) => {
+            const btn = e.target.closest("[data-floor]");
+            if (!btn) return;
+            const fid = btn.getAttribute("data-floor");
+            if (fid === state.currentFloorId) return;
+            state.currentFloorId = fid;
+            // 새 층의 첫 식당으로 자동 선택
+            const f = getFloor(fid);
+            state.currentStoreId = f && f.stores[0] ? f.stores[0].id : null;
+            persistFloorStore();
+            renderFloorTabs();
+            renderStoreList();
+            renderMenuGrid();
+        });
+
+        // 사이드바 식당 클릭
+        $storeList.addEventListener("click", (e) => {
+            const li = e.target.closest("[data-store]");
+            if (!li) return;
+            const sid = li.getAttribute("data-store");
+            if (sid === state.currentStoreId) return;
+            state.currentStoreId = sid;
+            persistFloorStore();
+            renderStoreList();
+            renderMenuGrid();
+        });
+
+        // 메뉴 그리드 위임
+        $menuGrid.addEventListener("click", (e) => {
+            // 1) "+ 담기" 버튼
+            const addBtn = e.target.closest("[data-add]");
+            if (addBtn) {
+                e.stopPropagation();
+                addToCart(parseInt(addBtn.getAttribute("data-add"), 10));
+                return;
+            }
+            // 2) 썸네일 → 상세 오버레이
+            const thumb = e.target.closest("[data-detail-trigger]");
+            if (thumb) {
+                openDetail(parseInt(thumb.getAttribute("data-detail-trigger"), 10));
+                return;
+            }
+        });
+
+        // 카트 바 — 수량 / 삭제
+        $cartTrack.addEventListener("click", (e) => {
+            const qtyBtn = e.target.closest("[data-cart-qty]");
+            if (qtyBtn) {
+                const id = parseInt(qtyBtn.getAttribute("data-cart-qty"), 10);
+                const delta = parseInt(qtyBtn.getAttribute("data-delta"), 10);
+                changeCartQty(id, delta);
+                return;
+            }
+            const rmBtn = e.target.closest("[data-cart-remove]");
+            if (rmBtn) {
+                removeFromCart(parseInt(rmBtn.getAttribute("data-cart-remove"), 10));
+                return;
+            }
+        });
+
+        // 카트 화살표
+        $cartArrowPrev.addEventListener("click", () => {
+            $cartTrack.scrollBy({ left: -180, behavior: "smooth" });
+        });
+        $cartArrowNext.addEventListener("click", () => {
+            $cartTrack.scrollBy({ left: 180, behavior: "smooth" });
+        });
+
+        // 결제하기
+        document.addEventListener("click", (e) => {
+            const btn = e.target.closest('[data-action="checkout"]');
+            if (btn) gotoCheckout();
+        });
+
+        // 상세 닫기
+        document.addEventListener("click", (e) => {
+            const btn = e.target.closest('[data-action="close-detail"]');
+            if (btn) closeDetail();
+        });
+
+        // 상세에서 카트 담기
+        document.addEventListener("click", (e) => {
+            const btn = e.target.closest('[data-action="add-from-detail"]');
+            if (btn && openDetailMenuId != null) {
+                addToCart(openDetailMenuId);
+                closeDetail();
+            }
+        });
+
+        // AI 채팅
+        document.addEventListener("click", (e) => {
+            if (e.target.closest('[data-action="open-chat"]'))   openChat();
+            if (e.target.closest('[data-action="close-chat"]'))  closeChat();
+            if (e.target.closest('[data-action="export-chat"]')) exportChatJson();
+            if (e.target.closest('[data-action="reset-chat"]'))  resetChat();
+        });
+        $chatDim.addEventListener("click", closeChat);
+
+        // 마이크
+        $micBtn.addEventListener("click", toggleMic);
+
+        // ESC 로 오버레이 닫기 (디버깅 편의)
+        document.addEventListener("keydown", (e) => {
+            if (e.key === "Escape") {
+                if (!$detail.hidden) closeDetail();
+                else if ($chatPanel.classList.contains("ai-chat-panel--open")) closeChat();
+            }
+        });
+    }
+
+    // ---------- 초기화 ----------
+    function bootstrap() {
+        loadSession();
+
+        // 매장 브랜드명
+        $brand.textContent = window.MenuData.data.brand;
+
+        // 기본 위치 = 1층 / 첫 식당 (세션값이 유효하면 그대로)
+        if (!state.currentFloorId || !getFloor(state.currentFloorId)) {
+            state.currentFloorId = window.MenuData.data.floors[0].id;
+        }
+        const f = getFloor(state.currentFloorId);
+        if (!state.currentStoreId || !getStore(state.currentFloorId, state.currentStoreId)) {
+            state.currentStoreId = f && f.stores[0] ? f.stores[0].id : null;
+        }
+        persistFloorStore();
+        sessionStorage.setItem("currentStep", "N02");
+
+        renderFloorTabs();
+        renderStoreList();
+        renderMenuGrid();
+        renderCartBar();
+        renderChatInitial();
+
+        bindEvents();
+
+        // 운영 상태는 1분마다 갱신
+        setInterval(renderStoreList, 60 * 1000);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", bootstrap);
+    } else {
+        bootstrap();
+    }
+})();

--- a/src/main/resources/static/front/js/flowN/menu-data.js
+++ b/src/main/resources/static/front/js/flowN/menu-data.js
@@ -1,0 +1,385 @@
+// ========================================================
+// menu-data.js — 상록원 식당 · 메뉴 데이터 단일 소스
+// 사용처: N02-menu (목록 + 상세 오버레이) 및 향후 P01 요약
+//
+// 구조:
+//   window.__MENU_DATA__ = {
+//       brand, floors[ { id, label, stores[ { id, name, hours, menus[] } ] } ]
+//   }
+//
+// 메뉴 객체 필드:
+//   id          숫자 ID
+//   name        메뉴명
+//   price       원
+//   aiPick      (옵션) AI 추천 뱃지
+//   badge       (옵션) "한정판매" 등 추가 뱃지 텍스트
+//   dailyDate   (옵션, store 레벨에서도 사용) "03/25(수)" 등 변동 메뉴 날짜 표기
+//   soldOut     (옵션) 품절
+//
+// 상세(메뉴구성/원산지/영양정보)는 buildMenuMeta(menu) 가
+// 메뉴명 키워드를 기반으로 카테고리를 추정해 자동 생성한다.
+// ========================================================
+
+(function () {
+    'use strict';
+
+    // -------- 1. 사용자 제공 실제 메뉴 데이터 --------
+    const DATA = {
+        brand: "상록원",
+        floors: [
+            {
+                id: "F1", label: "1층",
+                stores: [
+                    {
+                        id: "sotn-noodle",
+                        name: "솥앤누들",
+                        hours: "11:00~19:00",
+                        menus: [
+                            { id: 101, name: "삼겹살김치철판",  price: 6000 },
+                            { id: 102, name: "치즈불닭철판",    price: 7000, aiPick: true },
+                            { id: 103, name: "데리야끼치킨솥밥", price: 5700 },
+                            { id: 104, name: "숯불삼겹솥밥",    price: 5000 },
+                            { id: 105, name: "우삼겹솥밥",      price: 6500 },
+                            { id: 106, name: "콘치즈솥밥",      price: 5000 },
+                            { id: 107, name: "우동",            price: 5000 },
+                            { id: 108, name: "우동·돈가스 set", price: 6800 },
+                            { id: 109, name: "우동·알밥 set",   price: 6500 },
+                            { id: 110, name: "철판치즈돈가스",  price: 7000 },
+                            { id: 111, name: "낙지삼겹솥밥",    price: 6500 },
+                        ],
+                    },
+                    {
+                        id: "bunsik",
+                        name: "분식당",
+                        hours: "10:00~14:00",
+                        menus: [
+                            { id: 121, name: "추억의도시락", price: 4000 },
+                            { id: 122, name: "계란라면",     price: 3800 },
+                            { id: 123, name: "치즈라면",     price: 4000 },
+                            { id: 124, name: "해장라면",     price: 4000 },
+                            { id: 125, name: "공기밥",       price: 1000 },
+                        ],
+                    },
+                ],
+            },
+            {
+                id: "F2", label: "2층",
+                stores: [
+                    {
+                        id: "ilpum",
+                        name: "일품",
+                        hours: "11:00~14:00 / 15:00~16:00",
+                        dailyDate: "03/25(수)",
+                        menus: [
+                            { id: 201, name: "매콤제육덮밥·핫도그·자율배식·배추김치/단무지", price: 4500 },
+                        ],
+                    },
+                    {
+                        id: "yang",
+                        name: "양식",
+                        hours: "11:00~14:00",
+                        dailyDate: "03/25(수)",
+                        menus: [
+                            { id: 211, name: "치즈돈까스",            price: 6300 },
+                            { id: 212, name: "토마토파스타·마늘빵",   price: 6000 },
+                            { id: 213, name: "치즈오븐파스타",        price: 6500, badge: "한정판매" },
+                        ],
+                    },
+                    {
+                        id: "deojinguk",
+                        name: "더진국",
+                        hours: "11:00~14:00 / 15:00~16:00",
+                        menus: [
+                            { id: 221, name: "수육국밥·순대국밥", price: 6800 },
+                            { id: 222, name: "얼큰국밥",          price: 7000 },
+                        ],
+                    },
+                ],
+            },
+            {
+                id: "F3", label: "3층",
+                stores: [
+                    {
+                        id: "jipbap",
+                        name: "집밥",
+                        hours: "11:00~14:00 / 17:00~19:00",
+                        dailyDate: "03/25(수)",
+                        menus: [
+                            { id: 301, name: "[중식] 샤브칼국수·삼겹살수육·도토리묵상추무침·샐러드·배추김치", price: 7000 },
+                            { id: 302, name: "[석식] 파채고추장삼겹살·치킨너겟·미역줄기볶음·샐러드·배추김치", price: 7000 },
+                        ],
+                    },
+                    {
+                        id: "hangreut",
+                        name: "한그릇",
+                        hours: "12:00~14:00",
+                        dailyDate: "03/25(수)",
+                        menus: [
+                            { id: 311, name: "[중식] 카레&그릴소세지·통새우볼튀김·마시는요플레·배추김치", price: 7000, badge: "한정판매" },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+
+    // -------- 2. 메뉴 카테고리 추정 --------
+    // 가장 먼저 매칭된 카테고리를 사용 (배열 순서 = 우선순위)
+    const CATEGORY_RULES = [
+        { id: "ramen",       keywords: ["라면"] },
+        { id: "udon",        keywords: ["우동"] },
+        { id: "pasta",       keywords: ["파스타"] },
+        { id: "donkkasu",    keywords: ["돈가스", "돈까스"] },
+        { id: "guk",         keywords: ["국밥", "해장"] },
+        { id: "chulpan",     keywords: ["철판"] },
+        { id: "sotbap",      keywords: ["솥밥"] },
+        { id: "deopbap",     keywords: ["덮밥"] },
+        { id: "dosirak",     keywords: ["도시락"] },
+        { id: "rice-extra",  keywords: ["공기밥"] },
+        { id: "set",         keywords: ["set", "세트"] },
+        { id: "korean-set",  keywords: ["[중식]", "[석식]", "샐러드", "배추김치"] },
+    ];
+
+    function detectCategory(menu) {
+        const name = menu.name;
+        for (const rule of CATEGORY_RULES) {
+            if (rule.keywords.some((kw) => name.toLowerCase().indexOf(kw.toLowerCase()) >= 0)) {
+                return rule.id;
+            }
+        }
+        return "etc";
+    }
+
+    // -------- 3. 카테고리별 데모 메타데이터 템플릿 --------
+    // - components: 메뉴구성 칩에 표시될 구성품
+    // - ingredients: 원재료/원산지 (기본 국내산, true면 수입산으로 표시)
+    // - nutritionRatio: 가격에 비례해서 칼로리/영양소 추정에 쓰임 (대략적)
+    const META_BY_CATEGORY = {
+        ramen: {
+            description: "얼큰한 국물에 쫄깃한 면발을 즐기는 따끈한 한 그릇",
+            components: ["라면사리", "국물 베이스", "계란", "대파", "김치"],
+            ingredients: [
+                { name: "라면사리(밀)", origin: "수입산", imported: true },
+                { name: "계란",         origin: "국내산" },
+                { name: "대파",         origin: "국내산" },
+                { name: "고춧가루",     origin: "국내산" },
+                { name: "배추김치",     origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 540, protein: 18, carb: 78, fat: 18 },
+        },
+        udon: {
+            description: "진한 가쓰오 육수와 부드러운 우동면의 조화",
+            components: ["우동면", "가쓰오 육수", "유부", "쪽파", "어묵"],
+            ingredients: [
+                { name: "우동면(밀)", origin: "국내산" },
+                { name: "가쓰오부시", origin: "수입산", imported: true },
+                { name: "유부",       origin: "국내산" },
+                { name: "쪽파",       origin: "국내산" },
+                { name: "간장",       origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 580, protein: 16, carb: 92, fat: 14 },
+        },
+        pasta: {
+            description: "이탈리안 정통 레시피로 풍미 가득한 파스타",
+            components: ["스파게티 면", "토마토 소스", "마늘", "올리브오일", "파마산 치즈"],
+            ingredients: [
+                { name: "스파게티(밀)", origin: "수입산", imported: true },
+                { name: "토마토",       origin: "국내산" },
+                { name: "마늘",         origin: "국내산" },
+                { name: "올리브오일",   origin: "수입산", imported: true },
+                { name: "파마산 치즈",  origin: "수입산", imported: true },
+            ],
+            nutritionBase: { kcal: 720, protein: 22, carb: 95, fat: 26 },
+        },
+        donkkasu: {
+            description: "두툼한 등심을 바삭하게 튀긴 정통 일식 돈가스",
+            components: ["돈가스 등심", "빵가루", "양배추 샐러드", "데미글라스 소스", "밥"],
+            ingredients: [
+                { name: "돼지고기 등심", origin: "국내산" },
+                { name: "빵가루(밀)",    origin: "국내산" },
+                { name: "양배추",        origin: "국내산" },
+                { name: "데미글라스",    origin: "국내산" },
+                { name: "쌀",            origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 820, protein: 32, carb: 78, fat: 36 },
+        },
+        guk: {
+            description: "사골을 우려낸 깊은 국물에 푸짐한 건더기",
+            components: ["사골 육수", "수육·내장", "대파", "다진양념", "공기밥"],
+            ingredients: [
+                { name: "한우 사골", origin: "국내산" },
+                { name: "돼지고기",  origin: "국내산" },
+                { name: "대파",      origin: "국내산" },
+                { name: "고춧가루",  origin: "국내산" },
+                { name: "쌀",        origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 760, protein: 38, carb: 72, fat: 22 },
+        },
+        chulpan: {
+            description: "뜨거운 철판에서 바로 볶아낸 한국식 볶음 요리",
+            components: ["철판볶음밥", "메인 단백질", "묵은지", "대파", "참기름", "깨"],
+            ingredients: [
+                { name: "삼겹살(돼지)", origin: "국내산" },
+                { name: "쌀",           origin: "국내산" },
+                { name: "배추김치",     origin: "국내산" },
+                { name: "대파",         origin: "국내산" },
+                { name: "참기름",       origin: "국내산" },
+                { name: "고춧가루",     origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 720, protein: 28, carb: 82, fat: 24 },
+        },
+        sotbap: {
+            description: "뜨거운 솥에 갓 지은 밥과 메인 토핑이 어우러진 한 그릇",
+            components: ["솥에 지은 밥", "메인 토핑", "쪽파", "참기름", "구운 김"],
+            ingredients: [
+                { name: "쌀",       origin: "국내산" },
+                { name: "닭가슴살", origin: "국내산" },
+                { name: "쪽파",     origin: "국내산" },
+                { name: "참기름",   origin: "국내산" },
+                { name: "구운김",   origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 700, protein: 26, carb: 88, fat: 18 },
+        },
+        deopbap: {
+            description: "갓 지은 밥 위에 매콤한 양념을 더한 한 끼 식사",
+            components: ["흰쌀밥", "메인 토핑", "양념장", "야채", "단무지"],
+            ingredients: [
+                { name: "쌀",         origin: "국내산" },
+                { name: "돼지고기",   origin: "국내산" },
+                { name: "양파",       origin: "국내산" },
+                { name: "고추장",     origin: "국내산" },
+                { name: "단무지",     origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 680, protein: 24, carb: 92, fat: 18 },
+        },
+        dosirak: {
+            description: "옛날 학교 도시락 그대로의 정겨운 한 끼",
+            components: ["흰쌀밥", "스팸", "계란말이", "김치", "단무지"],
+            ingredients: [
+                { name: "쌀",     origin: "국내산" },
+                { name: "스팸",   origin: "국내산" },
+                { name: "계란",   origin: "국내산" },
+                { name: "배추김치", origin: "국내산" },
+                { name: "단무지", origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 620, protein: 20, carb: 78, fat: 22 },
+        },
+        "rice-extra": {
+            description: "갓 지은 따끈한 밥 한 공기",
+            components: ["쌀밥"],
+            ingredients: [
+                { name: "쌀", origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 310, protein: 6, carb: 68, fat: 1 },
+        },
+        set: {
+            description: "두 가지 메뉴를 한 번에 즐기는 풍성한 세트",
+            components: ["메인 메뉴", "사이드 메뉴", "반찬", "음료"],
+            ingredients: [
+                { name: "쌀",         origin: "국내산" },
+                { name: "돼지고기",   origin: "국내산" },
+                { name: "밀가루",     origin: "수입산", imported: true },
+                { name: "양배추",     origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 880, protein: 28, carb: 110, fat: 28 },
+        },
+        "korean-set": {
+            description: "오늘의 한식 정찬 — 메인 + 반찬 구성",
+            components: ["메인 요리", "샐러드", "배추김치", "공기밥", "반찬"],
+            ingredients: [
+                { name: "쌀",         origin: "국내산" },
+                { name: "삼겹살(돼지)", origin: "국내산" },
+                { name: "배추",       origin: "국내산" },
+                { name: "고춧가루",   origin: "국내산" },
+                { name: "참기름",     origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 760, protein: 30, carb: 85, fat: 24 },
+        },
+        etc: {
+            description: "오늘의 메뉴 — 정성껏 준비한 한 끼",
+            components: ["메인 구성", "사이드", "반찬"],
+            ingredients: [
+                { name: "쌀",     origin: "국내산" },
+                { name: "야채",   origin: "국내산" },
+                { name: "양념",   origin: "국내산" },
+            ],
+            nutritionBase: { kcal: 650, protein: 22, carb: 80, fat: 20 },
+        },
+    };
+
+    // -------- 4. 메타 빌더 --------
+    function buildMenuMeta(menu) {
+        const cat = detectCategory(menu);
+        const tpl = META_BY_CATEGORY[cat] || META_BY_CATEGORY.etc;
+
+        // 가격에 비례해서 영양소를 ±10% 흔들어 다양성 부여 (결정론적)
+        const seed = (menu.id % 7) - 3;          // -3 ~ +3
+        const factor = 1 + (seed * 0.03);        // 0.91 ~ 1.09
+
+        const n = tpl.nutritionBase;
+        const nutrition = {
+            kcal:    Math.round(n.kcal    * factor / 10) * 10,
+            protein: Math.round(n.protein * factor),
+            carb:    Math.round(n.carb    * factor),
+            fat:     Math.round(n.fat     * factor),
+        };
+
+        return {
+            category: cat,
+            description: tpl.description,
+            components:  tpl.components.slice(),
+            ingredients: tpl.ingredients.map(function (i) { return Object.assign({}, i); }),
+            nutrition: nutrition,
+        };
+    }
+
+    // -------- 5. 운영 시간 파싱 → 현재 운영중 여부 --------
+    // hours 예: "11:00~19:00", "11:00~14:00 / 15:00~16:00"
+    function parseHoursToRanges(hoursStr) {
+        if (!hoursStr) return [];
+        return hoursStr.split("/").map(function (chunk) {
+            const m = chunk.trim().match(/(\d{1,2}):(\d{2})\s*~\s*(\d{1,2}):(\d{2})/);
+            if (!m) return null;
+            return {
+                startMin: (+m[1]) * 60 + (+m[2]),
+                endMin:   (+m[3]) * 60 + (+m[4]),
+            };
+        }).filter(Boolean);
+    }
+
+    function isOpenNow(hoursStr, now) {
+        const date = now || new Date();
+        const cur = date.getHours() * 60 + date.getMinutes();
+        return parseHoursToRanges(hoursStr).some(function (r) {
+            return cur >= r.startMin && cur < r.endMin;
+        });
+    }
+
+    // -------- 6. 헬퍼 --------
+    function formatPrice(won) {
+        return "₩ " + Number(won).toLocaleString("ko-KR");
+    }
+
+    function findMenuById(id) {
+        for (const f of DATA.floors) {
+            for (const s of f.stores) {
+                for (const m of s.menus) {
+                    if (m.id === id) {
+                        return { menu: m, store: s, floor: f };
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    // -------- 7. 외부 노출 --------
+    window.__MENU_DATA__ = DATA;
+    window.MenuData = {
+        data: DATA,
+        buildMenuMeta: buildMenuMeta,
+        isOpenNow: isOpenNow,
+        formatPrice: formatPrice,
+        findMenuById: findMenuById,
+    };
+})();

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=720, initial-scale=1" />
+    <title>메뉴 선택 · 눈치 키오스크</title>
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowN/N02-menu.css">
+</head>
+<body>
+<main class="page-bg n02">
+
+    <!-- ========================================================
+         ① 상단바 — 좌(뒤로 + 매장/식당명) · 우(대화기록 + 마이크)
+         ======================================================== -->
+    <header class="app-topbar fade-up" style="--delay: 0ms;">
+        <div class="app-topbar__left">
+            <button class="app-topbar__back" type="button"
+                    aria-label="뒤로 가기"
+                    onclick="location.href='/S02-dine.html'">
+                <i class="xi xi-angle-left-thin" aria-hidden="true"></i>
+            </button>
+            <div class="app-topbar__store">
+                <span class="app-topbar__store-sub" data-bind="brand">상록원</span>
+                <span class="app-topbar__store-name" data-bind="storeName">솥앤누들</span>
+            </div>
+        </div>
+        <div class="app-topbar__right">
+            <button class="app-topbar__action-pill" type="button"
+                    data-action="open-chat"
+                    aria-label="AI 대화 기록 열기">
+                <i class="xi xi-message" aria-hidden="true"></i>
+                <span>대화 기록</span>
+            </button>
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
+        </div>
+    </header>
+
+    <!-- ========================================================
+         ② 층 탭 — 1층 / 2층 / 3층
+         ======================================================== -->
+    <nav class="n02__floor-tabs fade-up" style="--delay: 80ms;"
+         aria-label="층 선택">
+        <div class="pill-tab-group" data-floor-tabs>
+            <!-- JS 가 동적으로 채움 -->
+        </div>
+    </nav>
+
+    <!-- ========================================================
+         ③ 본문 — 사이드바(식당) + 메뉴 그리드
+         ======================================================== -->
+    <section class="n02__body fade-up" style="--delay: 160ms;">
+        <!-- 좌측: 식당 리스트 -->
+        <aside class="n02__store-list" data-store-list aria-label="식당 목록">
+            <!-- JS 동적 -->
+        </aside>
+
+        <!-- 우측: 메뉴 그리드 -->
+        <div class="n02__menu-area">
+            <ul class="n02__menu-grid" data-menu-grid>
+                <!-- JS 동적 -->
+            </ul>
+            <!-- 빈 상태 (메뉴 없을 때) -->
+            <div class="n02__menu-empty" data-menu-empty hidden>
+                <i class="xi xi-glass" aria-hidden="true"></i>
+                <p>아직 등록된 메뉴가 없어요</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- ========================================================
+         ④ 하단 카트 바 — 빈 상태 / 채워진 상태 토글
+         ======================================================== -->
+    <section class="n02__cart-bar n02__cart-bar--empty"
+             data-cart-bar
+             aria-label="장바구니">
+        <!-- 빈 상태 -->
+        <div class="n02__cart-empty" data-cart-empty>
+            <div class="n02__cart-empty-head">
+                <i class="xi xi-cart" aria-hidden="true"></i>
+                <span>카트</span>
+            </div>
+            <p class="n02__cart-empty-msg">메뉴를 담으면 여기에 표시됩니다</p>
+            <button class="btn-cta btn-cta--primary btn-cta--block n02__cart-pay-btn"
+                    type="button" disabled>
+                결제하기
+            </button>
+        </div>
+
+        <!-- 채워진 상태 -->
+        <div class="n02__cart-filled" data-cart-filled hidden>
+            <div class="n02__cart-filled-head">
+                <div class="n02__cart-filled-head-left">
+                    <i class="xi xi-cart" aria-hidden="true"></i>
+                    <span>카트</span>
+                    <span class="n02__cart-filled-count" data-cart-count>0</span>
+                </div>
+                <div class="n02__cart-filled-head-right">
+                    <span class="n02__cart-total-label">총 주문금액</span>
+                    <span class="n02__cart-total-value" data-cart-total>₩ 0</span>
+                </div>
+            </div>
+
+            <div class="n02__cart-track-wrap">
+                <button class="n02__cart-arrow n02__cart-arrow--prev"
+                        type="button"
+                        data-cart-arrow="prev"
+                        aria-label="이전 카트 항목"
+                        hidden>
+                    <i class="xi xi-angle-left-thin" aria-hidden="true"></i>
+                </button>
+                <ul class="n02__cart-track" data-cart-track>
+                    <!-- JS 동적 -->
+                </ul>
+                <button class="n02__cart-arrow n02__cart-arrow--next"
+                        type="button"
+                        data-cart-arrow="next"
+                        aria-label="다음 카트 항목"
+                        hidden>
+                    <i class="xi xi-angle-right-thin" aria-hidden="true"></i>
+                </button>
+            </div>
+
+            <button class="btn-cta btn-cta--primary btn-cta--block n02__cart-pay-btn"
+                    type="button"
+                    data-action="checkout">
+                <i class="xi xi-cart" aria-hidden="true"></i>
+                <span>결제하기</span>
+                <span class="n02__cart-pay-amount" data-cart-pay-amount>· ₩ 0</span>
+            </button>
+        </div>
+    </section>
+
+    <!-- ========================================================
+         ⑤ 메뉴 상세 풀스크린 오버레이
+         ======================================================== -->
+    <div class="n02__detail" data-detail hidden aria-hidden="true">
+        <article class="n02__detail-panel">
+            <!-- 히어로 (사진 placeholder + 메뉴명/가격 + X) -->
+            <div class="n02__detail-hero" data-detail-hero>
+                <div class="n02__detail-hero-overlay"></div>
+                <button class="n02__detail-close"
+                        type="button"
+                        data-action="close-detail"
+                        aria-label="닫기">
+                    <i class="xi xi-close-thin" aria-hidden="true"></i>
+                </button>
+                <div class="n02__detail-hero-meta">
+                    <span class="n02__detail-name" data-detail-name></span>
+                    <span class="n02__detail-price" data-detail-price></span>
+                </div>
+            </div>
+
+            <!-- 본문 (스크롤) -->
+            <div class="n02__detail-body" data-detail-body>
+                <p class="n02__detail-desc" data-detail-desc></p>
+
+                <section class="n02__detail-section">
+                    <h3 class="n02__detail-section-title">
+                        <i class="xi xi-restaurant" aria-hidden="true"></i>
+                        메뉴 구성
+                    </h3>
+                    <div class="n02__detail-chips" data-detail-components></div>
+                </section>
+
+                <section class="n02__detail-section">
+                    <h3 class="n02__detail-section-title">
+                        <i class="xi xi-list" aria-hidden="true"></i>
+                        원재료 및 원산지
+                    </h3>
+                    <ul class="n02__detail-ingredients" data-detail-ingredients></ul>
+                </section>
+
+                <section class="n02__detail-section">
+                    <h3 class="n02__detail-section-title">
+                        <i class="xi xi-heart" aria-hidden="true"></i>
+                        영양정보 <span class="n02__detail-section-sub">(1인분 기준)</span>
+                    </h3>
+                    <div class="n02__detail-nutrition">
+                        <div class="n02__detail-nutrition-cell n02__detail-nutrition-cell--kcal">
+                            <span class="n02__detail-nutrition-value" data-detail-nut-kcal>0</span>
+                            <span class="n02__detail-nutrition-unit">kcal</span>
+                            <span class="n02__detail-nutrition-label">열량</span>
+                        </div>
+                        <div class="n02__detail-nutrition-cell">
+                            <span class="n02__detail-nutrition-value" data-detail-nut-protein>0</span>
+                            <span class="n02__detail-nutrition-unit">g</span>
+                            <span class="n02__detail-nutrition-label">단백질</span>
+                        </div>
+                        <div class="n02__detail-nutrition-cell">
+                            <span class="n02__detail-nutrition-value" data-detail-nut-carb>0</span>
+                            <span class="n02__detail-nutrition-unit">g</span>
+                            <span class="n02__detail-nutrition-label">탄수화물</span>
+                        </div>
+                        <div class="n02__detail-nutrition-cell">
+                            <span class="n02__detail-nutrition-value" data-detail-nut-fat>0</span>
+                            <span class="n02__detail-nutrition-unit">g</span>
+                            <span class="n02__detail-nutrition-label">지방</span>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <!-- 하단 CTA -->
+            <div class="n02__detail-cta-wrap">
+                <button class="btn-cta btn-cta--primary btn-cta--block btn-cta--lg n02__detail-cta"
+                        type="button"
+                        data-action="add-from-detail">
+                    <i class="xi xi-cart" aria-hidden="true"></i>
+                    <span>장바구니에 담기</span>
+                    <span class="n02__detail-cta-price" data-detail-cta-price>· ₩ 0</span>
+                </button>
+            </div>
+        </article>
+    </div>
+
+    <!-- ========================================================
+         ⑥ AI 대화 기록 패널 (우측 슬라이드)
+         ======================================================== -->
+    <div class="ai-chat-dim" data-chat-dim aria-hidden="true"></div>
+    <aside class="ai-chat-panel" data-chat-panel aria-hidden="true" aria-label="AI 대화 기록">
+        <div class="ai-chat-panel__header">
+            <div class="ai-chat-panel__header-info">
+                <span class="ai-chat-panel__title">
+                    <i class="xi xi-message" aria-hidden="true"></i>
+                    AI 대화 기록
+                </span>
+                <span class="ai-chat-panel__session">
+                    세션 ID: <span data-chat-session>—</span>
+                </span>
+            </div>
+            <button class="ai-chat-panel__close"
+                    type="button"
+                    data-action="close-chat"
+                    aria-label="대화 기록 닫기">
+                <i class="xi xi-close-thin" aria-hidden="true"></i>
+            </button>
+        </div>
+
+        <div class="ai-chat-panel__status">
+            <div class="ai-chat-panel__status-text">
+                <strong>📝 항상 청취 중</strong>
+                <span>핀 마이크가 항상 켜져 있어요 · MCP AI 에이전트 연결됨</span>
+            </div>
+            <span class="ai-chat-panel__live">LIVE</span>
+        </div>
+
+        <p class="ai-chat-panel__memory-note">음성 대화 기록 · 세션당 메모리 저장</p>
+
+        <div class="ai-chat-panel__messages" data-chat-messages>
+            <!-- JS 동적 -->
+        </div>
+
+        <div class="ai-chat-panel__footer">
+            <button class="ai-chat-panel__footer-btn ai-chat-panel__footer-btn--save"
+                    type="button"
+                    data-action="export-chat">
+                <i class="xi xi-download" aria-hidden="true"></i>
+                <span>JSON 저장</span>
+            </button>
+            <button class="ai-chat-panel__footer-btn ai-chat-panel__footer-btn--reset"
+                    type="button"
+                    data-action="reset-chat">
+                <i class="xi xi-trash" aria-hidden="true"></i>
+                <span>세션 초기화</span>
+            </button>
+        </div>
+    </aside>
+
+</main>
+
+<script src="/lib/jquery-3.7.0.min.js"></script>
+<script src="/js/flowN/menu-data.js"></script>
+<script src="/js/flowN/N02-menu.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 📣 Related Issue

- close #20
- close #21
- close #22
- close #23
- close #24

## 📝 Summary

flowN(메뉴 선택) 화면을 구현하면서 프론트 작업을 함께 정리한 PR 입니다.
이슈 5개(#20~#24)를 의존 순서대로 5개 커밋으로 분리하여 리뷰가 용이하도록 구성했습니다.

### 변경 내역

| 커밋 | 이슈 | 내용 |
|---|---|---|
| `[Docs] #20` | #20 | `docs/FRONTEND_GUIDE.md` 추가 — 프론트 디렉터리·디자인 토큰·BEM 명명·세션 키 가이드 |
| `[Chore] #21` | #21 | `dev-server.py` 추가(Spring Boot 정적 매핑 모방) + `.DS_Store` gitignore |
| `[Fix] #22` | #22 | `common.css` 에 `[hidden] { display: none !important; }` 전역 리셋 — 페이지 CSS 의 `display:flex/grid` 가 `hidden` 속성을 무시하지 않도록 보장 |
| `[Feat] #23` | #23 | 공통 컴포넌트 6종(`.app-topbar` / `.pill-tab` / `.qty-stepper` / `.origin-pill` / `.ai-chat-panel` / `.ai-chat-bubble`) + `@media (min-width: 800px)` 데스크톱 키오스크 미리보기 프레임 |
| `[Feat] #24` | #24 | flowN N02 메뉴 선택 화면 — 1·2·3층 식당 실데이터 반영, 장바구니/메뉴 상세(원산지·영양정보)/AI 채팅 패널 오버레이 통합 |

### 영향 파일
- `docs/FRONTEND_GUIDE.md` (신규)
- `dev-server.py` (신규), `.gitignore`
- `src/main/resources/static/front/css/common.css`
- `src/main/resources/static/front/css/components.css`
- `src/main/resources/static/front/css/flowN/N02-menu.css` (신규)
- `src/main/resources/static/front/js/flowN/menu-data.js` (신규)
- `src/main/resources/static/front/js/flowN/N02-menu.js` (신규)
- `src/main/resources/templates_front/flowN/N02-menu.html` (신규)

## 🙏 Question & PR point

- `dev-server.py` 는 개발용 미리보기 전용입니다. 실행: `python3 dev-server.py 5500`
- 키오스크 화면 기준 해상도는 720×1280px 이며, 데스크톱 브라우저에서는 `@media (min-width: 800px)` 로 가운데 정렬된 키오스크 프레임이 표시됩니다.

## 📬 Postman

- 백엔드 API 변경 없음 — 해당 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메뉴 선택 화면 추가: 층별/매장별 메뉴 탐색 기능
  * 장바구니 관리 기능: 아이템 추가/제거, 수량 조정, 가격 계산
  * 메뉴 상세 정보 오버레이: 설명, 재료, 영양 정보 표시
  * AI 대화 패널: 채팅 로그 기능 포함

* **문서**
  * 프론트엔드 개발 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->