### PR TITLE
[Feat] #28~#34 flowP 결제 플로우 전체 구현

### DIFF
--- a/src/main/resources/static/front/css/components.css
+++ b/src/main/resources/static/front/css/components.css
@@ -758,3 +758,292 @@
 .ai-chat-panel__footer-btn:active {
     transform: scale(0.97);
 }
+
+/* ========================================================
+   .p-topbar — 결제 플로우 전용 상단바
+   구조: [뒤로가기 네모버튼] [상점명 소제목 + 페이지 제목]
+   (flowN .app-topbar 와 충돌 없는 별도 이름)
+   ======================================================== */
+
+.p-topbar {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 24px var(--pad-side) 16px;
+}
+
+.p-topbar__back {
+    flex-shrink: 0;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--neutral-100);
+    border-radius: var(--btn-radius);
+    color: var(--color-text-body);
+    font-size: 28px;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.p-topbar__back:active {
+    background-color: var(--neutral-200);
+    transform: scale(0.94);
+}
+
+.p-topbar__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.p-topbar__eyebrow {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+}
+
+.p-topbar__title {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+    line-height: 1.1;
+}
+
+/* ========================================================
+   .step-indicator — 3-step 원형 프로그레스
+   구조: <ol> > <li class="step-indicator__item" data-state="done|active|pending">
+   상태: done(체크), active(번호 강조), pending(번호 희미)
+   ======================================================== */
+
+.step-indicator {
+    display: grid;
+    grid-template-columns: repeat(var(--steps, 3), 1fr);
+    align-items: center;
+    padding: 20px var(--pad-side);
+    background-color: var(--neutral-0);
+    border-top: 1px solid var(--color-border-default);
+    border-bottom: 1px solid var(--color-border-default);
+}
+
+.step-indicator__item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.step-indicator__dot {
+    position: relative;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 18px;
+    font-weight: 700;
+    background-color: var(--neutral-100);
+    color: var(--color-text-disabled);
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+}
+
+.step-indicator__item[data-state="done"] .step-indicator__dot,
+.step-indicator__item[data-state="active"] .step-indicator__dot {
+    background-color: var(--primary-500);
+    color: var(--color-text-inverse);
+}
+
+.step-indicator__label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+}
+
+.step-indicator__item[data-state="active"] .step-indicator__label {
+    color: var(--primary-700);
+    font-weight: 700;
+}
+
+.step-indicator__item[data-state="done"] .step-indicator__label {
+    color: var(--color-text-body);
+}
+
+/* 연결선: 아이템 사이의 가로줄 */
+.step-indicator__item + .step-indicator__item::before {
+    content: "";
+    position: absolute;
+    top: 20px;
+    right: calc(50% + 24px);
+    width: calc(100% - 48px);
+    height: 2px;
+    background-color: var(--neutral-200);
+}
+
+.step-indicator__item[data-state="active"]::before,
+.step-indicator__item[data-state="done"]::before {
+    background-color: var(--primary-500);
+}
+
+/* ========================================================
+   .method-card — 결제 수단 선택 카드 (IC카드 / 정맥인증)
+   선택 시 var(--tint, --primary-500) 으로 보더·체크 색 변경
+   ======================================================== */
+
+.method-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 28px 16px 24px;
+    background-color: var(--neutral-0);
+    border: 2px solid transparent;
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.method-card:active {
+    transform: scale(0.98);
+}
+
+.method-card[aria-pressed="true"],
+.method-card.is-selected {
+    border-color: var(--tint, var(--primary-500));
+    box-shadow: 0 8px 24px rgba(232, 96, 10, 0.18);
+    background-color: var(--primary-50);
+}
+
+.method-card__icon {
+    width: 72px;
+    height: 72px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    background-color: var(--neutral-100);
+    color: var(--color-text-secondary);
+    font-size: 36px;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+}
+
+.method-card[aria-pressed="true"] .method-card__icon,
+.method-card.is-selected .method-card__icon {
+    background-color: var(--tint, var(--primary-500));
+    color: var(--color-text-inverse);
+}
+
+.method-card__title {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+
+.method-card__desc {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    text-align: center;
+}
+
+.method-card__check {
+    position: absolute;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--tint, var(--primary-500));
+    color: var(--color-text-inverse);
+    font-size: 14px;
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.method-card[aria-pressed="true"] .method-card__check,
+.method-card.is-selected .method-card__check {
+    opacity: 1;
+}
+
+/* ========================================================
+   .status-screen — 중앙 상태 화면 (성공 · 실패 · 대기)
+   P03 vein(success/fail), P04 processing, P05 complete, P06 fail 에서 공용
+   ======================================================== */
+
+.status-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    padding: 48px 32px;
+    text-align: center;
+}
+
+.status-screen__icon {
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--primary-500);
+    color: var(--color-text-inverse);
+    font-size: 64px;
+    box-shadow: 0 12px 32px rgba(232, 96, 10, 0.28);
+}
+
+.status-screen[data-variant="success"] .status-screen__icon {
+    background-color: var(--semantic-success);
+    box-shadow: 0 12px 32px rgba(22, 163, 74, 0.28);
+}
+
+.status-screen[data-variant="error"] .status-screen__icon {
+    background-color: var(--semantic-error);
+    box-shadow: 0 12px 32px rgba(220, 53, 69, 0.28);
+}
+
+.status-screen[data-variant="warning"] .status-screen__icon {
+    background-color: var(--semantic-warning);
+    box-shadow: 0 12px 32px rgba(245, 158, 11, 0.28);
+}
+
+.status-screen[data-variant="vein"] .status-screen__icon {
+    background-color: var(--secondary-500);
+    box-shadow: 0 12px 32px rgba(212, 179, 10, 0.32);
+}
+
+.status-screen__title {
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+
+.status-screen__subtitle {
+    font-size: 16px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 440px;
+}
+
+.status-screen__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    max-width: 440px;
+    margin-top: 12px;
+}
+

--- a/src/main/resources/static/front/css/flowP/P01-summary.css
+++ b/src/main/resources/static/front/css/flowP/P01-summary.css
@@ -1,0 +1,221 @@
+/* ========================================================
+   P01-summary.css — 주문 요약/확인 (Step 1/3)
+   공통 토큰만 사용 (common.css)
+   공통 컴포넌트: .page-bg / .p-topbar / .step-indicator / .btn-cta
+   ======================================================== */
+
+.p01 {
+    position: relative;
+    padding: 20px var(--pad-side);
+}
+
+/* ---- 주문 내역 카드 ---- */
+
+.p01__card {
+    background-color: var(--color-bg-card);
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+}
+
+.p01__card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 20px 20px 16px;
+    border-bottom: 1px solid var(--color-border-default);
+}
+
+.p01__card-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+
+.p01__card-count {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 10px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--primary-700);
+    background-color: var(--primary-100);
+    border-radius: 999px;
+}
+
+/* ---- 아이템 리스트 ---- */
+
+.p01__items {
+    display: flex;
+    flex-direction: column;
+}
+
+.p01__item {
+    display: grid;
+    grid-template-columns: 64px 1fr auto auto;
+    grid-template-areas: "thumb info qty del";
+    align-items: center;
+    gap: 14px;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--color-border-default);
+}
+
+.p01__item:last-child {
+    border-bottom: none;
+}
+
+.p01__thumb {
+    grid-area: thumb;
+    width: 64px;
+    height: 64px;
+    border-radius: 12px;
+    background-color: var(--neutral-100);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-disabled);
+    font-size: 28px;
+    overflow: hidden;
+}
+
+.p01__thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.p01__info {
+    grid-area: info;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.p01__name {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text-heading);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.p01__price {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-price);
+}
+
+/* ---- 인라인 수량 스테퍼 (이미지 기반 원형 ± + 숫자) ---- */
+
+.p01__qty {
+    grid-area: qty;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.p01__qty-btn {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--neutral-0);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-text-body);
+    font-size: 16px;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.p01__qty-btn:active {
+    background-color: var(--neutral-100);
+    transform: scale(0.92);
+}
+
+.p01__qty-btn:disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.p01__qty-value {
+    min-width: 16px;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+
+/* ---- 삭제 버튼 (연한 빨간 사각) ---- */
+
+.p01__del {
+    grid-area: del;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background-color: var(--semantic-error-bg);
+    color: var(--semantic-error);
+    font-size: 14px;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.p01__del:active {
+    background-color: #FDD4D4;
+    transform: scale(0.92);
+}
+
+/* ---- 합계 ---- */
+
+.p01__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 20px 20px;
+    background-color: var(--neutral-0);
+}
+
+.p01__total-label {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+
+.p01__total-price {
+    font-size: 26px;
+    font-weight: 800;
+    color: var(--color-text-price);
+    letter-spacing: -0.5px;
+}
+
+/* ---- 빈 상태 ---- */
+
+.p01__empty {
+    padding: 48px 20px;
+    text-align: center;
+    color: var(--color-text-secondary);
+    font-size: 15px;
+}
+
+/* ---- 하단 CTA ---- */
+
+.p01__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 16px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+}
+
+.p01__cta {
+    width: 100%;
+}

--- a/src/main/resources/static/front/css/flowP/P02-payment.css
+++ b/src/main/resources/static/front/css/flowP/P02-payment.css
@@ -1,0 +1,141 @@
+/* ========================================================
+   P02-payment.css — 결제 수단 선택 (Step 2/3)
+   공통 토큰만 사용 (common.css)
+   공통 컴포넌트: .page-bg / .p-topbar / .step-indicator
+                 / .method-card / .btn-cta
+   ======================================================== */
+
+.p02 {
+    position: relative;
+    padding: 20px var(--pad-side) 0;
+}
+
+/* ---- 결제 금액 요약 카드 ---- */
+
+.p02__amount-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 22px 24px;
+    background: linear-gradient(135deg,
+        var(--primary-500) 0%,
+        var(--primary-600) 100%);
+    color: var(--color-text-inverse);
+    border-radius: var(--card-radius);
+    box-shadow: 0 12px 32px rgba(232, 96, 10, 0.22);
+}
+
+.p02__amount-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.p02__amount-label {
+    font-size: 14px;
+    font-weight: 600;
+    opacity: 0.92;
+}
+
+.p02__amount-count {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 12px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-text-inverse);
+    background-color: rgba(255, 255, 255, 0.22);
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.p02__amount-price {
+    font-size: 34px;
+    font-weight: 800;
+    letter-spacing: -0.8px;
+    line-height: 1.1;
+}
+
+/* ---- 섹션 헤딩 ---- */
+
+.p02__heading {
+    margin-top: 28px;
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+    letter-spacing: -0.3px;
+}
+
+.p02__subheading {
+    margin-top: 6px;
+    font-size: 13px;
+    color: var(--color-text-secondary);
+}
+
+/* ---- 결제 수단 그리드 ---- */
+
+.p02__methods {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-top: 18px;
+}
+
+.p02__method {
+    min-height: 196px;
+    padding-bottom: 36px;
+}
+
+.p02__method .method-card__desc {
+    line-height: 1.45;
+}
+
+/* ---- 힌트 (정보 안내) ---- */
+
+.p02__hint {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    background-color: var(--neutral-100);
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    line-height: 1.4;
+    transition: background-color var(--duration-base) var(--ease-out),
+                color var(--duration-base) var(--ease-out);
+}
+
+.p02__hint i {
+    font-size: 16px;
+    color: var(--color-text-tertiary);
+    flex-shrink: 0;
+}
+
+.p02__hint--selected {
+    background-color: var(--primary-50);
+    color: var(--primary-700);
+}
+
+.p02__hint--selected i {
+    color: var(--primary-500);
+}
+
+/* ---- 하단 CTA ---- */
+
+.p02__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 16px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+}
+
+.p02__cta {
+    width: 100%;
+}

--- a/src/main/resources/static/front/css/flowP/P02-payment.css
+++ b/src/main/resources/static/front/css/flowP/P02-payment.css
@@ -91,6 +91,22 @@
     line-height: 1.45;
 }
 
