### PR TITLE
[Feat] 추천 로직을 위한 동적 조건 쿼리 및 API

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
@@ -1,7 +1,9 @@
 package dgu.capstone.nunchi.domain.menu.controller;
 
+import dgu.capstone.nunchi.domain.menu.dto.request.MenuFilterRequest;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
+import dgu.capstone.nunchi.domain.menu.dto.response.MenuFilterResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
 import dgu.capstone.nunchi.domain.menu.service.MenuService;
@@ -43,6 +45,14 @@ public class MenuController {
             @Parameter(description = "카테고리 ID (선택)") @RequestParam(required = false) Long categoryId
     ) {
         return ResponseEntity.ok(ApiResponse.ok(menuService.getMenus(categoryId)));
+    }
+
+    @Operation(summary = "메뉴 필터 조회", description = "AI 추천 에이전트용 동적 필터. 모든 파라미터 선택사항. excludeAllergies는 AllergyType enum 이름 콤마 구분 (예: MILK,EGG,WHEAT)")
+    @GetMapping("/filter")
+    public ResponseEntity<ApiResponse<List<MenuFilterResponse>>> filterMenus(
+            @ModelAttribute MenuFilterRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(menuService.filterMenus(request)));
     }
 
     @Operation(summary = "메뉴 상세 조회", description = "옵션그룹 및 옵션 포함")

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuFilterRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuFilterRequest.java
@@ -1,0 +1,19 @@
+package dgu.capstone.nunchi.domain.menu.dto.request;
+
+import dgu.capstone.nunchi.domain.menu.entity.enums.Season;
+import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.VegetarianType;
+
+public record MenuFilterRequest(
+        Integer maxCalorie,
+        Integer minCalorie,
+        Double minProtein,
+        Double maxSodium,
+        Integer maxSpicyLevel,
+        Integer minSpicyLevel,
+        TemperatureType temperatureType,
+        VegetarianType vegetarianType,
+        Season season,
+        Long categoryId,
+        String excludeAllergies   // "MILK,EGG,WHEAT" 형태로 전달
+) {}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuFilterRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuFilterRequest.java
@@ -15,5 +15,8 @@ public record MenuFilterRequest(
         VegetarianType vegetarianType,
         Season season,
         Long categoryId,
-        String excludeAllergies   // "MILK,EGG,WHEAT" 형태로 전달
+        String excludeAllergies,  // "MILK,EGG,WHEAT" 형태로 전달
+        Integer minPrice,
+        Integer maxPrice,
+        Integer limit             // 반환할 최대 메뉴 수 (null이면 제한 없음)
 ) {}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/MenuFilterResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/MenuFilterResponse.java
@@ -1,0 +1,71 @@
+package dgu.capstone.nunchi.domain.menu.dto.response;
+
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import dgu.capstone.nunchi.domain.menu.entity.NutritionInfo;
+import dgu.capstone.nunchi.domain.menu.entity.enums.AllergyType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.Season;
+import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.VegetarianType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public record MenuFilterResponse(
+        Long menuId,
+        String name,
+        Integer price,
+        Long categoryId,
+        String imageUrl,
+        Integer spicyLevel,
+        TemperatureType temperatureType,
+        VegetarianType vegetarianType,
+        Season seasonRecommended,
+        Set<AllergyType> allergies,
+        Boolean isSoldOut,
+        NutritionResponse nutrition
+) {
+
+    public record NutritionResponse(
+            Integer calorie,
+            Double protein,
+            Double carbohydrate,
+            Double fat,
+            Integer sodium,
+            Double sugar,
+            Double transFat,
+            Integer cholesterol,
+            Double dietaryFiber
+    ) {
+        public static NutritionResponse from(NutritionInfo info) {
+            if (info == null) return null;
+            return new NutritionResponse(
+                    info.getCalorie(),
+                    info.getProtein(),
+                    info.getCarbohydrate(),
+                    info.getFat(),
+                    info.getSodium(),
+                    info.getSugar(),
+                    info.getTransFat(),
+                    info.getCholesterol(),
+                    info.getDietaryFiber()
+            );
+        }
+    }
+
+    public static MenuFilterResponse from(Menu menu) {
+        return new MenuFilterResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getCategory().getCategoryId(),
+                menu.getImageUrl(),
+                menu.getSpicyLevel(),
+                menu.getTemperatureType(),
+                menu.getVegetarianType(),
+                menu.getSeasonRecommended(),
+                new HashSet<>(menu.getAllergies()),
+                menu.getIsSoldOut(),
+                NutritionResponse.from(menu.getNutrition())
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
@@ -2,10 +2,11 @@ package dgu.capstone.nunchi.domain.menu.repository;
 
 import dgu.capstone.nunchi.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long>, JpaSpecificationExecutor<Menu> {
 
     // 카테고리 ID로 메뉴 목록 조회
     List<Menu> findByCategory_CategoryId(Long categoryId);

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
@@ -1,0 +1,85 @@
+package dgu.capstone.nunchi.domain.menu.repository;
+
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import dgu.capstone.nunchi.domain.menu.entity.enums.AllergyType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.Season;
+import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.VegetarianType;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+public class MenuSpecification {
+
+    // 항상 적용: 품절 메뉴 제외
+    public static Specification<Menu> notSoldOut() {
+        return (root, query, cb) -> cb.equal(root.get("isSoldOut"), false);
+    }
+
+    public static Specification<Menu> maxCalorie(Integer max) {
+        return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("nutrition").get("calorie"), max);
+    }
+
+    public static Specification<Menu> minCalorie(Integer min) {
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("nutrition").get("calorie"), min);
+    }
+
+    public static Specification<Menu> minProtein(Double min) {
+        return (root, query, cb) -> {
+            Expression<Double> protein = root.get("nutrition").get("protein");
+            return cb.greaterThanOrEqualTo(protein, min);
+        };
+    }
+
+    // sodium은 Integer 컬럼이므로 Double 파라미터를 int로 변환하여 비교
+    public static Specification<Menu> maxSodium(Double max) {
+        return (root, query, cb) -> {
+            Expression<Integer> sodium = root.get("nutrition").get("sodium");
+            return cb.lessThanOrEqualTo(sodium, max.intValue());
+        };
+    }
+
+    public static Specification<Menu> maxSpicyLevel(Integer max) {
+        return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("spicyLevel"), max);
+    }
+
+    public static Specification<Menu> minSpicyLevel(Integer min) {
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("spicyLevel"), min);
+    }
+
+    public static Specification<Menu> temperatureType(TemperatureType type) {
+        return (root, query, cb) -> cb.equal(root.get("temperatureType"), type);
+    }
+
+    public static Specification<Menu> vegetarianType(VegetarianType type) {
+        return (root, query, cb) -> cb.equal(root.get("vegetarianType"), type);
+    }
+
+    // seasonRecommended = ALL인 메뉴는 어떤 계절 필터에도 항상 포함
+    public static Specification<Menu> season(Season season) {
+        return (root, query, cb) -> cb.or(
+                cb.equal(root.get("seasonRecommended"), season),
+                cb.equal(root.get("seasonRecommended"), Season.ALL)
+        );
+    }
+
+    public static Specification<Menu> categoryId(Long id) {
+        return (root, query, cb) -> cb.equal(root.get("category").get("categoryId"), id);
+    }
+
+    // 지정 알레르기를 하나라도 포함하는 메뉴를 서브쿼리 NOT IN으로 제외
+    public static Specification<Menu> excludeAllergies(List<AllergyType> allergyList) {
+        return (root, query, cb) -> {
+            Subquery<Long> subquery = query.subquery(Long.class);
+            Root<Menu> subRoot = subquery.from(Menu.class);
+            Join<Menu, AllergyType> allergyJoin = subRoot.join("allergies");
+            subquery.select(subRoot.get("menuId"))
+                    .where(allergyJoin.in(allergyList));
+            return cb.not(root.get("menuId").in(subquery));
+        };
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
@@ -7,6 +7,7 @@ import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
 import dgu.capstone.nunchi.domain.menu.entity.enums.VegetarianType;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
@@ -18,6 +19,16 @@ public class MenuSpecification {
     // 항상 적용: 품절 메뉴 제외
     public static Specification<Menu> notSoldOut() {
         return (root, query, cb) -> cb.equal(root.get("isSoldOut"), false);
+    }
+
+    // category N+1 방지: FETCH JOIN (COUNT 쿼리 시에는 생략)
+    public static Specification<Menu> fetchCategory() {
+        return (root, query, cb) -> {
+            if (Long.class != query.getResultType()) {
+                root.fetch("category", JoinType.LEFT);
+            }
+            return cb.conjunction();
+        };
     }
 
     public static Specification<Menu> maxCalorie(Integer max) {

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
@@ -82,6 +82,14 @@ public class MenuSpecification {
         return (root, query, cb) -> cb.equal(root.get("category").get("categoryId"), id);
     }
 
+    public static Specification<Menu> minPrice(Integer min) {
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("price"), min);
+    }
+
+    public static Specification<Menu> maxPrice(Integer max) {
+        return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("price"), max);
+    }
+
     // 지정 알레르기를 하나라도 포함하는 메뉴를 서브쿼리 NOT IN으로 제외
     public static Specification<Menu> excludeAllergies(List<AllergyType> allergyList) {
         return (root, query, cb) -> {

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Transactional(readOnly = true)
@@ -86,6 +87,8 @@ public class MenuService {
             spec = spec.and(MenuSpecification.season(req.season()));
         }
         if (req.categoryId() != null) spec = spec.and(MenuSpecification.categoryId(req.categoryId()));
+        if (req.minPrice() != null) spec = spec.and(MenuSpecification.minPrice(req.minPrice()));
+        if (req.maxPrice() != null) spec = spec.and(MenuSpecification.maxPrice(req.maxPrice()));
         if (req.excludeAllergies() != null && !req.excludeAllergies().isBlank()) {
             List<AllergyType> allergyList = Arrays.stream(req.excludeAllergies().split(","))
                     .map(String::trim)
@@ -100,9 +103,10 @@ public class MenuService {
             spec = spec.and(MenuSpecification.excludeAllergies(allergyList));
         }
 
-        return menuRepository.findAll(spec).stream()
-                .map(MenuFilterResponse::from)
-                .toList();
+        List<Menu> menus = menuRepository.findAll(spec);
+        Stream<Menu> stream = menus.stream();
+        if (req.limit() != null) stream = stream.limit(req.limit());
+        return stream.map(MenuFilterResponse::from).toList();
     }
 
     // 메뉴 상세 조회 (옵션그룹 + 옵션 포함, N+1 방지)

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -10,6 +10,7 @@ import dgu.capstone.nunchi.domain.menu.entity.Menu;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOption;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOptionGroup;
 import dgu.capstone.nunchi.domain.menu.entity.enums.AllergyType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.Season;
 import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
 import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuOptionGroupRepository;
@@ -67,7 +68,8 @@ public class MenuService {
 
     // 동적 필터 조회 (AI 추천 에이전트용)
     public List<MenuFilterResponse> filterMenus(MenuFilterRequest req) {
-        Specification<Menu> spec = Specification.where(MenuSpecification.notSoldOut());
+        Specification<Menu> spec = Specification.where(MenuSpecification.notSoldOut())
+                .and(MenuSpecification.fetchCategory());
 
         if (req.maxCalorie() != null) spec = spec.and(MenuSpecification.maxCalorie(req.maxCalorie()));
         if (req.minCalorie() != null) spec = spec.and(MenuSpecification.minCalorie(req.minCalorie()));
@@ -79,12 +81,21 @@ public class MenuService {
             spec = spec.and(MenuSpecification.temperatureType(req.temperatureType()));
         }
         if (req.vegetarianType() != null) spec = spec.and(MenuSpecification.vegetarianType(req.vegetarianType()));
-        if (req.season() != null) spec = spec.and(MenuSpecification.season(req.season()));
+        // season=ALL 전달 시 필터 없음 (전체 반환)
+        if (req.season() != null && req.season() != Season.ALL) {
+            spec = spec.and(MenuSpecification.season(req.season()));
+        }
         if (req.categoryId() != null) spec = spec.and(MenuSpecification.categoryId(req.categoryId()));
         if (req.excludeAllergies() != null && !req.excludeAllergies().isBlank()) {
             List<AllergyType> allergyList = Arrays.stream(req.excludeAllergies().split(","))
                     .map(String::trim)
-                    .map(AllergyType::valueOf)
+                    .map(s -> {
+                        try {
+                            return AllergyType.valueOf(s);
+                        } catch (IllegalArgumentException e) {
+                            throw new MenuException(MenuErrorCode.INVALID_ALLERGY_TYPE);
+                        }
+                    })
                     .toList();
             spec = spec.and(MenuSpecification.excludeAllergies(allergyList));
         }

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -1,25 +1,32 @@
 package dgu.capstone.nunchi.domain.menu.service;
 
+import dgu.capstone.nunchi.domain.menu.dto.request.MenuFilterRequest;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
+import dgu.capstone.nunchi.domain.menu.dto.response.MenuFilterResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
 import dgu.capstone.nunchi.domain.menu.entity.Menu;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOption;
 import dgu.capstone.nunchi.domain.menu.entity.MenuOptionGroup;
+import dgu.capstone.nunchi.domain.menu.entity.enums.AllergyType;
+import dgu.capstone.nunchi.domain.menu.entity.enums.TemperatureType;
 import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuOptionGroupRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuOptionRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.domain.menu.repository.MenuSpecification;
 import dgu.capstone.nunchi.domain.menu.repository.SalesDailyRepository;
 import dgu.capstone.nunchi.global.exception.domainException.MenuException;
 import dgu.capstone.nunchi.global.exception.errorcode.MenuErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,6 +63,35 @@ public class MenuService {
     // 오늘 날짜 기준 판매량 상위 메뉴 조회
     public List<TopMenuResponse> getTopMenus(int limit) {
         return salesDailyRepository.findTopMenusByDate(LocalDate.now(), PageRequest.of(0, limit));
+    }
+
+    // 동적 필터 조회 (AI 추천 에이전트용)
+    public List<MenuFilterResponse> filterMenus(MenuFilterRequest req) {
+        Specification<Menu> spec = Specification.where(MenuSpecification.notSoldOut());
+
+        if (req.maxCalorie() != null) spec = spec.and(MenuSpecification.maxCalorie(req.maxCalorie()));
+        if (req.minCalorie() != null) spec = spec.and(MenuSpecification.minCalorie(req.minCalorie()));
+        if (req.minProtein() != null) spec = spec.and(MenuSpecification.minProtein(req.minProtein()));
+        if (req.maxSodium() != null) spec = spec.and(MenuSpecification.maxSodium(req.maxSodium()));
+        if (req.maxSpicyLevel() != null) spec = spec.and(MenuSpecification.maxSpicyLevel(req.maxSpicyLevel()));
+        if (req.minSpicyLevel() != null) spec = spec.and(MenuSpecification.minSpicyLevel(req.minSpicyLevel()));
+        if (req.temperatureType() != null && req.temperatureType() != TemperatureType.BOTH) {
+            spec = spec.and(MenuSpecification.temperatureType(req.temperatureType()));
+        }
+        if (req.vegetarianType() != null) spec = spec.and(MenuSpecification.vegetarianType(req.vegetarianType()));
+        if (req.season() != null) spec = spec.and(MenuSpecification.season(req.season()));
+        if (req.categoryId() != null) spec = spec.and(MenuSpecification.categoryId(req.categoryId()));
+        if (req.excludeAllergies() != null && !req.excludeAllergies().isBlank()) {
+            List<AllergyType> allergyList = Arrays.stream(req.excludeAllergies().split(","))
+                    .map(String::trim)
+                    .map(AllergyType::valueOf)
+                    .toList();
+            spec = spec.and(MenuSpecification.excludeAllergies(allergyList));
+        }
+
+        return menuRepository.findAll(spec).stream()
+                .map(MenuFilterResponse::from)
+                .toList();
     }
 
     // 메뉴 상세 조회 (옵션그룹 + 옵션 포함, N+1 방지)

--- a/src/main/java/dgu/capstone/nunchi/domain/order/repository/CartRedisRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/repository/CartRedisRepository.java
@@ -3,6 +3,8 @@ package dgu.capstone.nunchi.domain.order.repository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dgu.capstone.nunchi.domain.order.dto.cart.CartItem;
+import dgu.capstone.nunchi.global.exception.domainException.OrderException;
+import dgu.capstone.nunchi.global.exception.errorcode.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -47,7 +49,7 @@ public class CartRedisRepository {
             String json = objectMapper.writeValueAsString(items);
             redisTemplate.opsForValue().set(key(sessionId), json, CART_TTL_SECONDS, TimeUnit.SECONDS);
         } catch (Exception e) {
-            throw new RuntimeException("장바구니 저장 실패", e);
+            throw new OrderException(OrderErrorCode.CART_SAVE_FAILED);
         }
     }
 

--- a/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
@@ -9,6 +9,14 @@ public enum MenuErrorCode implements ErrorCode {
     /**
      * 404 NOT_FOUND
      */
+    /**
+     * 400 BAD_REQUEST
+     */
+    INVALID_ALLERGY_TYPE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 알레르기 항목입니다. (예: MILK, EGG, WHEAT)"),
+
+    /**
+     * 404 NOT_FOUND
+     */
     NOT_FOUND_MENU(HttpStatus.NOT_FOUND, 404, "존재하지 않는 메뉴입니다."),
     NOT_FOUND_MENU_OPTION(HttpStatus.NOT_FOUND, 404, "존재하지 않는 메뉴 옵션입니다.");
 

--- a/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/OrderErrorCode.java
@@ -18,7 +18,12 @@ public enum OrderErrorCode implements ErrorCode {
      * 404 NOT_FOUND
      */
     NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, 404, "존재하지 않는 주문입니다."),
-    NOT_FOUND_ORDER_ITEM(HttpStatus.NOT_FOUND, 404, "존재하지 않는 주문 항목입니다.");
+    NOT_FOUND_ORDER_ITEM(HttpStatus.NOT_FOUND, 404, "존재하지 않는 주문 항목입니다."),
+
+    /**
+     * 500 INTERNAL_SERVER_ERROR
+     */
+    CART_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "장바구니 저장에 실패했습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/dgu/capstone/nunchi/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/handler/GlobalExceptionHandler.java
@@ -4,8 +4,12 @@ import dgu.capstone.nunchi.global.exception.BusinessException;
 import dgu.capstone.nunchi.global.exception.errorcode.GlobalErrorCode;
 import dgu.capstone.nunchi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
@@ -25,6 +29,38 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GlobalErrorCode.NOT_FOUND_URL.getStatus())
                 .body(ApiResponse.fail(GlobalErrorCode.NOT_FOUND_URL.getCode(), GlobalErrorCode.NOT_FOUND_URL.getMsg()));
+    }
+
+    // 지원하지 않는 HTTP Method (예: GET 엔드포인트에 POST 요청)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.fail(GlobalErrorCode.METHOD_NOT_ALLOWED.getCode(), GlobalErrorCode.METHOD_NOT_ALLOWED.getMsg()));
+    }
+
+    // 요청 바디 파싱 실패 (JSON 형식 오류, 타입 불일치)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getStatus())
+                .body(ApiResponse.fail(GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getCode(), GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getMsg()));
+    }
+
+    // @RequestParam / @ModelAttribute enum 바인딩 실패 (예: temperatureType=INVALID)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.NOT_VALID_EXCEPTION.getStatus())
+                .body(ApiResponse.fail(GlobalErrorCode.NOT_VALID_EXCEPTION.getCode(), GlobalErrorCode.NOT_VALID_EXCEPTION.getMsg()));
+    }
+
+    // @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.NOT_VALID_EXCEPTION.getStatus())
+                .body(ApiResponse.fail(GlobalErrorCode.NOT_VALID_EXCEPTION.getCode(), GlobalErrorCode.NOT_VALID_EXCEPTION.getMsg()));
     }
 
     // 그 외 모든 예외