+/* ---- 정맥 커스텀 SVG 아이콘 ----
+   .method-card__icon 는 기본 font-size 36px(아이콘폰트 기준) 이라,
+   SVG 는 자체 width/height 로 제어.
+   stroke="currentColor" 로 선택 전/후 color 토큰을 자동 상속. */
+.p02__method-icon--vein svg {
+    display: block;
+    width: 40px;
+    height: 40px;
+    transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.p02__method[aria-pressed="true"] .p02__method-icon--vein svg,
+.p02__method.is-selected .p02__method-icon--vein svg {
+    transform: scale(1.04);
+}
+
 /* ---- 힌트 (정보 안내) ---- */
 
 .p02__hint {

--- a/src/main/resources/static/front/css/flowP/P03-vein.css
+++ b/src/main/resources/static/front/css/flowP/P03-vein.css
@@ -1,0 +1,320 @@
+/* ========================================================
+   P03-vein.css — 정맥 인증 (Step 3/3 · 4상태 전환)
+   states: prepare / scanning / success / fail
+   상태는 section.p03 의 [data-state="…"] 로 전환
+   ======================================================== */
+
+.p03 {
+    position: relative;
+    padding: 24px var(--pad-side) 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+}
+
+/* ===========================
+   1) 스캐너 비주얼 (공통)
+   =========================== */
+.p03__scanner {
+    position: relative;
+    width: 320px;
+    height: 320px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* ---- 원형 프레임 ---- */
+.p03__frame {
+    position: relative;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 50%,
+        var(--primary-50) 0%,
+        var(--neutral-0) 70%);
+    border: 3px solid var(--primary-200);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 12px 40px rgba(232, 96, 10, 0.14);
+    overflow: hidden;
+    transition: border-color var(--duration-base) var(--ease-out),
+                box-shadow var(--duration-base) var(--ease-out),
+                background var(--duration-base) var(--ease-out);
+}
+
+/* ---- 손바닥 SVG ---- */
+.p03__palm {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 180px;
+    height: 180px;
+    color: var(--primary-500);
+    transition: color var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-out);
+}
+
+.p03__vein {
+    opacity: 0.5;
+    transition: opacity var(--duration-base) var(--ease-out);
+}
+
+/* ---- 스캔 라인 (scanning 상태에서만 노출) ---- */
+.p03__scanline {
+    position: absolute;
+    left: 8%;
+    right: 8%;
+    top: 0;
+    height: 3px;
+    border-radius: 2px;
+    background: linear-gradient(90deg,
+        transparent 0%,
+        var(--primary-500) 50%,
+        transparent 100%);
+    box-shadow: 0 0 20px 4px rgba(232, 96, 10, 0.55),
+                0 0 40px 8px rgba(232, 96, 10, 0.25);
+    opacity: 0;
+    transform: translateY(0);
+    pointer-events: none;
+}
+
+/* ---- 펄스 링 (prepare/scanning 에서만) ---- */
+.p03__pulse {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    border: 2px solid var(--primary-400);
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* ---- 상태 오버레이 아이콘 (success/fail) ---- */
+.p03__status-icon {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 72px;
+    font-weight: 700;
+    color: var(--color-text-inverse);
+    opacity: 0;
+    transform: scale(0.6);
+    transition: opacity var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-bounce);
+    pointer-events: none;
+}
+
+.p03__status-icon--success { background-color: var(--semantic-success, #1F9254); }
+.p03__status-icon--fail    { background-color: var(--semantic-error,   #E02D3C); }
+
+/* ===========================
+   2) 상태 텍스트
+   =========================== */
+.p03__text {
+    text-align: center;
+    padding: 0 12px;
+    max-width: 520px;
+}
+
+.p03__title {
+    font-size: 26px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    letter-spacing: -0.6px;
+    line-height: 1.25;
+    transition: color var(--duration-base) var(--ease-out);
+}
+
+.p03__desc {
+    margin-top: 10px;
+    font-size: 15px;
+    color: var(--color-text-secondary);
+    line-height: 1.55;
+}
+
+/* ---- 진행 바 (scanning 에서만) ---- */
+.p03__progress {
+    margin-top: 20px;
+    height: 6px;
+    border-radius: 999px;
+    background-color: var(--neutral-200);
+    overflow: hidden;
+    opacity: 0;
+    transition: opacity var(--duration-base) var(--ease-out);
+}
+
+.p03__progress-bar {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--primary-400), var(--primary-600));
+    border-radius: inherit;
+    transition: width 120ms linear;
+}
+
+/* ===========================
+   3) 하단 CTA
+   =========================== */
+.p03__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 16px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+}
+
+.p03__cta {
+    width: 100%;
+}
+
+.p03__cta-row {
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 10px;
+}
+
+.p03__cta-ghost,
+.p03__cta-primary {
+    width: 100%;
+}
+
+.p03__cta--success-hint {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    padding: 16px 0;
+}
+
+/* ===========================
+   4) 상태별 분기 (CSS 기반)
+   =========================== */
+
+/* --- 공통: 기본적으로 상태 오버레이/스캔라인 숨김, fail CTA/success hint 도 숨김 --- */
+.p03__cta--fail-actions       { display: none; }
+.p03__cta--success-hint       { display: none; }
+
+/* ---- prepare ---- */
+.p03[data-state="prepare"] .p03__pulse { animation: p03-pulse 2.2s var(--ease-out) infinite; }
+.p03[data-state="prepare"] .p03__pulse--2 { animation-delay: 0.7s; }
+.p03[data-state="prepare"] .p03__pulse--3 { animation-delay: 1.4s; }
+
+/* ---- scanning ---- */
+.p03[data-state="scanning"] .p03__frame {
+    border-color: var(--primary-500);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 0 0 4px rgba(232, 96, 10, 0.15),
+                0 12px 40px rgba(232, 96, 10, 0.28);
+}
+.p03[data-state="scanning"] .p03__scanline {
+    opacity: 1;
+    animation: p03-scanline 1.8s ease-in-out infinite;
+}
+.p03[data-state="scanning"] .p03__vein {
+    animation: p03-vein-pulse 1.2s ease-in-out infinite alternate;
+}
+.p03[data-state="scanning"] .p03__vein--2 { animation-delay: 0.18s; }
+.p03[data-state="scanning"] .p03__vein--3 { animation-delay: 0.36s; }
+.p03[data-state="scanning"] .p03__pulse { animation: p03-pulse 1.6s var(--ease-out) infinite; }
+.p03[data-state="scanning"] .p03__pulse--2 { animation-delay: 0.55s; }
+.p03[data-state="scanning"] .p03__pulse--3 { animation-delay: 1.1s; }
+.p03[data-state="scanning"] .p03__progress { opacity: 1; }
+
+/* ---- success ---- */
+.p03[data-state="success"] .p03__frame {
+    border-color: var(--semantic-success, #1F9254);
+    background: radial-gradient(circle at 50% 50%,
+        rgba(31, 146, 84, 0.1) 0%,
+        var(--neutral-0) 70%);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 12px 40px rgba(31, 146, 84, 0.25);
+}
+.p03[data-state="success"] .p03__palm {
+    color: var(--semantic-success, #1F9254);
+    transform: scale(0.94);
+    opacity: 0.25;
+}
+.p03[data-state="success"] .p03__status-icon--success {
+    opacity: 1;
+    transform: scale(1);
+}
+.p03[data-state="success"] .p03__title { color: var(--semantic-success, #1F9254); }
+.p03[data-state="success"] .p03__cta--cancel       { display: none; }
+.p03[data-state="success"] .p03__cta--fail-actions { display: none; }
+.p03[data-state="success"] .p03__cta--success-hint { display: block; }
+
+/* ---- fail ---- */
+.p03[data-state="fail"] .p03__frame {
+    border-color: var(--semantic-error, #E02D3C);
+    background: radial-gradient(circle at 50% 50%,
+        rgba(224, 45, 60, 0.08) 0%,
+        var(--neutral-0) 70%);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 12px 40px rgba(224, 45, 60, 0.22);
+    animation: p03-shake 0.4s var(--ease-out) 1;
+}
+.p03[data-state="fail"] .p03__palm {
+    color: var(--semantic-error, #E02D3C);
+    transform: scale(0.94);
+    opacity: 0.22;
+}
+.p03[data-state="fail"] .p03__status-icon--fail {
+    opacity: 1;
+    transform: scale(1);
+}
+.p03[data-state="fail"] .p03__title { color: var(--semantic-error, #E02D3C); }
+.p03[data-state="fail"] .p03__cta--cancel       { display: none; }
+.p03[data-state="fail"] .p03__cta--fail-actions { display: grid; }
+.p03[data-state="fail"] .p03__cta--success-hint { display: none; }
+
+/* ===========================
+   5) 애니메이션 keyframes
+   =========================== */
+@keyframes p03-pulse {
+    0%   { opacity: 0.8; transform: scale(0.95); }
+    70%  { opacity: 0;   transform: scale(1.25); }
+    100% { opacity: 0;   transform: scale(1.3);  }
+}
+
+@keyframes p03-scanline {
+    0%   { transform: translateY(0%);    opacity: 0;   }
+    10%  { opacity: 1; }
+    50%  { transform: translateY(278px); opacity: 1;   }
+    60%  { opacity: 1; }
+    100% { transform: translateY(0%);    opacity: 0.9; }
+}
+
+@keyframes p03-vein-pulse {
+    from { opacity: 0.3; }
+    to   { opacity: 1;   }
+}
+
+@keyframes p03-shake {
+    0%, 100% { transform: translateX(0); }
+    20%      { transform: translateX(-8px); }
+    40%      { transform: translateX(8px); }
+    60%      { transform: translateX(-5px); }
+    80%      { transform: translateX(5px); }
+}
+
+/* 접근성: 모션 감소 선호 시 애니메이션 최소화 */
+@media (prefers-reduced-motion: reduce) {
+    .p03__pulse,
+    .p03__scanline,
+    .p03__vein,
+    .p03[data-state="fail"] .p03__frame {
+        animation: none !important;
+    }
+    .p03__scanline { opacity: 1 !important; }
+}

--- a/src/main/resources/static/front/css/flowP/P04-processing.css
+++ b/src/main/resources/static/front/css/flowP/P04-processing.css
@@ -1,0 +1,398 @@
+/* ========================================================
+   P04-processing.css — 카드 결제 처리 (Step 3/3 · 3상태)
+   states: inserting / processing / approved
+   실패 → /flowP/P06-fail.html (페이지 이동)
+   ======================================================== */
+
+.p04 {
+    position: relative;
+    padding: 16px var(--pad-side) 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+}
+
+/* ===========================
+   1) 결제 금액 요약
+   =========================== */
+.p04__amount {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 18px;
+    background-color: var(--neutral-0);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+}
+
+.p04__amount-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+}
+
+.p04__amount-price {
+    font-size: 22px;
+    font-weight: 800;
+    color: var(--color-text-price);
+    letter-spacing: -0.4px;
+}
+
+/* ===========================
+   2) 카드 슬롯 비주얼
+   =========================== */
+.p04__visual {
+    position: relative;
+    width: 320px;
+    height: 360px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    margin-top: 6px;
+}
+
+/* ---- 유도 화살표 (inserting 상태만) ---- */
+.p04__arrows {
+    position: absolute;
+    top: 12px;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    color: var(--primary-500);
+    font-size: 32px;
+    line-height: 0.8;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-base) var(--ease-out);
+}
+.p04__arrows i:nth-child(1) { animation: p04-arrow-bob 1.2s ease-in-out infinite; }
+.p04__arrows i:nth-child(2) { animation: p04-arrow-bob 1.2s ease-in-out 0.2s infinite; }
+
+/* ---- 카드 ---- */
+.p04__card {
+    position: absolute;
+    left: 50%;
+    top: 68px;
+    width: 220px;
+    height: 138px;
+    transform: translateX(-50%);
+    border-radius: 14px;
+    background: linear-gradient(135deg, #2D2A27 0%, #4A4540 50%, #2D2A27 100%);
+    color: var(--color-text-inverse);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.28),
+                inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    transition: transform var(--duration-slow) var(--ease-out),
+                top var(--duration-slow) var(--ease-out),
+                opacity var(--duration-base) var(--ease-out);
+    z-index: 2;
+}
+
+/* 카드 광택 라인 */
+.p04__card::before {
+    content: '';
+    position: absolute;
+    top: -40%;
+    left: -20%;
+    width: 60%;
+    height: 180%;
+    background: linear-gradient(105deg,
+        transparent 0%,
+        rgba(255, 255, 255, 0.08) 45%,
+        rgba(255, 255, 255, 0.2)  50%,
+        rgba(255, 255, 255, 0.08) 55%,
+        transparent 100%);
+    transform: rotate(18deg);
+    pointer-events: none;
+}
+
+.p04__card-chip {
+    position: absolute;
+    top: 18px;
+    left: 20px;
+    width: 44px;
+    height: 34px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows:    repeat(2, 1fr);
+    gap: 2px;
+    padding: 4px;
+    background: linear-gradient(135deg, #E5B94B 0%, #C79B2B 50%, #8F6E17 100%);
+    border-radius: 5px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+.p04__card-chip span {
+    background-color: rgba(0, 0, 0, 0.18);
+    border-radius: 1px;
+}
+
+.p04__card-stripe {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 20px;
+    height: 10px;
+    background: repeating-linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.08) 0 3px,
+        rgba(255, 255, 255, 0.16) 3px 4px
+    );
+}
+
+.p04__card-brand {
+    position: absolute;
+    right: 16px;
+    bottom: 38px;
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 1.5px;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+/* ---- 슬롯 ---- */
+.p04__slot {
+    position: relative;
+    width: 280px;
+    height: 160px;
+    border-radius: 18px;
+    background: linear-gradient(180deg, var(--neutral-100) 0%, var(--neutral-200) 100%);
+    border: 2px solid var(--color-border-default);
+    box-shadow: 0 4px 0 var(--neutral-300, #CFC8C2),
+                0 16px 32px rgba(0, 0, 0, 0.08);
+    z-index: 1;
+    transition: border-color var(--duration-base) var(--ease-out),
+                background var(--duration-base) var(--ease-out),
+                box-shadow var(--duration-base) var(--ease-out);
+}
+
+/* 슬롯 입구 (어두운 가로 띠) */
+.p04__slot-mouth {
+    position: absolute;
+    top: 22px;
+    left: 16px;
+    right: 16px;
+    height: 14px;
+    border-radius: 4px;
+    background: linear-gradient(180deg, #1C1917 0%, #2D2A27 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.8),
+                inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.p04__slot-label {
+    position: absolute;
+    bottom: 14px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: var(--color-text-secondary);
+    opacity: 0.7;
+}
+
+/* ---- 스피너 (processing 에서만) ---- */
+.p04__spinner {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 44px;
+    height: 44px;
+    opacity: 0;
+    pointer-events: none;
+}
+.p04__spinner i {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 4px solid rgba(232, 96, 10, 0.2);
+    border-top-color: var(--primary-500);
+    animation: p04-spin 0.9s linear infinite;
+}
+
+/* ---- 성공 체크 (approved) ---- */
+.p04__check {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 92px;
+    height: 92px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--semantic-success, #16A34A);
+    color: var(--color-text-inverse);
+    font-size: 54px;
+    font-weight: 800;
+    opacity: 0;
+    transform: scale(0.6);
+    transition: opacity var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-bounce);
+    pointer-events: none;
+}
+
+/* ===========================
+   3) 상태 텍스트
+   =========================== */
+.p04__text {
+    text-align: center;
+    padding: 0 12px;
+    max-width: 520px;
+}
+
+.p04__title {
+    font-size: 24px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    letter-spacing: -0.5px;
+    line-height: 1.3;
+    transition: color var(--duration-base) var(--ease-out);
+}
+
+.p04__desc {
+    margin-top: 8px;
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.p04__progress {
+    margin-top: 16px;
+    height: 6px;
+    border-radius: 999px;
+    background-color: var(--neutral-200);
+    overflow: hidden;
+    opacity: 0;
+    transition: opacity var(--duration-base) var(--ease-out);
+}
+.p04__progress-bar {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--primary-400), var(--primary-600));
+    border-radius: inherit;
+    transition: width 120ms linear;
+}
+
+/* ===========================
+   4) 하단 CTA
+   =========================== */
+.p04__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 16px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+}
+
+.p04__cta { width: 100%; }
+
+.p04__cta--processing-hint,
+.p04__cta--approved-hint {
+    display: none;
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    padding: 12px 0;
+}
+
+.p04__cta--processing-hint {
+    color: var(--primary-700);
+    font-weight: 600;
+}
+.p04__cta--processing-hint i {
+    margin-right: 6px;
+    color: var(--primary-500);
+}
+
+/* ===========================
+   5) 상태별 분기
+   =========================== */
+
+/* ---- inserting ---- */
+.p04[data-state="inserting"] .p04__arrows { opacity: 1; }
+.p04[data-state="inserting"] .p04__card {
+    animation: p04-card-bob 1.4s ease-in-out infinite;
+}
+
+/* ---- processing ---- */
+.p04[data-state="processing"] .p04__card {
+    top: 128px;              /* 슬롯 쪽으로 내려와 절반 삽입된 듯 */
+    transform: translateX(-50%) scale(0.96);
+    opacity: 0.55;
+    animation: none;
+}
+.p04[data-state="processing"] .p04__slot {
+    border-color: var(--primary-500);
+    background: linear-gradient(180deg, var(--primary-50) 0%, var(--neutral-100) 100%);
+    box-shadow: 0 4px 0 var(--primary-200),
+                0 16px 32px rgba(232, 96, 10, 0.18);
+}
+.p04[data-state="processing"] .p04__spinner { opacity: 1; }
+.p04[data-state="processing"] .p04__progress { opacity: 1; }
+.p04[data-state="processing"] .p04__cta--cancel { display: none; }
+.p04[data-state="processing"] .p04__cta--processing-hint { display: block; }
+
+/* ---- approved ---- */
+.p04[data-state="approved"] .p04__card {
+    top: 168px;              /* 완전 삽입 */
+    transform: translateX(-50%) scale(0.9);
+    opacity: 0.15;
+    animation: none;
+}
+.p04[data-state="approved"] .p04__slot {
+    border-color: var(--semantic-success, #16A34A);
+    background: linear-gradient(180deg,
+        var(--semantic-success-bg, #F0FDF4) 0%,
+        var(--neutral-100) 100%);
+    box-shadow: 0 4px 0 #BBF7D0,
+                0 16px 32px rgba(22, 163, 74, 0.22);
+}
+.p04[data-state="approved"] .p04__check {
+    opacity: 1;
+    transform: scale(1);
+}
+.p04[data-state="approved"] .p04__spinner { opacity: 0; }
+.p04[data-state="approved"] .p04__title {
+    color: var(--semantic-success, #16A34A);
+}
+.p04[data-state="approved"] .p04__cta--cancel { display: none; }
+.p04[data-state="approved"] .p04__cta--approved-hint { display: block; }
+
+/* ===========================
+   6) keyframes
+   =========================== */
+@keyframes p04-card-bob {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50%      { transform: translateX(-50%) translateY(-10px); }
+}
+
+@keyframes p04-arrow-bob {
+    0%, 100% { transform: translateY(0);    opacity: 0.35; }
+    50%      { transform: translateY(6px);  opacity: 1; }
+}
+
+@keyframes p04-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* 접근성 */
+@media (prefers-reduced-motion: reduce) {
+    .p04__card,
+    .p04__arrows i,
+    .p04__spinner i {
+        animation: none !important;
+    }
+}

--- a/src/main/resources/static/front/css/flowP/P05-complete.css
+++ b/src/main/resources/static/front/css/flowP/P05-complete.css
@@ -1,0 +1,341 @@
+/* ========================================================
+   P05-complete.css — 주문 완료 (결제 성공 후 대기번호 화면)
+   공통 토큰 + .p-topbar / .step-indicator / .btn-cta 재사용
+   ======================================================== */
+
+/* ===========================
+   상단바 (완료 단계 전용: 뒤로가기 대신 X)
+   =========================== */
+.p05__topbar {
+    justify-content: space-between;
+}
+.p05__topbar-spacer {
+    width: 44px;
+    height: 44px;
+}
+.p05__topbar-close {
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--neutral-100);
+    color: var(--color-text-heading);
+    font-size: 18px;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+.p05__topbar-close:active {
+    background-color: var(--neutral-200);
+    transform: scale(0.95);
+}
+
+/* ===========================
+   본문
+   =========================== */
+.p05 {
+    position: relative;
+    padding: 8px var(--pad-side) 0;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
+}
+
+/* ===========================
+   성공 hero (체크 + 링 + 컨페티)
+   =========================== */
+.p05__hero {
+    position: relative;
+    width: 100%;
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.p05__hero-ring {
+    position: absolute;
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    border: 2px solid var(--semantic-success, #16A34A);
+    opacity: 0.18;
+    animation: p05-ring-pulse 2s var(--ease-out) infinite;
+}
+
+.p05__hero-circle {
+    position: relative;
+    width: 130px;
+    height: 130px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: linear-gradient(135deg,
+        var(--semantic-success, #16A34A) 0%,
+        #0F8A45 100%);
+    color: var(--color-text-inverse);
+    font-size: 78px;
+    font-weight: 800;
+    box-shadow: 0 16px 40px rgba(22, 163, 74, 0.35);
+    animation: p05-check-pop 0.6s var(--ease-bounce) 1;
+}
+
+/* ---- 컨페티 닷 ---- */
+.p05__confetti {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    opacity: 0;
+    animation: p05-confetti 1.4s var(--ease-out) 0.2s forwards;
+}
+.p05__confetti--1 { top: 20%;  left: 26%;  background: var(--primary-500); animation-delay: 0.20s; }
+.p05__confetti--2 { top: 12%;  left: 58%;  background: var(--semantic-success, #16A34A); animation-delay: 0.30s; }
+.p05__confetti--3 { top: 30%;  left: 78%;  background: var(--primary-400); animation-delay: 0.40s; width: 8px; height: 8px; border-radius: 50%; }
+.p05__confetti--4 { top: 68%;  left: 18%;  background: #FFC048;                             animation-delay: 0.25s; width: 6px; height: 6px; border-radius: 50%; }
+.p05__confetti--5 { top: 74%;  left: 70%;  background: var(--primary-600);                  animation-delay: 0.45s; width: 12px; height: 12px; }
+.p05__confetti--6 { top: 56%;  left: 86%;  background: var(--semantic-success, #16A34A);    animation-delay: 0.55s; width: 8px; height: 8px; border-radius: 50%; }
+
+/* ===========================
+   대기번호 카드
+   =========================== */
+.p05__order-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 22px 20px 20px;
+    background: linear-gradient(180deg, var(--primary-50) 0%, var(--neutral-0) 100%);
+    border: 2px solid var(--primary-200);
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+}
+
+.p05__order-label {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--primary-700);
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+}
+
+.p05__order-number {
+    font-size: 72px;
+    font-weight: 800;
+    color: var(--primary-600);
+    letter-spacing: -2px;
+    line-height: 1.05;
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 2px 0 rgba(232, 96, 10, 0.08);
+}
+
+.p05__order-store {
+    margin-top: 4px;
+    padding: 4px 12px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--color-text-inverse);
+    background-color: var(--primary-500);
+    border-radius: 999px;
+}
+
+.p05__order-hint {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    line-height: 1.4;
+}
+
+/* ===========================
+   주문 요약 카드
+   =========================== */
+.p05__summary {
+    padding: 14px 18px;
+    background-color: var(--color-bg-card);
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border-default);
+}
+
+.p05__summary-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 0;
+    border-bottom: 1px dashed var(--color-border-default);
+}
+.p05__summary-row:last-child {
+    border-bottom: none;
+}
+
+.p05__summary-key {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+}
+
+.p05__summary-val {
+    font-size: 14px;
+    color: var(--color-text-heading);
+    font-weight: 600;
+    text-align: right;
+    max-width: 60%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.p05__summary-row--total {
+    padding-top: 14px;
+    margin-top: 4px;
+    border-top: 1px solid var(--color-border-default);
+    border-bottom: none;
+}
+.p05__summary-row--total .p05__summary-key {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+}
+.p05__summary-val--price {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--color-text-price);
+    letter-spacing: -0.3px;
+}
+
+/* ===========================
+   영수증 출력 안내
+   =========================== */
+.p05__receipt {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background-color: var(--primary-50);
+    border-radius: 12px;
+    border: 1px dashed var(--primary-200);
+}
+.p05__receipt > i {
+    font-size: 22px;
+    color: var(--primary-600);
+    flex-shrink: 0;
+    animation: p05-print-wiggle 1.2s ease-in-out infinite;
+}
+.p05__receipt-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+}
+.p05__receipt-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--primary-700);
+}
+.p05__receipt-progress {
+    display: block;
+    height: 4px;
+    border-radius: 999px;
+    background-color: var(--primary-100);
+    overflow: hidden;
+}
+.p05__receipt-progress-bar {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--primary-400), var(--primary-600));
+    border-radius: inherit;
+    animation: p05-receipt-fill 3s ease-out forwards;
+}
+.p05__receipt--done > i { animation: none; }
+.p05__receipt--done .p05__receipt-title::after {
+    content: ' · 완료';
+    color: var(--semantic-success, #16A34A);
+}
+
+/* ===========================
+   하단 CTA
+   =========================== */
+.p05__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 12px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+}
+
+.p05__autoreset {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    padding: 8px 0 12px;
+}
+.p05__autoreset span {
+    font-weight: 700;
+    color: var(--primary-600);
+    font-variant-numeric: tabular-nums;
+}
+
+.p05__cta {
+    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+.p05__cta i {
+    font-size: 18px;
+}
+
+/* ===========================
+   keyframes
+   =========================== */
+@keyframes p05-ring-pulse {
+    0%   { transform: scale(0.85); opacity: 0.28; }
+    70%  { transform: scale(1.25); opacity: 0;    }
+    100% { transform: scale(1.3);  opacity: 0;    }
+}
+
+@keyframes p05-check-pop {
+    0%   { transform: scale(0.2);  opacity: 0; }
+    60%  { transform: scale(1.12); opacity: 1; }
+    100% { transform: scale(1);    opacity: 1; }
+}
+
+@keyframes p05-confetti {
+    0%   { transform: translateY(8px)  scale(0.2) rotate(0deg);    opacity: 0;   }
+    40%  { opacity: 1; }
+    100% { transform: translateY(-40px) scale(1)   rotate(240deg);  opacity: 0;   }
+}
+
+@keyframes p05-print-wiggle {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(-2px); }
+}
+
+@keyframes p05-receipt-fill {
+    from { width: 0%;  }
+    to   { width: 100%; }
+}
+
+/* 접근성 */
+@media (prefers-reduced-motion: reduce) {
+    .p05__hero-ring,
+    .p05__hero-circle,
+    .p05__confetti,
+    .p05__receipt > i,
+    .p05__receipt-progress-bar {
+        animation: none !important;
+    }
+    .p05__confetti { opacity: 0; }
+    .p05__receipt-progress-bar { width: 100%; }
+}

--- a/src/main/resources/static/front/css/flowP/P06-fail.css
+++ b/src/main/resources/static/front/css/flowP/P06-fail.css
@@ -1,0 +1,252 @@
+/* ========================================================
+   P06-fail.css — 결제 실패 (5가지 사유별 분기)
+   reasons: timeout / card_error / declined
+            / vein_timeout / vein_unregistered
+   ======================================================== */
+
+/* ===========================
+   step-indicator 의 error 변형
+   =========================== */
+.p06__step-error .step-indicator__dot {
+    background-color: var(--semantic-error, #DC3545) !important;
+    color: var(--color-text-inverse) !important;
+    border-color: var(--semantic-error, #DC3545) !important;
+}
+.p06__step-error .step-indicator__label {
+    color: var(--semantic-error, #DC3545) !important;
+}
+
+/* ===========================
+   본문
+   =========================== */
+.p06 {
+    position: relative;
+    padding: 8px var(--pad-side) 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+/* ===========================
+   경고 hero
+   =========================== */
+.p06__hero {
+    position: relative;
+    height: 170px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.p06__hero-ring {
+    position: absolute;
+    width: 170px;
+    height: 170px;
+    border-radius: 50%;
+    border: 2px solid var(--semantic-error, #DC3545);
+    opacity: 0.22;
+    animation: p06-ring-pulse 2s var(--ease-out) infinite;
+}
+.p06__hero-circle {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: linear-gradient(135deg,
+        var(--semantic-error, #DC3545) 0%,
+        #B32535 100%);
+    color: var(--color-text-inverse);
+    font-size: 68px;
+    font-weight: 800;
+    box-shadow: 0 16px 36px rgba(220, 53, 69, 0.38);
+    animation: p06-x-pop 0.5s var(--ease-bounce) 1,
+               p06-shake 0.5s var(--ease-out) 0.5s 1;
+}
+
+/* ===========================
+   사유 카드
+   =========================== */
+.p06__reason-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 20px 22px;
+    background: linear-gradient(180deg, var(--semantic-error-bg, #FEF2F2) 0%, var(--neutral-0) 100%);
+    border: 1px solid var(--semantic-error, #DC3545);
+    border-radius: var(--card-radius);
+    box-shadow: var(--shadow-sm);
+    text-align: center;
+}
+
+.p06__reason-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--color-text-inverse);
+    background-color: var(--semantic-error, #DC3545);
+    border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+}
+
+.p06__reason-title {
+    font-size: 22px;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    letter-spacing: -0.4px;
+    line-height: 1.3;
+}
+
+.p06__reason-desc {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    line-height: 1.55;
+    max-width: 440px;
+}
+
+/* ===========================
+   도움말 섹션
+   =========================== */
+.p06__help {
+    padding: 14px 18px;
+    background-color: var(--color-bg-card);
+    border-radius: var(--card-radius);
+    border: 1px solid var(--color-border-default);
+}
+
+.p06__help-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--color-text-heading);
+    margin-bottom: 10px;
+}
+.p06__help-title i {
+    font-size: 15px;
+    color: var(--primary-500);
+}
+
+.p06__help-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-left: 2px;
+}
+.p06__help-list li {
+    position: relative;
+    padding-left: 18px;
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+.p06__help-list li::before {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--primary-400);
+}
+
+/* ===========================
+   결제 금액 참고
+   =========================== */
+.p06__amount {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    background-color: var(--neutral-100);
+    border-radius: 12px;
+}
+.p06__amount-key {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    font-weight: 600;
+}
+.p06__amount-val {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--color-text-price);
+}
+
+/* ===========================
+   하단 CTA
+   =========================== */
+.p06__cta-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 12px var(--pad-side) var(--pad-footer);
+    background: linear-gradient(to top,
+        var(--color-bg-page) 72%,
+        rgba(250, 248, 246, 0) 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.p06__cta-row {
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 10px;
+}
+.p06__cta-row--single {
+    grid-template-columns: 1fr;
+}
+.p06__cta-ghost,
+.p06__cta-primary { width: 100%; }
+
+.p06__home-link {
+    align-self: center;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    background: transparent;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: color var(--duration-fast) var(--ease-out);
+}
+.p06__home-link:active {
+    color: var(--color-text-heading);
+}
+
+/* ===========================
+   keyframes
+   =========================== */
+@keyframes p06-ring-pulse {
+    0%   { transform: scale(0.85); opacity: 0.3; }
+    70%  { transform: scale(1.25); opacity: 0; }
+    100% { transform: scale(1.3);  opacity: 0; }
+}
+@keyframes p06-x-pop {
+    0%   { transform: scale(0.2);  opacity: 0; }
+    60%  { transform: scale(1.12); opacity: 1; }
+    100% { transform: scale(1);    opacity: 1; }
+}
+@keyframes p06-shake {
+    0%, 100% { transform: translateX(0); }
+    25%      { transform: translateX(-6px); }
+    50%      { transform: translateX(6px); }
+    75%      { transform: translateX(-3px); }
+}
+
+/* 접근성 */
+@media (prefers-reduced-motion: reduce) {
+    .p06__hero-ring,
+    .p06__hero-circle {
+        animation: none !important;
+    }
+}

--- a/src/main/resources/static/front/js/flowP/P01-summary.js
+++ b/src/main/resources/static/front/js/flowP/P01-summary.js
@@ -1,0 +1,156 @@
+/* ========================================================
+   P01-summary.js — 주문 요약/확인 (Step 1/3)
+   - sessionStorage.cart 를 읽어 리스트·합계 렌더
+   - 수량 ± / 삭제 / 주문 확인 완료 → P02
+   - cart 가 비어있으면 데모 mock 데이터로 렌더 (디자인 확인 편의)
+   - cart 아이템 형식: { id, name, price, qty, storeName?, imageUrl? }
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    /* ---------- Session helpers ---------- */
+    const SESSION_KEY = 'cart';
+    const STORE_KEY   = 'currentStoreName';
+
+    const MOCK_CART = [
+        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
+    ];
+
+    function loadCart() {
+        try {
+            const raw = sessionStorage.getItem(SESSION_KEY);
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : null;
+        } catch (_) { return null; }
+    }
+    function saveCart(cart) {
+        try { sessionStorage.setItem(SESSION_KEY, JSON.stringify(cart)); } catch (_) {}
+    }
+
+    /* ---------- Formatters ---------- */
+    const nf = new Intl.NumberFormat('ko-KR');
+    const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
+
+    /* ---------- DOM refs ---------- */
+    const $ = (sel, root = document) => root.querySelector(sel);
+    const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+    const listEl   = $('[data-bind="items"]');
+    const countEl  = $('[data-bind="count"]');
+    const totalEl  = $('[data-bind="total"]');
+    const storeEl  = $('[data-bind="storeName"]');
+    const ctaEl    = $('[data-action="next"]');
+    const backEl   = $('[data-action="back"]');
+    const itemTpl  = $('#tpl-p01-item');
+
+    /* ---------- State ---------- */
+    let cart = loadCart();
+    if (!cart || cart.length === 0) {
+        cart = MOCK_CART.slice();
+    }
+
+    /* ---------- Render ---------- */
+    function renderStoreName() {
+        const storeName =
+            (sessionStorage.getItem(STORE_KEY)) ||
+            (cart[0] && cart[0].storeName) ||
+            '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+    }
+
+    function renderList() {
+        listEl.innerHTML = '';
+
+        if (cart.length === 0) {
+            const empty = document.createElement('li');
+            empty.className = 'p01__empty';
+            empty.textContent = '장바구니가 비어있어요';
+            listEl.appendChild(empty);
+            return;
+        }
+
+        cart.forEach((item, idx) => {
+            const node = itemTpl.content.firstElementChild.cloneNode(true);
+            node.dataset.index = String(idx);
+
+            $('[data-name]', node).textContent  = item.name || '';
+            $('[data-price]', node).textContent = fmtWon(item.price);
+            $('[data-qty-value]', node).textContent = String(item.qty || 1);
+
+            if (item.imageUrl) {
+                const thumb = $('[data-thumb]', node);
+                thumb.innerHTML = '';
+                const img = document.createElement('img');
+                img.src = item.imageUrl;
+                img.alt = item.name || '';
+                thumb.appendChild(img);
+            }
+
+            const decBtn = $('[data-qty-dec]', node);
+            if ((item.qty || 1) <= 1) decBtn.disabled = true;
+
+            listEl.appendChild(node);
+        });
+    }
+
+    function renderSummary() {
+        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
+        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+
+        countEl.textContent = totalQty + '개';
+        totalEl.textContent = fmtWon(totalPrice);
+
+        ctaEl.disabled = totalQty === 0;
+    }
+
+    function renderAll() {
+        renderStoreName();
+        renderList();
+        renderSummary();
+    }
+
+    /* ---------- Events ---------- */
+    listEl.addEventListener('click', (e) => {
+        const itemEl = e.target.closest('[data-item]');
+        if (!itemEl) return;
+        const idx = Number(itemEl.dataset.index);
+        if (Number.isNaN(idx) || !cart[idx]) return;
+
+        if (e.target.closest('[data-qty-inc]')) {
+            cart[idx].qty = (cart[idx].qty || 1) + 1;
+            saveCart(cart);
+            renderAll();
+            return;
+        }
+        if (e.target.closest('[data-qty-dec]')) {
+            const nextQty = (cart[idx].qty || 1) - 1;
+            if (nextQty < 1) return;
+            cart[idx].qty = nextQty;
+            saveCart(cart);
+            renderAll();
+            return;
+        }
+        if (e.target.closest('[data-del]')) {
+            cart.splice(idx, 1);
+            saveCart(cart);
+            renderAll();
+            return;
+        }
+    });
+
+    backEl.addEventListener('click', () => {
+        if (history.length > 1) history.back();
+        else location.href = '/flowN/N02-menu.html';
+    });
+
+    ctaEl.addEventListener('click', () => {
+        if (cart.length === 0) return;
+        saveCart(cart);
+        location.href = '/flowP/P02-payment.html';
+    });
+
+    /* ---------- Init ---------- */
+    renderAll();
+})();

--- a/src/main/resources/static/front/js/flowP/P02-payment.js
+++ b/src/main/resources/static/front/js/flowP/P02-payment.js
@@ -1,0 +1,142 @@
+/* ========================================================
+   P02-payment.js — 결제 수단 선택 (Step 2/3)
+   - sessionStorage.cart 로 금액/수량 요약
+   - IC카드 / 정맥인증 중 하나 선택 (라디오)
+   - 선택 시 sessionStorage.paymentMethod 저장
+   - CTA 클릭 시 분기
+       ic   → /flowP/P04-processing.html (카드 결제 처리)
+       vein → /flowP/P03-vein.html        (정맥 인증)
+   - cart 가 비어있으면 P01 과 동일한 mock 로 렌더 (디자인 확인 편의)
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    /* ---------- Session helpers ---------- */
+    const CART_KEY    = 'cart';
+    const STORE_KEY   = 'currentStoreName';
+    const METHOD_KEY  = 'paymentMethod';
+
+    const MOCK_CART = [
+        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
+    ];
+
+    function loadCart() {
+        try {
+            const raw = sessionStorage.getItem(CART_KEY);
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : null;
+        } catch (_) { return null; }
+    }
+
+    /* ---------- Formatters ---------- */
+    const nf = new Intl.NumberFormat('ko-KR');
+    const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
+
+    /* ---------- DOM refs ---------- */
+    const $  = (sel, root = document) => root.querySelector(sel);
+    const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+    const countEl   = $('[data-bind="count"]');
+    const totalEl   = $('[data-bind="total"]');
+    const storeEl   = $('[data-bind="storeName"]');
+    const hintEl    = $('[data-bind="hint"]');
+    const hintTxtEl = hintEl ? $('span', hintEl) : null;
+    const ctaEl     = $('[data-action="next"]');
+    const backEl    = $('[data-action="back"]');
+    const methodEls = $$('.method-card[data-method]');
+
+    /* ---------- State ---------- */
+    let cart = loadCart();
+    if (!cart || cart.length === 0) {
+        cart = MOCK_CART.slice();
+    }
+    let selectedMethod = null;
+
+    /* ---------- Render ---------- */
+    function renderStoreName() {
+        const storeName =
+            sessionStorage.getItem(STORE_KEY) ||
+            (cart[0] && cart[0].storeName) ||
+            '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+    }
+
+    function renderSummary() {
+        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
+        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+
+        if (countEl) countEl.textContent = totalQty + '개';
+        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+    }
+
+    function renderSelection() {
+        methodEls.forEach((el) => {
+            const isOn = el.dataset.method === selectedMethod;
+            el.setAttribute('aria-pressed', String(isOn));
+            el.setAttribute('aria-checked', String(isOn));
+            el.classList.toggle('is-selected', isOn);
+        });
+
+        if (selectedMethod === 'ic') {
+            ctaEl.textContent = 'IC카드로 결제하기 →';
+            if (hintEl && hintTxtEl) {
+                hintEl.classList.add('p02__hint--selected');
+                hintTxtEl.textContent = 'IC카드 투입구에 카드를 꽂아주세요';
+            }
+        } else if (selectedMethod === 'vein') {
+            ctaEl.textContent = '정맥인증으로 결제하기 →';
+            if (hintEl && hintTxtEl) {
+                hintEl.classList.add('p02__hint--selected');
+                hintTxtEl.textContent = '등록된 손바닥 정맥으로 간편하게 인증해요';
+            }
+        } else {
+            ctaEl.textContent = '결제 수단 선택 →';
+            if (hintEl && hintTxtEl) {
+                hintEl.classList.remove('p02__hint--selected');
+                hintTxtEl.textContent = '결제 수단을 선택하면 다음 단계로 진행할 수 있어요';
+            }
+        }
+
+        ctaEl.disabled = !selectedMethod;
+    }
+
+    function renderAll() {
+        renderStoreName();
+        renderSummary();
+        renderSelection();
+    }
+
+    /* ---------- Events ---------- */
+    methodEls.forEach((el) => {
+        el.addEventListener('click', () => {
+            const m = el.dataset.method;
+            if (!m) return;
+            selectedMethod = (selectedMethod === m) ? null : m;
+            renderSelection();
+        });
+    });
+
+    if (backEl) {
+        backEl.addEventListener('click', () => {
+            if (history.length > 1) history.back();
+            else location.href = '/flowP/P01-summary.html';
+        });
+    }
+
+    if (ctaEl) {
+        ctaEl.addEventListener('click', () => {
+            if (!selectedMethod) return;
+            try { sessionStorage.setItem(METHOD_KEY, selectedMethod); } catch (_) {}
+            if (selectedMethod === 'ic') {
+                location.href = '/flowP/P04-processing.html';
+            } else if (selectedMethod === 'vein') {
+                location.href = '/flowP/P03-vein.html';
+            }
+        });
+    }
+
+    /* ---------- Init ---------- */
+    renderAll();
+})();

--- a/src/main/resources/static/front/js/flowP/P03-vein.js
+++ b/src/main/resources/static/front/js/flowP/P03-vein.js
@@ -1,0 +1,180 @@
+/* ========================================================
+   P03-vein.js — 정맥 인증 (Step 3/3 · 4상태 전환)
+   states: prepare → scanning → success | fail
+
+   자동 전환:
+     prepare  (1.8s) → scanning
+     scanning (3.5s + progress 0→100%) → result (default: success)
+     success  (2.0s) → /flowP/P05-complete.html
+     fail     → 사용자 액션
+
+   디자인 확인용 쿼리스트링:
+     ?state=prepare|scanning|success|fail   초기 상태 강제
+     ?result=success|fail                   scanning 종료 시 결과 강제
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    const $ = (sel, root = document) => root.querySelector(sel);
+
+    /* ---------- DOM refs ---------- */
+    const sectionEl  = $('.p03');
+    const titleEl    = $('[data-bind="title"]');
+    const descEl     = $('[data-bind="desc"]');
+    const progressEl = $('.p03__progress');
+    const progressBarEl = $('[data-bind="progressBar"]');
+    const storeEl    = $('[data-bind="storeName"]');
+
+    const backEl   = $('[data-action="back"]');
+    const cancelEl = $('[data-action="cancel"]');
+    const retryEl  = $('[data-action="retry"]');
+    const switchEl = $('[data-action="switch"]');
+
+    /* ---------- Session helpers ---------- */
+    const STORE_KEY   = 'currentStoreName';
+    const METHOD_KEY  = 'paymentMethod';
+    const STATUS_KEY  = 'paymentStatus';
+
+    function getQuery(name) {
+        try { return new URLSearchParams(location.search).get(name); }
+        catch (_) { return null; }
+    }
+
+    /* ---------- Copy per state ---------- */
+    const COPY = {
+        prepare: {
+            title: '손바닥을 올려주세요',
+            desc:  '센서 위 약 15cm 높이에 손바닥을 펴서 올려주세요'
+        },
+        scanning: {
+            title: '정맥을 인식하고 있어요',
+            desc:  '잠시만 기다려주세요. 손바닥을 움직이지 마세요'
+        },
+        success: {
+            title: '인증이 완료되었어요',
+            desc:  '결제가 정상적으로 처리되었습니다'
+        },
+        fail: {
+            title: '인식하지 못했어요',
+            desc:  '손바닥 위치를 다시 확인한 후 재시도하거나 다른 결제 수단을 선택해주세요'
+        }
+    };
+
+    /* ---------- Timers ---------- */
+    let prepareTimer = null;
+    let scanTimer    = null;
+    let progressRaf  = null;
+    let successTimer = null;
+
+    function clearAllTimers() {
+        if (prepareTimer) { clearTimeout(prepareTimer); prepareTimer = null; }
+        if (scanTimer)    { clearTimeout(scanTimer);    scanTimer    = null; }
+        if (successTimer) { clearTimeout(successTimer); successTimer = null; }
+        if (progressRaf)  { cancelAnimationFrame(progressRaf); progressRaf = null; }
+    }
+
+    /* ---------- State setter ---------- */
+    function setState(nextState) {
+        clearAllTimers();
+        sectionEl.dataset.state = nextState;
+
+        const copy = COPY[nextState] || COPY.prepare;
+        if (titleEl) titleEl.textContent = copy.title;
+        if (descEl)  descEl.textContent  = copy.desc;
+
+        if (nextState === 'scanning') {
+            startScanning();
+        } else if (nextState === 'prepare') {
+            resetProgress();
+            prepareTimer = setTimeout(() => setState('scanning'), 1800);
+        } else if (nextState === 'success') {
+            setProgress(100);
+            try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
+            successTimer = setTimeout(() => {
+                location.href = '/flowP/P05-complete.html';
+            }, 2000);
+        } else if (nextState === 'fail') {
+            try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+        }
+    }
+
+    /* ---------- Progress helpers ---------- */
+    function setProgress(pct) {
+        const clamped = Math.max(0, Math.min(100, pct));
+        if (progressBarEl) progressBarEl.style.width = clamped + '%';
+        if (progressEl) progressEl.setAttribute('aria-valuenow', String(Math.round(clamped)));
+    }
+    function resetProgress() { setProgress(0); }
+
+    /* ---------- Scanning ---------- */
+    function startScanning() {
+        resetProgress();
+
+        const DURATION = 3500;
+        const startTs = performance.now();
+
+        const tick = (now) => {
+            const elapsed = now - startTs;
+            const pct = Math.min(100, (elapsed / DURATION) * 100);
+            setProgress(pct);
+            if (elapsed < DURATION) {
+                progressRaf = requestAnimationFrame(tick);
+            }
+        };
+        progressRaf = requestAnimationFrame(tick);
+
+        scanTimer = setTimeout(() => {
+            const forced = getQuery('result');
+            const finalState = (forced === 'fail' || forced === 'success')
+                ? forced
+                : 'success';
+            setState(finalState);
+        }, DURATION);
+    }
+
+    /* ---------- Misc render ---------- */
+    function renderStoreName() {
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+    }
+
+    /* ---------- Events ---------- */
+    if (backEl) {
+        backEl.addEventListener('click', () => {
+            clearAllTimers();
+            if (history.length > 1) history.back();
+            else location.href = '/flowP/P02-payment.html';
+        });
+    }
+    if (cancelEl) {
+        cancelEl.addEventListener('click', () => {
+            clearAllTimers();
+            location.href = '/flowP/P02-payment.html';
+        });
+    }
+    if (switchEl) {
+        switchEl.addEventListener('click', () => {
+            clearAllTimers();
+            location.href = '/flowP/P02-payment.html';
+        });
+    }
+    if (retryEl) {
+        retryEl.addEventListener('click', () => {
+            setState('prepare');
+        });
+    }
+
+    window.addEventListener('beforeunload', clearAllTimers);
+
+    /* ---------- Init ---------- */
+    renderStoreName();
+
+    const initial = getQuery('state');
+    if (initial && COPY[initial]) {
+        setState(initial);
+    } else {
+        try { sessionStorage.setItem(METHOD_KEY, 'vein'); } catch (_) {}
+        setState('prepare');
+    }
+})();

--- a/src/main/resources/static/front/js/flowP/P04-processing.js
+++ b/src/main/resources/static/front/js/flowP/P04-processing.js
@@ -1,0 +1,177 @@
+/* ========================================================
+   P04-processing.js — 카드 결제 처리 (Step 3/3 · 3상태)
+   states: inserting → processing → approved
+   실패 → /flowP/P06-fail.html?reason=…
+
+   자동 전환:
+     inserting  (3.0s) → processing     (카드 인식 가정)
+     processing (3.0s + progress 0→100%) → result
+         · default: approved
+         · ?result=timeout|card_error|declined → P06 으로 이동
+     approved   (2.0s) → /flowP/P05-complete.html
+
+   디자인 확인용 쿼리스트링:
+     ?state=inserting|processing|approved   초기 상태 강제
+     ?result=approved|timeout|card_error|declined
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    const $ = (sel, root = document) => root.querySelector(sel);
+
+    /* ---------- DOM refs ---------- */
+    const sectionEl  = $('.p04');
+    const titleEl    = $('[data-bind="title"]');
+    const descEl     = $('[data-bind="desc"]');
+    const storeEl    = $('[data-bind="storeName"]');
+    const totalEl    = $('[data-bind="total"]');
+    const progressEl = $('.p04__progress');
+    const progressBarEl = $('[data-bind="progressBar"]');
+
+    const backEl   = $('[data-action="back"]');
+    const cancelEl = $('[data-action="cancel"]');
+
+    /* ---------- Session ---------- */
+    const CART_KEY   = 'cart';
+    const STORE_KEY  = 'currentStoreName';
+    const METHOD_KEY = 'paymentMethod';
+    const STATUS_KEY = 'paymentStatus';
+
+    const MOCK_CART = [
+        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
+    ];
+
+    function loadCart() {
+        try {
+            const raw = sessionStorage.getItem(CART_KEY);
+            if (!raw) return MOCK_CART.slice();
+            const parsed = JSON.parse(raw);
+            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
+        } catch (_) { return MOCK_CART.slice(); }
+    }
+
+    function getQuery(name) {
+        try { return new URLSearchParams(location.search).get(name); }
+        catch (_) { return null; }
+    }
+
+    const nf = new Intl.NumberFormat('ko-KR');
+    const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
+
+    /* ---------- Copy ---------- */
+    const COPY = {
+        inserting: {
+            title: '카드를 투입해주세요',
+            desc:  'IC칩이 위로 향하게 하여 슬롯에 카드를 넣어주세요'
+        },
+        processing: {
+            title: '결제를 처리하고 있어요',
+            desc:  '잠시만 기다려주세요. 카드 승인 요청 중이에요'
+        },
+        approved: {
+            title: '결제가 완료되었어요',
+            desc:  '카드 결제 승인이 정상적으로 완료되었습니다'
+        }
+    };
+
+    /* ---------- Timers ---------- */
+    let insertTimer = null;
+    let processTimer = null;
+    let approvedTimer = null;
+    let progressRaf = null;
+
+    function clearAllTimers() {
+        if (insertTimer)   { clearTimeout(insertTimer);   insertTimer = null; }
+        if (processTimer)  { clearTimeout(processTimer);  processTimer = null; }
+        if (approvedTimer) { clearTimeout(approvedTimer); approvedTimer = null; }
+        if (progressRaf)   { cancelAnimationFrame(progressRaf); progressRaf = null; }
+    }
+
+    /* ---------- Progress ---------- */
+    function setProgress(pct) {
+        const clamped = Math.max(0, Math.min(100, pct));
+        if (progressBarEl) progressBarEl.style.width = clamped + '%';
+        if (progressEl) progressEl.setAttribute('aria-valuenow', String(Math.round(clamped)));
+    }
+
+    /* ---------- State ---------- */
+    function setState(nextState) {
+        clearAllTimers();
+        sectionEl.dataset.state = nextState;
+
+        const copy = COPY[nextState] || COPY.inserting;
+        if (titleEl) titleEl.textContent = copy.title;
+        if (descEl)  descEl.textContent  = copy.desc;
+
+        if (nextState === 'inserting') {
+            setProgress(0);
+            insertTimer = setTimeout(() => setState('processing'), 3000);
+
+        } else if (nextState === 'processing') {
+            setProgress(0);
+            const DURATION = 3000;
+            const startTs = performance.now();
+            const tick = (now) => {
+                const elapsed = now - startTs;
+                setProgress(Math.min(100, (elapsed / DURATION) * 100));
+                if (elapsed < DURATION) {
+                    progressRaf = requestAnimationFrame(tick);
+                }
+            };
+            progressRaf = requestAnimationFrame(tick);
+
+            processTimer = setTimeout(() => {
+                const forced = getQuery('result');
+                if (forced === 'timeout' || forced === 'card_error' || forced === 'declined') {
+                    try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+                    location.href = '/flowP/P06-fail.html?reason=' + encodeURIComponent(forced);
+                    return;
+                }
+                setState('approved');
+            }, DURATION);
+
+        } else if (nextState === 'approved') {
+            setProgress(100);
+            try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
+            approvedTimer = setTimeout(() => {
+                location.href = '/flowP/P05-complete.html';
+            }, 2000);
+        }
+    }
+
+    /* ---------- Init render ---------- */
+    function renderStoreAndTotal() {
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+
+        const cart = loadCart();
+        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+    }
+
+    /* ---------- Events ---------- */
+    if (backEl) {
+        backEl.addEventListener('click', () => {
+            clearAllTimers();
+            if (history.length > 1) history.back();
+            else location.href = '/flowP/P02-payment.html';
+        });
+    }
+    if (cancelEl) {
+        cancelEl.addEventListener('click', () => {
+            clearAllTimers();
+            location.href = '/flowP/P02-payment.html';
+        });
+    }
+
+    window.addEventListener('beforeunload', clearAllTimers);
+
+    /* ---------- Boot ---------- */
+    renderStoreAndTotal();
+    try { sessionStorage.setItem(METHOD_KEY, 'ic'); } catch (_) {}
+
+    const initial = getQuery('state');
+    if (initial && COPY[initial]) setState(initial);
+    else setState('inserting');
+})();

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -1,0 +1,155 @@
+/* ========================================================
+   P05-complete.js — 주문 완료
+   - 주문번호(대기번호) 랜덤 생성 후 sessionStorage 유지
+   - cart / paymentMethod 로 요약 렌더
+   - 영수증 프로그레스 3초 후 \"· 완료\" 표시
+   - 60초 자동 홈 복귀 (/)  — 카운트다운 UI 표시
+   - CTA/X 클릭 → 즉시 홈 복귀 + flow 세션 초기화
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    const $ = (sel, root = document) => root.querySelector(sel);
+
+    /* ---------- DOM refs ---------- */
+    const orderNoEl      = $('[data-bind="orderNo"]');
+    const storeEl        = $('[data-bind="storeName"]');
+    const orderTimeEl    = $('[data-bind="orderTime"]');
+    const methodLabelEl  = $('[data-bind="methodLabel"]');
+    const itemsSummaryEl = $('[data-bind="itemsSummary"]');
+    const totalEl        = $('[data-bind="total"]');
+    const autoSecEl      = $('[data-bind="autoSec"]');
+    const receiptEl      = $('[data-bind="receipt"]');
+
+    const homeEls = Array.from(document.querySelectorAll('[data-action="home"]'));
+
+    /* ---------- Session ---------- */
+    const CART_KEY    = 'cart';
+    const STORE_KEY   = 'currentStoreName';
+    const METHOD_KEY  = 'paymentMethod';
+    const STATUS_KEY  = 'paymentStatus';
+    const ORDERNO_KEY = 'orderNumber';
+
+    const FLOW_KEYS_TO_CLEAR = [
+        CART_KEY, STORE_KEY, METHOD_KEY, STATUS_KEY, ORDERNO_KEY,
+        'mode', 'dineOption', 'currentFloor', 'currentStore',
+        'aiSessionId', 'currentStep'
+    ];
+
+    const MOCK_CART = [
+        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
+    ];
+
+    function loadCart() {
+        try {
+            const raw = sessionStorage.getItem(CART_KEY);
+            if (!raw) return MOCK_CART.slice();
+            const parsed = JSON.parse(raw);
+            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
+        } catch (_) { return MOCK_CART.slice(); }
+    }
+
+    /* ---------- Utils ---------- */
+    const nf = new Intl.NumberFormat('ko-KR');
+    const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
+    const pad2 = (n) => String(n).padStart(2, '0');
+
+    function generateOrderNo() {
+        const letters = 'ABCDEFGHJKMNPQRSTUVWXYZ';
+        const letter = letters[Math.floor(Math.random() * letters.length)];
+        const number = pad2(Math.floor(Math.random() * 99) + 1);
+        return `${letter}-${number}`;
+    }
+
+    function formatOrderTime(d = new Date()) {
+        return `${d.getFullYear()}.${pad2(d.getMonth() + 1)}.${pad2(d.getDate())} `
+             + `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+    }
+
+    function getMethodLabel() {
+        const m = sessionStorage.getItem(METHOD_KEY);
+        if (m === 'vein') return '정맥 인증';
+        if (m === 'ic')   return 'IC 카드';
+        return 'IC 카드';
+    }
+
+    /* ---------- Render ---------- */
+    function renderAll() {
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+
+        let orderNo = sessionStorage.getItem(ORDERNO_KEY);
+        if (!orderNo) {
+            orderNo = generateOrderNo();
+            try { sessionStorage.setItem(ORDERNO_KEY, orderNo); } catch (_) {}
+        }
+        if (orderNoEl) orderNoEl.textContent = orderNo;
+
+        if (orderTimeEl) orderTimeEl.textContent = formatOrderTime();
+        if (methodLabelEl) methodLabelEl.textContent = getMethodLabel();
+
+        const cart = loadCart();
+        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
+        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+
+        if (itemsSummaryEl) {
+            const firstName = cart[0] ? (cart[0].name || '') : '';
+            const extra = cart.length > 1 ? ` 외 ${cart.length - 1}건` : '';
+            itemsSummaryEl.textContent = firstName
+                ? `${firstName}${extra} (총 ${totalQty}개)`
+                : `${totalQty}개`;
+        }
+        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+    }
+
+    /* ---------- Receipt progress done ---------- */
+    function markReceiptDone() {
+        if (receiptEl) receiptEl.classList.add('p05__receipt--done');
+    }
+
+    /* ---------- Auto-reset countdown ---------- */
+    const AUTO_SEC = 60;
+    let remaining = AUTO_SEC;
+    let tickTimer = null;
+
+    function startCountdown() {
+        if (autoSecEl) autoSecEl.textContent = String(remaining);
+        tickTimer = setInterval(() => {
+            remaining -= 1;
+            if (autoSecEl) autoSecEl.textContent = String(Math.max(0, remaining));
+            if (remaining <= 0) {
+                clearInterval(tickTimer);
+                tickTimer = null;
+                goHome();
+            }
+        }, 1000);
+    }
+
+    function clearFlowSession() {
+        try {
+            FLOW_KEYS_TO_CLEAR.forEach((k) => sessionStorage.removeItem(k));
+        } catch (_) {}
+    }
+
+    function goHome() {
+        if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+        clearFlowSession();
+        location.href = '/index.html';
+    }
+
+    /* ---------- Events ---------- */
+    homeEls.forEach((el) => {
+        el.addEventListener('click', goHome);
+    });
+
+    window.addEventListener('beforeunload', () => {
+        if (tickTimer) clearInterval(tickTimer);
+    });
+
+    /* ---------- Init ---------- */
+    renderAll();
+    try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
+    setTimeout(markReceiptDone, 3000);
+    startCountdown();
+})();

--- a/src/main/resources/static/front/js/flowP/P06-fail.js
+++ b/src/main/resources/static/front/js/flowP/P06-fail.js
@@ -1,0 +1,220 @@
+/* ========================================================
+   P06-fail.js — 결제 실패 (사유별 분기)
+   reasons:
+     timeout          — 카드 투입 시간 초과
+     card_error       — 카드 인식 실패
+     declined         — 카드사 승인 거절
+     vein_timeout     — 정맥 인식 시간 초과
+     vein_unregistered— 미등록 정맥
+
+   Query: ?reason=<code>  (없거나 알 수 없으면 default 적용)
+
+   CTA 분기:
+     - 재시도 가능 (timeout/card_error/vein_timeout) → [다른 수단] + [다시 시도 →] 2버튼
+     - 재시도 불가 (declined/vein_unregistered)     → [다른 결제 수단] 1버튼
+     retry 클릭 시 돌아갈 대상:
+        vein_* → /flowP/P03-vein.html
+        ic_*   → /flowP/P04-processing.html
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    const $  = (sel, root = document) => root.querySelector(sel);
+
+    /* ---------- DOM refs ---------- */
+    const storeEl      = $('[data-bind="storeName"]');
+    const pillEl       = $('[data-bind="reasonPill"]');
+    const titleEl      = $('[data-bind="title"]');
+    const descEl       = $('[data-bind="desc"]');
+    const helpListEl   = $('[data-bind="helpList"]');
+    const totalEl      = $('[data-bind="total"]');
+    const ctaRowEl     = $('[data-bind="ctaRow"]');
+
+    const backEl   = $('[data-action="back"]');
+    const switchEl = $('[data-action="switch"]');
+    const retryEl  = $('[data-action="retry"]');
+    const homeEl   = $('[data-action="home"]');
+
+    /* ---------- Session ---------- */
+    const CART_KEY   = 'cart';
+    const STORE_KEY  = 'currentStoreName';
+    const METHOD_KEY = 'paymentMethod';
+    const STATUS_KEY = 'paymentStatus';
+
+    const FLOW_KEYS_TO_CLEAR = [
+        CART_KEY, STORE_KEY, METHOD_KEY, STATUS_KEY, 'orderNumber',
+        'mode', 'dineOption', 'currentFloor', 'currentStore',
+        'aiSessionId', 'currentStep'
+    ];
+
+    const MOCK_CART = [
+        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
+    ];
+
+    function loadCart() {
+        try {
+            const raw = sessionStorage.getItem(CART_KEY);
+            if (!raw) return MOCK_CART.slice();
+            const parsed = JSON.parse(raw);
+            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
+        } catch (_) { return MOCK_CART.slice(); }
+    }
+
+    function getQuery(name) {
+        try { return new URLSearchParams(location.search).get(name); }
+        catch (_) { return null; }
+    }
+
+    const nf = new Intl.NumberFormat('ko-KR');
+    const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
+
+    /* ---------- Reason copy map ---------- */
+    const REASONS = {
+        timeout: {
+            pill: 'E-001 · 시간초과',
+            title: '결제 시간이 초과되었어요',
+            desc:  '카드 투입이 감지되지 않아 결제가 자동 취소되었습니다. 다시 시도하거나 다른 결제 수단을 선택해주세요.',
+            help:  [
+                'IC 칩이 있는 면이 위로 향하는지 확인해주세요',
+                '카드를 끝까지 밀어 넣어주세요',
+                '인식이 계속 안 되면 다른 결제 수단을 이용해주세요'
+            ],
+            retry: 'ic'
+        },
+        card_error: {
+            pill: 'E-002 · 카드 인식 실패',
+            title: '카드를 인식할 수 없어요',
+            desc:  '카드 표면의 IC 칩이나 마그네틱 스트라이프가 손상되었을 수 있어요. 카드 상태를 확인한 뒤 다시 시도해주세요.',
+            help:  [
+                'IC 칩 부분에 먼지·이물질이 없는지 닦아주세요',
+                '카드가 휘어지거나 파손되지 않았는지 확인해주세요',
+                '여러 번 실패하면 다른 카드나 결제 수단을 이용해주세요'
+            ],
+            retry: 'ic'
+        },
+        declined: {
+            pill: 'E-003 · 승인 거절',
+            title: '카드 결제가 거절되었어요',
+            desc:  '카드사로부터 승인이 거절되었습니다. 한도 초과·정지·카드사 정책 등의 원인이 있을 수 있어요. 카드사에 문의하거나 다른 결제 수단을 이용해주세요.',
+            help:  [
+                '카드 한도 또는 잔액을 확인해주세요',
+                '카드 유효기간이 지나지 않았는지 확인해주세요',
+                '문제 지속 시 카드사 고객센터로 문의해주세요'
+            ],
+            retry: null
+        },
+        vein_timeout: {
+            pill: 'V-001 · 시간초과',
+            title: '정맥 인식 시간이 초과되었어요',
+            desc:  '센서 위에 손바닥을 올려주시지 않아 인증이 종료되었습니다. 다시 시도하거나 다른 결제 수단을 선택해주세요.',
+            help:  [
+                '센서 위 약 15cm 높이에 손바닥을 펴서 올려주세요',
+                '손바닥이 센서와 평행하도록 맞춰주세요',
+                '주변 조명이 너무 밝으면 가려주세요'
+            ],
+            retry: 'vein'
+        },
+        vein_unregistered: {
+            pill: 'V-002 · 미등록',
+            title: '등록되지 않은 정맥이에요',
+            desc:  '현재 키오스크에 등록된 정맥 정보와 일치하지 않습니다. 카운터에서 등록을 진행하거나 다른 결제 수단을 이용해주세요.',
+            help:  [
+                '정맥 결제는 사전 등록이 필요한 회원 전용 기능입니다',
+                '카운터(또는 모바일 앱)에서 정맥을 등록해주세요',
+                '오늘은 다른 결제 수단으로 진행해주세요'
+            ],
+            retry: null
+        }
+    };
+
+    const DEFAULT_REASON = {
+        pill: 'E-000 · 결제 실패',
+        title: '결제에 실패했어요',
+        desc:  '일시적인 오류가 발생했어요. 잠시 후 다시 시도하거나 다른 결제 수단을 선택해주세요.',
+        help:  [
+            '네트워크 상태를 확인해주세요',
+            '다시 시도해도 실패하면 다른 결제 수단을 이용해주세요',
+            '계속 실패하면 카운터로 문의해주세요'
+        ],
+        retry: null
+    };
+
+    /* ---------- Render ---------- */
+    function renderStoreAndTotal() {
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+
+        const cart = loadCart();
+        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+    }
+
+    function renderReason(config) {
+        if (pillEl)  pillEl.textContent  = config.pill;
+        if (titleEl) titleEl.textContent = config.title;
+        if (descEl)  descEl.textContent  = config.desc;
+
+        if (helpListEl) {
+            helpListEl.innerHTML = '';
+            config.help.forEach((txt) => {
+                const li = document.createElement('li');
+                li.textContent = txt;
+                helpListEl.appendChild(li);
+            });
+        }
+
+        const canRetry = !!config.retry;
+        if (ctaRowEl) {
+            ctaRowEl.classList.toggle('p06__cta-row--single', !canRetry);
+        }
+        if (retryEl) {
+            retryEl.style.display = canRetry ? '' : 'none';
+        }
+    }
+
+    /* ---------- Navigation ---------- */
+    function goSwitch() {
+        location.href = '/flowP/P02-payment.html';
+    }
+
+    function goRetry(retryTarget) {
+        if (retryTarget === 'vein') {
+            location.href = '/flowP/P03-vein.html';
+        } else if (retryTarget === 'ic') {
+            location.href = '/flowP/P04-processing.html';
+        } else {
+            goSwitch();
+        }
+    }
+
+    function clearFlowSession() {
+        try { FLOW_KEYS_TO_CLEAR.forEach((k) => sessionStorage.removeItem(k)); }
+        catch (_) {}
+    }
+
+    function goHome() {
+        clearFlowSession();
+        location.href = '/index.html';
+    }
+
+    /* ---------- Boot ---------- */
+    try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+
+    const code = getQuery('reason');
+    const config = REASONS[code] || DEFAULT_REASON;
+
+    renderStoreAndTotal();
+    renderReason(config);
+
+    /* ---------- Events ---------- */
+    if (backEl) {
+        backEl.addEventListener('click', () => {
+            if (history.length > 1) history.back();
+            else goSwitch();
+        });
+    }
+    if (switchEl) switchEl.addEventListener('click', goSwitch);
+    if (retryEl)  retryEl.addEventListener('click', () => goRetry(config.retry));
+    if (homeEl)   homeEl.addEventListener('click', goHome);
+})();

--- a/src/main/resources/templates_front/flowP/P01-summary.html
+++ b/src/main/resources/templates_front/flowP/P01-summary.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
     <title>주문 확인 · 눈치 키오스크</title>
 
-    <link rel="stylesheet" href="/libs/xeicon/2.2.0/xeicon.min.css">
-    <link rel="stylesheet" href="/front/css/common.css">
-    <link rel="stylesheet" href="/front/css/components.css">
-    <link rel="stylesheet" href="/front/css/flowP/P01-summary.css">
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P01-summary.css">
 </head>
 <body>
 <div class="page-bg">
@@ -93,6 +93,6 @@
     </li>
 </template>
 
-<script src="/front/js/flowP/P01-summary.js" defer></script>
+<script src="/js/flowP/P01-summary.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P01-summary.html
+++ b/src/main/resources/templates_front/flowP/P01-summary.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>주문 확인 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/libs/xeicon/2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/front/css/common.css">
+    <link rel="stylesheet" href="/front/css/components.css">
+    <link rel="stylesheet" href="/front/css/flowP/P01-summary.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="뒤로가기">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">결제</h1>
+        </div>
+    </header>
+
+    <!-- 3-step 진행 표시 -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">1</span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="pending">
+            <span class="step-indicator__dot" aria-hidden="true">2</span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="pending">
+            <span class="step-indicator__dot" aria-hidden="true">3</span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 주문 요약 영역 -->
+    <section class="p01" aria-label="주문 요약">
+        <div class="p01__card">
+            <header class="p01__card-header">
+                <h2 class="p01__card-title">주문 내역</h2>
+                <span class="p01__card-count" data-bind="count">0개</span>
+            </header>
+
+            <ul class="p01__items" data-bind="items">
+                <!-- JS 로 동적 렌더 -->
+            </ul>
+
+            <footer class="p01__footer">
+                <span class="p01__total-label">합계</span>
+                <span class="p01__total-price" data-bind="total">₩0</span>
+            </footer>
+        </div>
+    </section>
+
+    <!-- 하단 CTA -->
+    <footer class="p01__cta-wrap">
+        <button type="button" class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p01__cta"
+                data-action="next">
+            주문 확인 완료 →
+        </button>
+    </footer>
+</div>
+
+<!-- 아이템 템플릿 -->
+<template id="tpl-p01-item">
+    <li class="p01__item" data-item>
+        <div class="p01__thumb" data-thumb>
+            <i class="xi-image-o" aria-hidden="true"></i>
+        </div>
+        <div class="p01__info">
+            <span class="p01__name" data-name></span>
+            <span class="p01__price" data-price></span>
+        </div>
+        <div class="p01__qty" role="group" aria-label="수량">
+            <button type="button" class="p01__qty-btn" data-qty-dec aria-label="수량 감소">
+                <i class="xi-minus" aria-hidden="true"></i>
+            </button>
+            <span class="p01__qty-value" data-qty-value>1</span>
+            <button type="button" class="p01__qty-btn" data-qty-inc aria-label="수량 증가">
+                <i class="xi-plus" aria-hidden="true"></i>
+            </button>
+        </div>
+        <button type="button" class="p01__del" data-del aria-label="삭제">
+            <i class="xi-trash" aria-hidden="true"></i>
+        </button>
+    </li>
+</template>
+
+<script src="/front/js/flowP/P01-summary.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -86,8 +86,22 @@
                     aria-checked="false"
                     data-method="vein"
                     style="--tint: var(--primary-600);">
-                <span class="method-card__icon" aria-hidden="true">
-                    <i class="xi-fingerprint"></i>
+                <span class="method-card__icon p02__method-icon--vein" aria-hidden="true">
+                    <!-- 손바닥 정맥인증 아이콘 (커스텀 SVG)
+                         - 손가락 4개 + 엄지 실루엣
+                         - 내부 2줄의 정맥 라인(곡선) 으로 "정맥" 은유
+                         - stroke="currentColor" : method-card 의 color(tint) 를 상속
+                    -->
+                    <svg viewBox="0 0 48 48" width="40" height="40"
+                         fill="none" stroke="currentColor"
+                         stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M18 22V11a2.5 2.5 0 0 1 5 0v11"/>
+                        <path d="M23 22V9a2.5 2.5 0 0 1 5 0v13"/>
+                        <path d="M28 22V10a2.5 2.5 0 0 1 5 0v12"/>
+                        <path d="M33 22v-4a2.5 2.5 0 0 1 5 0v16.5C38 39.5 34 43.5 28.5 43.5h-4c-2.6 0-5-1-6.7-2.9l-6.2-7c-1.3-1.5-1-3.3.5-4.2 1.5-.8 3.2-.3 4.2.9L18 32"/>
+                        <path d="M20 32c2 1.6 5.5 1.6 8 0" opacity=".6"/>
+                        <path d="M22 36.5c1.6 1 3.4 1 5 0" opacity=".45"/>
+                    </svg>
                 </span>
                 <span class="method-card__title">정맥인증</span>
                 <span class="method-card__desc">등록된 손바닥 정맥으로<br>간편하게 결제합니다</span>

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>결제 수단 선택 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P02-payment.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="뒤로가기">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">결제 수단 선택</h1>
+        </div>
+    </header>
+
+    <!-- 3-step 진행 표시 -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true">
+                <i class="xi-check-min"></i>
+            </span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">2</span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="pending">
+            <span class="step-indicator__dot" aria-hidden="true">3</span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 본문 -->
+    <section class="p02" aria-label="결제 수단 선택">
+
+        <!-- 결제 금액 요약 카드 -->
+        <div class="p02__amount-card">
+            <div class="p02__amount-row">
+                <span class="p02__amount-label">총 결제 금액</span>
+                <span class="p02__amount-count" data-bind="count">0개</span>
+            </div>
+            <strong class="p02__amount-price" data-bind="total">₩0</strong>
+        </div>
+
+        <!-- 섹션 안내 -->
+        <h2 class="p02__heading">결제 수단을 선택해주세요</h2>
+        <p class="p02__subheading">원하시는 결제 방법으로 진행할 수 있습니다</p>
+
+        <!-- 결제 수단 그리드 -->
+        <div class="p02__methods" role="radiogroup" aria-label="결제 수단">
+
+            <!-- IC카드 -->
+            <button type="button"
+                    class="method-card p02__method"
+                    role="radio"
+                    aria-pressed="false"
+                    aria-checked="false"
+                    data-method="ic">
+                <span class="method-card__icon" aria-hidden="true">
+                    <i class="xi-credit-card"></i>
+                </span>
+                <span class="method-card__title">IC카드</span>
+                <span class="method-card__desc">신용·체크카드를<br>투입구에 넣어주세요</span>
+                <span class="method-card__check" aria-hidden="true">
+                    <i class="xi-check-min"></i>
+                </span>
+            </button>
+
+            <!-- 정맥인증 -->
+            <button type="button"
+                    class="method-card p02__method"
+                    role="radio"
+                    aria-pressed="false"
+                    aria-checked="false"
+                    data-method="vein"
+                    style="--tint: var(--primary-600);">
+                <span class="method-card__icon" aria-hidden="true">
+                    <i class="xi-fingerprint"></i>
+                </span>
+                <span class="method-card__title">정맥인증</span>
+                <span class="method-card__desc">등록된 손바닥 정맥으로<br>간편하게 결제합니다</span>
+                <span class="method-card__check" aria-hidden="true">
+                    <i class="xi-check-min"></i>
+                </span>
+            </button>
+
+        </div>
+
+        <!-- 힌트 영역 -->
+        <div class="p02__hint" data-bind="hint">
+            <i class="xi-info-o" aria-hidden="true"></i>
+            <span>결제 수단을 선택하면 다음 단계로 진행할 수 있어요</span>
+        </div>
+
+    </section>
+
+    <!-- 하단 CTA -->
+    <footer class="p02__cta-wrap">
+        <button type="button"
+                class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p02__cta"
+                data-action="next"
+                disabled>
+            결제 수단 선택 →
+        </button>
+    </footer>
+</div>
+
+<script src="/js/flowP/P02-payment.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/templates_front/flowP/P03-vein.html
+++ b/src/main/resources/templates_front/flowP/P03-vein.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>정맥 인증 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P03-vein.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="뒤로가기">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">정맥 인증</h1>
+        </div>
+    </header>
+
+    <!-- 3-step 진행 표시 -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">3</span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 본문 : data-state 로 4상태 전환 -->
+    <section class="p03" data-state="prepare" aria-live="polite">
+
+        <!-- 스캐너 비주얼 -->
+        <div class="p03__scanner" aria-hidden="true">
+
+            <!-- 바깥 펄스 링 (prepare/scanning 에서 애니메이션) -->
+            <span class="p03__pulse p03__pulse--1"></span>
+            <span class="p03__pulse p03__pulse--2"></span>
+            <span class="p03__pulse p03__pulse--3"></span>
+
+            <!-- 원형 스캐너 프레임 -->
+            <div class="p03__frame">
+
+                <!-- 손바닥 SVG (정맥 라인 포함) -->
+                <svg class="p03__palm" viewBox="0 0 200 200"
+                     fill="none" stroke="currentColor"
+                     stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                    <!-- 손가락 4개 + 엄지 + 손바닥 아웃라인 -->
+                    <path d="M72 92V44a11 11 0 0 1 22 0v48"/>
+                    <path d="M94 92V36a11 11 0 0 1 22 0v56"/>
+                    <path d="M116 92V42a11 11 0 0 1 22 0v50"/>
+                    <path d="M138 92V74a11 11 0 0 1 22 0v72c0 24-18 42-42 42h-18c-11 0-21-4-29-12l-28-30c-5-6-4-14 2-18 6-4 14-2 18 3l9 9"/>
+                    <!-- 정맥 라인 (곡선 3개) -->
+                    <path class="p03__vein p03__vein--1" d="M82 130c10 7 28 7 38 0"/>
+                    <path class="p03__vein p03__vein--2" d="M92 150c7 4 16 4 23 0"/>
+                    <path class="p03__vein p03__vein--3" d="M98 168c5 2.5 10 2.5 15 0"/>
+                </svg>
+
+                <!-- 스캔 라인 (scanning 상태일 때만 표시·왕복) -->
+                <span class="p03__scanline" aria-hidden="true"></span>
+
+                <!-- 상태 오버레이 아이콘 (success / fail) -->
+                <span class="p03__status-icon p03__status-icon--success" aria-hidden="true">
+                    <i class="xi-check"></i>
+                </span>
+                <span class="p03__status-icon p03__status-icon--fail" aria-hidden="true">
+                    <i class="xi-close"></i>
+                </span>
+            </div>
+        </div>
+
+        <!-- 상태 텍스트 -->
+        <div class="p03__text">
+            <h2 class="p03__title" data-bind="title">손바닥을 올려주세요</h2>
+            <p class="p03__desc" data-bind="desc">센서 위 15cm 높이에 손바닥을 펴서 올려주세요</p>
+
+            <!-- 진행 프로그레스 (scanning 에서만 표시) -->
+            <div class="p03__progress" role="progressbar"
+                 aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="p03__progress-bar" data-bind="progressBar"></span>
+            </div>
+        </div>
+    </section>
+
+    <!-- 하단 액션 영역 : 상태별 버튼 -->
+    <footer class="p03__cta-wrap">
+
+        <!-- prepare / scanning : 취소 (결제 수단 변경) -->
+        <button type="button"
+                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p03__cta p03__cta--cancel"
+                data-action="cancel">
+            다른 결제 수단으로 변경
+        </button>
+
+        <!-- fail : 다시 시도 / 결제 수단 변경 -->
+        <div class="p03__cta-row p03__cta--fail-actions">
+            <button type="button"
+                    class="btn-cta btn-cta--secondary btn-cta--lg p03__cta-ghost"
+                    data-action="switch">
+                다른 결제 수단
+            </button>
+            <button type="button"
+                    class="btn-cta btn-cta--primary btn-cta--lg p03__cta-primary"
+                    data-action="retry">
+                다시 시도 →
+            </button>
+        </div>
+
+        <!-- success : 자동 이동 안내 -->
+        <p class="p03__cta--success-hint" aria-live="polite">
+            잠시 후 주문 완료 화면으로 이동합니다…
+        </p>
+    </footer>
+</div>
+
+<script src="/js/flowP/P03-vein.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/templates_front/flowP/P04-processing.html
+++ b/src/main/resources/templates_front/flowP/P04-processing.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>카드 결제 처리 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P04-processing.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="뒤로가기">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">카드 결제</h1>
+        </div>
+    </header>
+
+    <!-- 3-step 진행 표시 -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">3</span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 본문 : 3상태 전환 (inserting / processing / approved) -->
+    <section class="p04" data-state="inserting" aria-live="polite">
+
+        <!-- 결제 금액 요약 -->
+        <div class="p04__amount">
+            <span class="p04__amount-label">결제 금액</span>
+            <strong class="p04__amount-price" data-bind="total">₩0</strong>
+        </div>
+
+        <!-- 카드 슬롯 비주얼 -->
+        <div class="p04__visual" aria-hidden="true">
+
+            <!-- 유도 화살표 (inserting 에서만 노출) -->
+            <div class="p04__arrows">
+                <i class="xi-angle-down-thin"></i>
+                <i class="xi-angle-down-thin"></i>
+            </div>
+
+            <!-- 카드 (IC 칩 + 매그스트라이프) -->
+            <div class="p04__card">
+                <div class="p04__card-chip" aria-hidden="true">
+                    <span></span><span></span><span></span>
+                    <span></span><span></span><span></span>
+                </div>
+                <div class="p04__card-stripe"></div>
+                <span class="p04__card-brand">NUNCHI</span>
+            </div>
+
+            <!-- 슬롯 (카드가 삽입될 박스) -->
+            <div class="p04__slot">
+                <span class="p04__slot-mouth"></span>
+                <span class="p04__slot-label">IC CARD</span>
+
+                <!-- processing 스피너 (슬롯 하단) -->
+                <span class="p04__spinner" role="status" aria-label="결제 처리 중">
+                    <i></i>
+                </span>
+
+                <!-- 성공 오버레이 (approved) -->
+                <span class="p04__check" aria-hidden="true">
+                    <i class="xi-check"></i>
+                </span>
+            </div>
+        </div>
+
+        <!-- 상태 텍스트 -->
+        <div class="p04__text">
+            <h2 class="p04__title" data-bind="title">카드를 투입해주세요</h2>
+            <p class="p04__desc" data-bind="desc">IC칩이 위로 향하게 하여 슬롯에 카드를 넣어주세요</p>
+
+            <!-- processing 진행바 -->
+            <div class="p04__progress" role="progressbar"
+                 aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="p04__progress-bar" data-bind="progressBar"></span>
+            </div>
+        </div>
+    </section>
+
+    <!-- 하단 액션 -->
+    <footer class="p04__cta-wrap">
+
+        <!-- inserting : 결제 취소 가능 -->
+        <button type="button"
+                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p04__cta p04__cta--cancel"
+                data-action="cancel">
+            결제 취소 (다른 수단 선택)
+        </button>
+
+        <!-- processing : 카드 유지 안내 (버튼 없음) -->
+        <p class="p04__cta--processing-hint" aria-live="polite">
+            <i class="xi-warning" aria-hidden="true"></i>
+            <span>처리 중에는 카드를 빼지 마세요</span>
+        </p>
+
+        <!-- approved : 자동 이동 안내 -->
+        <p class="p04__cta--approved-hint" aria-live="polite">
+            잠시 후 주문 완료 화면으로 이동합니다…
+        </p>
+    </footer>
+</div>
+
+<script src="/js/flowP/P04-processing.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/templates_front/flowP/P05-complete.html
+++ b/src/main/resources/templates_front/flowP/P05-complete.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>주문 완료 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P05-complete.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 (뒤로가기 없음 · 완료 단계이므로 홈 닫기만) -->
+    <header class="p-topbar p05__topbar">
+        <div class="p05__topbar-spacer" aria-hidden="true"></div>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow">결제 완료</span>
+            <h1 class="p-topbar__title">주문이 접수되었어요</h1>
+        </div>
+        <button type="button" class="p05__topbar-close" data-action="home" aria-label="홈으로">
+            <i class="xi-close" aria-hidden="true"></i>
+        </button>
+    </header>
+
+    <!-- 3-step : 전부 done -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 본문 -->
+    <section class="p05" aria-label="주문 완료">
+
+        <!-- 성공 비주얼 -->
+        <div class="p05__hero" aria-hidden="true">
+            <!-- 컨페티 닷 6개 -->
+            <span class="p05__confetti p05__confetti--1"></span>
+            <span class="p05__confetti p05__confetti--2"></span>
+            <span class="p05__confetti p05__confetti--3"></span>
+            <span class="p05__confetti p05__confetti--4"></span>
+            <span class="p05__confetti p05__confetti--5"></span>
+            <span class="p05__confetti p05__confetti--6"></span>
+
+            <div class="p05__hero-ring"></div>
+            <div class="p05__hero-circle">
+                <i class="xi-check"></i>
+            </div>
+        </div>
+
+        <!-- 대기번호 카드 -->
+        <div class="p05__order-card">
+            <span class="p05__order-label">대기번호</span>
+            <strong class="p05__order-number" data-bind="orderNo">A-00</strong>
+            <span class="p05__order-store" data-bind="storeName">상록원</span>
+            <p class="p05__order-hint">주문번호로 호출되면 카운터로 와주세요</p>
+        </div>
+
+        <!-- 주문 요약 카드 -->
+        <div class="p05__summary">
+            <div class="p05__summary-row">
+                <span class="p05__summary-key">주문 일시</span>
+                <span class="p05__summary-val" data-bind="orderTime">-</span>
+            </div>
+            <div class="p05__summary-row">
+                <span class="p05__summary-key">결제 수단</span>
+                <span class="p05__summary-val" data-bind="methodLabel">IC카드</span>
+            </div>
+            <div class="p05__summary-row">
+                <span class="p05__summary-key">주문 내역</span>
+                <span class="p05__summary-val" data-bind="itemsSummary">0건</span>
+            </div>
+            <div class="p05__summary-row p05__summary-row--total">
+                <span class="p05__summary-key">결제 금액</span>
+                <span class="p05__summary-val p05__summary-val--price" data-bind="total">₩0</span>
+            </div>
+        </div>
+
+        <!-- 영수증 출력 안내 -->
+        <div class="p05__receipt" data-bind="receipt">
+            <i class="xi-print" aria-hidden="true"></i>
+            <div class="p05__receipt-body">
+                <span class="p05__receipt-title">영수증이 출력되고 있어요</span>
+                <span class="p05__receipt-progress" aria-hidden="true">
+                    <span class="p05__receipt-progress-bar"></span>
+                </span>
+            </div>
+        </div>
+    </section>
+
+    <!-- 하단 CTA -->
+    <footer class="p05__cta-wrap">
+        <p class="p05__autoreset" aria-live="polite">
+            <span data-bind="autoSec">60</span>초 후 자동으로 처음 화면으로 돌아갑니다
+        </p>
+        <button type="button"
+                class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p05__cta"
+                data-action="home">
+            <i class="xi-redo" aria-hidden="true"></i>
+            <span>처음으로</span>
+        </button>
+    </footer>
+</div>
+
+<script src="/js/flowP/P05-complete.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/templates_front/flowP/P06-fail.html
+++ b/src/main/resources/templates_front/flowP/P06-fail.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>결제 실패 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P06-fail.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="뒤로가기">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">결제 실패</h1>
+        </div>
+    </header>
+
+    <!-- 3-step : 3단계 error -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item p06__step-error" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">
+                <i class="xi-close"></i>
+            </span>
+            <span class="step-indicator__label">결제 실패</span>
+        </li>
+    </ol>
+
+    <!-- 본문 -->
+    <section class="p06" aria-live="polite">
+
+        <!-- 경고 비주얼 -->
+        <div class="p06__hero" aria-hidden="true">
+            <div class="p06__hero-ring"></div>
+            <div class="p06__hero-circle">
+                <i class="xi-close"></i>
+            </div>
+        </div>
+
+        <!-- 사유 카드 -->
+        <div class="p06__reason-card">
+            <span class="p06__reason-pill" data-bind="reasonPill">ERROR</span>
+            <h2 class="p06__reason-title" data-bind="title">결제에 실패했어요</h2>
+            <p class="p06__reason-desc" data-bind="desc">
+                잠시 후 다시 시도하거나 다른 결제 수단을 선택해주세요
+            </p>
+        </div>
+
+        <!-- 도움말 섹션 -->
+        <div class="p06__help">
+            <span class="p06__help-title">
+                <i class="xi-info-o" aria-hidden="true"></i>
+                이런 점을 확인해보세요
+            </span>
+            <ul class="p06__help-list" data-bind="helpList">
+                <!-- JS 로 렌더 -->
+            </ul>
+        </div>
+
+        <!-- 결제 금액 참고 (항상 노출) -->
+        <div class="p06__amount">
+            <span class="p06__amount-key">결제 금액</span>
+            <span class="p06__amount-val" data-bind="total">₩0</span>
+        </div>
+    </section>
+
+    <!-- 하단 CTA -->
+    <footer class="p06__cta-wrap">
+        <div class="p06__cta-row" data-bind="ctaRow">
+            <button type="button"
+                    class="btn-cta btn-cta--secondary btn-cta--lg p06__cta-ghost"
+                    data-action="switch">
+                다른 결제 수단
+            </button>
+            <button type="button"
+                    class="btn-cta btn-cta--primary btn-cta--lg p06__cta-primary"
+                    data-action="retry">
+                다시 시도 →
+            </button>
+        </div>
+
+        <button type="button"
+                class="p06__home-link"
+                data-action="home">
+            주문 취소하고 처음으로 돌아가기
+        </button>
+    </footer>
+</div>
+
+<script src="/js/flowP/P06-fail.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## 📣 Related Issue

- close #28
- close #29
- close #30
- close #31
- close #32
- close #33
- close #34

> 참고: #26(dev-server.py) · #27([hidden] 전역 리셋·데스크톱 프레임 통합) 은 선행 PR #35(`feat/#24/menu-page`) 머지로 이미 dev 에 반영되어 본 PR 의 작업 범위 밖입니다. 이슈는 별개로 close 했습니다.

## 📝 Summary

flowP(결제 플로우) 전체 화면 7종을 구현한 PR 입니다. 공통 컴포넌트 4종을 먼저 도입한 뒤 P01~P06 페이지 6종을 그 위에 올려 동일 디자인 토큰을 재사용하도록 했습니다.

### 변경 내역 (커밋 = 이슈 매핑)

| 커밋 | 이슈 | 영역 | 내용 |
|---|---|---|---|
| `[Feat] #28` | #28 | 공통 | `components.css` 에 `.p-topbar` / `.step-indicator` / `.method-card` / `.status-screen` 4종 추가 |
| `[Feat] #29` | #29 | P01 | 주문 요약/확인 화면 (장바구니 검토 → 결제로 진입) |
| `[Fix] #29` | #29 | P01 | 정적 리소스 경로 `/front/...` → `/` (Spring 정적 매핑 준수) |
| `[Feat] #30` | #30 | P02 | 결제 수단 선택 (IC카드 / 정맥인증 토글) |
| `[Fix] #30` | #30 | P02 | 정맥인증 아이콘을 `xi-fingerprint`(지문) 에서 손바닥+정맥 라인 커스텀 SVG 로 교체 (의미적으로 정확한 표현) |
| `[Feat] #31` | #31 | P03 | 정맥 인증 4상태 전환 (대기 → 인식중 → 성공/실패) — 키오스크 정맥센서 인터랙션 |
| `[Feat] #32` | #32 | P04 | 카드 결제 처리 3상태 전환 (카드 삽입 대기 → 처리중 → 완료) |
| `[Feat] #33` | #33 | P05 | 주문 완료 화면 (주문 번호 안내 + 자동 홈 복귀 카운트다운) |
| `[Feat] #34` | #34 | P06 | 결제 실패 5가지 사유별 분기 (한도/잔액/통신/기타/정맥인식 실패) |

### 신규 파일 구조
src/main/resources/ ├── static/front/css/flowP/ │ ├── P01-summary.css │ ├── P02-payment.css │ ├── P03-vein.css │ ├── P04-processing.css │ ├── P05-complete.css │ └── P06-fail.css ├── static/front/js/flowP/ │ ├── P01-summary.js │ ├── P02-payment.js │ ├── P03-vein.js │ ├── P04-processing.js │ ├── P05-complete.js │ └── P06-fail.js └── templates_front/flowP/ ├── P01-summary.html ├── P02-payment.html ├── P03-vein.html ├── P04-processing.html ├── P05-complete.html └── P06-fail.html

### 영향 받은 기존 파일

- `src/main/resources/static/front/css/components.css` — 공통 4종 컴포넌트 append

## 🙏 Question & PR point

- **충돌 처리 이력**: 본 브랜치는 dev 위로 rebase 하면서 `#26 dev-server.py` 와 `#27 데스크톱 프레임/[hidden] 통합` 변경이 선행 PR #35/#37 과 중복되어 자동 drop 되었습니다. `components.css` 1건은 수동으로 머지(flowN 6종 + flowP 4종 양쪽 보존, [hidden] 중복분만 제거).
- **데모 가정**:
  - P03 정맥 인증의 4상태 전환은 데모용 시뮬레이션이며, 실제 정맥센서 SDK 연동은 별도 이슈로 처리 예정입니다.
  - P04 카드 결제의 3상태 전환도 동일하게 결제 게이트웨이 미연동 상태입니다.
- **다음 단계 제안**: 결제 결과(성공/실패) 를 `sessionStorage` 의 `paymentStatus` / `orderNumber` 로 표준화했으니, 백엔드 결제 API 연동 시 이 키를 그대로 읽어쓰면 됩니다.

## 📬 Postman

- 백엔드 API 변경 없음 — 해당 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 완전한 결제 흐름 UI 추가: 주문 확인, 결제 수단 선택, 정맥 인증, 카드 처리, 완료, 실패 페이지
  * 3단계 진행 표시기와 시각적 상태 피드백
  * 결제 수단 선택 인터페이스(IC카드, 정맥 인증)
  * 실시간 장바구니 관리 및 수량 조절 기능
  * 주문번호 및 영수증 상태 표시
  * 결제 실패 시 재시도 옵션과 상세 오류 메시지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->