--- a/src/main/java/dgu/capstone/nunchi/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import dgu.capstone.nunchi.global.exception.errorcode.GlobalErrorCode;
 import dgu.capstone.nunchi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,6 +46,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getStatus())
                 .body(ApiResponse.fail(GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getCode(), GlobalErrorCode.REQUEST_BODY_NOT_READABLE.getMsg()));
+    }
+
+    // @ModelAttribute 바인딩 실패 (enum 변환 실패, 숫자 타입 불일치 등)
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.NOT_VALID_EXCEPTION.getStatus())
+                .body(ApiResponse.fail(GlobalErrorCode.NOT_VALID_EXCEPTION.getCode(), GlobalErrorCode.NOT_VALID_EXCEPTION.getMsg()));
     }
 
     // @RequestParam / @ModelAttribute enum 바인딩 실패 (예: temperatureType=INVALID)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #39 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

 - `GET /api/menus/filter` — AI 추천 에이전트용 메뉴 동적 필터 조회 API 구현                                                                                                                                
  - **JPA Specification** 기반 동적 WHERE절 구성                                                                                                                                                                                                                                                                           
  - 누락된 에러코드 추가 (`INVALID_ALLERGY_TYPE`, `CART_SAVE_FAILED`)                                                                                                                                                 

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- queryDSL을 활용하여 동적쿼리를 하려 했지만, Q클래스 생성 등 빌드 시 충돌할 가능성도 있고 현재 메뉴테이블 단일에서 조회하는거라 조인도 필요없어서 JPA Specification이라는 것을 도입해봤습니다. JPA Specification은 queryDSL과 달리 Spring Data JPA 내장 기능으로 별도 의존성 추가 없이 사용 가능하다는 장점이 있는 것 같습니다!!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메뉴 필터링 API 추가: 칼로리, 단백질, 나트륨, 매운맛 수준, 온도, 채식 여부, 계절, 알레르기, 가격 범위로 메뉴를 필터링할 수 있습니다.

* **버그 수정**
  * 장바구니 저장 실패 시 더 정확한 오류 처리 추가
  * HTTP 요청 검증 및 바인딩 오류에 대한 예외 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->