### PR TITLE
[Refactor] 2·3층 매장 메뉴 origin_info 보완

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/global/config/DataInitializer.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/DataInitializer.java
@@ -152,7 +152,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(600, 35.0, 70.0, 18.0, 1700, 5.0, 0.2, 90, 3.0))
                 .allergies(allergies(AllergyType.PORK))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산").floor(2).restaurantName("더진국")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 대파:국내산, 양파:국내산, 마늘:국내산").floor(2).restaurantName("더진국")
                 .operatingHours("11:00-14:00,15:00-16:00").build());
 
         menuRepository.save(Menu.builder()
@@ -161,7 +161,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(620, 30.0, 75.0, 20.0, 1800, 4.0, 0.3, 100, 3.0))
                 .allergies(allergies(AllergyType.PORK))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산").floor(2).restaurantName("더진국")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기(순대 포함):국내산, 양파:국내산, 마늘:국내산").floor(2).restaurantName("더진국")
                 .operatingHours("11:00-14:00,15:00-16:00").build());
 
         menuRepository.save(Menu.builder()
@@ -170,7 +170,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(580, 28.0, 70.0, 17.0, 1900, 6.0, 0.2, 80, 4.0))
                 .allergies(allergies(AllergyType.BEEF, AllergyType.SOY))
                 .spicyLevel(3).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("쇠고기:국내산").floor(2).restaurantName("더진국")
+                .seasonRecommended(Season.ALL).originInfo("쇠고기:국내산, 콩나물:국내산, 무:국내산, 고춧가루:국내산").floor(2).restaurantName("더진국")
                 .operatingHours("11:00-14:00,15:00-16:00").build());
 
         // 솥밥 8개 국 선택 + 공기밥 추가 옵션 (스팸도시락 제외)
@@ -366,7 +366,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(750, 25.0, 110.0, 20.0, 1000, 12.0, 0.2, 30, 6.0))
                 .allergies(allergies(AllergyType.WHEAT))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("밀:미국산, 토마토:국내산").floor(2).restaurantName("양식")
+                .seasonRecommended(Season.ALL).originInfo("밀:미국산, 토마토:국내산, 마늘:국내산, 버터:뉴질랜드산").floor(2).restaurantName("양식")
                 .operatingHours("11:00-14:00").build());
 
         menuRepository.save(Menu.builder()
@@ -375,7 +375,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(850, 35.0, 95.0, 35.0, 1300, 10.0, 0.4, 75, 5.0))
                 .allergies(allergies(AllergyType.WHEAT, AllergyType.MILK, AllergyType.EGG))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("밀:미국산, 치즈:뉴질랜드산").floor(2).restaurantName("양식")
+                .seasonRecommended(Season.ALL).originInfo("밀:미국산, 치즈:뉴질랜드산, 우유:국내산, 버터:뉴질랜드산").floor(2).restaurantName("양식")
                 .operatingHours("11:00-14:00").build());
 
         // 라면 토핑 옵션
@@ -439,7 +439,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(950, 35.0, 100.0, 35.0, 1500, 15.0, 0.5, 80, 5.0))
                 .allergies(allergies(AllergyType.PORK, AllergyType.WHEAT, AllergyType.SOY))
                 .spicyLevel(2).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 밀:미국산").floor(2).restaurantName("일품")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기(제육·소시지):국내산, 밀:미국산, 양파:국내산, 고춧가루:국내산").floor(2).restaurantName("일품")
                 .operatingHours("11:00-14:00,15:00-16:00").build());
 
         // 2층 양식 (단품) — 영업시간: 점심
@@ -449,7 +449,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(850, 40.0, 70.0, 45.0, 1200, 8.0, 0.3, 100, 3.0))
                 .allergies(allergies(AllergyType.PORK, AllergyType.WHEAT, AllergyType.MILK, AllergyType.EGG))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 치즈:뉴질랜드산, 밀:미국산").floor(2).restaurantName("양식")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 치즈:뉴질랜드산, 밀:미국산, 양배추:국내산").floor(2).restaurantName("양식")
                 .operatingHours("11:00-14:00").build());
 
         // 3층 집밥 — 일자별로 메뉴가 변경되는 백반 (현재값은 03/25 기준)
@@ -460,7 +460,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(800, 40.0, 90.0, 28.0, 1800, 7.0, 0.3, 95, 6.0))
                 .allergies(allergies(AllergyType.PORK, AllergyType.WHEAT, AllergyType.SOY))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 밀:미국산").floor(3).restaurantName("집밥")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 밀:미국산, 도토리:국내산, 상추:국내산").floor(3).restaurantName("집밥")
                 .operatingHours("11:00-14:00").build());
 
         menuRepository.save(Menu.builder()
@@ -470,7 +470,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(900, 45.0, 80.0, 40.0, 1700, 12.0, 0.4, 110, 5.0))
                 .allergies(allergies(AllergyType.PORK, AllergyType.CHICKEN, AllergyType.WHEAT, AllergyType.SOY))
                 .spicyLevel(2).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 닭고기:국내산").floor(3).restaurantName("집밥")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 닭고기:국내산, 미역:국내산, 고추장:국내산").floor(3).restaurantName("집밥")
                 .operatingHours("17:00-19:00").build());
 
         // 3층 한그릇 — 일자별로 메뉴가 변경되는 백반 (현재값은 03/25 기준, 한정판매)
@@ -481,7 +481,7 @@ public class DataInitializer implements CommandLineRunner {
                 .nutrition(nutrition(850, 30.0, 100.0, 30.0, 1500, 18.0, 0.4, 90, 4.0))
                 .allergies(allergies(AllergyType.PORK, AllergyType.SHRIMP, AllergyType.WHEAT, AllergyType.MILK, AllergyType.EGG))
                 .spicyLevel(0).temperatureType(TemperatureType.HOT).vegetarianType(VegetarianType.NONE)
-                .seasonRecommended(Season.ALL).originInfo("돼지고기:국내산, 새우:베트남산").floor(3).restaurantName("한그릇")
+                .seasonRecommended(Season.ALL).originInfo("돼지고기(소시지):국내산, 새우:베트남산, 카레가루:인도산, 우유:국내산").floor(3).restaurantName("한그릇")
                 .operatingHours("11:00-14:00").build());
 
         // ===== 추가메뉴 =====


### PR DESCRIPTION
이름 기반으로 추정한 부재료 원산지 정보 추가:
- 더진국 (수육/순대/얼큰국밥): 채소·고춧가루 등 추가
- 양식 (파스타류·치즈돈까스): 우유·버터·양배추 등 추가
- 일품 (매콤제육덮밥+핫도그): 양파·고춧가루·소시지 정보 추가
- 집밥 (중·석식 백반): 도토리·상추·미역·고추장 추가
- 한그릇 (카레백반): 카레가루·우유 추가

## 📣 Related Issue

- close #55

## 📝 Summary

지난 PR(#53)에서 추가한 2·3층 매장 메뉴 10개의 `origin_info`를 메뉴명 기반으로 보완했습니다.

| 매장 | 메뉴 | 추가된 원산지 정보 |
|---|---|---|
| 더진국 | 수육국밥 | 대파·양파·마늘 |
| 더진국 | 순대국밥 | 순대(돼지부속)·양파·마늘 |
| 더진국 | 얼큰국밥 | 콩나물·무·고춧가루 |
| 양식 | 토마토파스타+마늘빵 | 마늘·버터 |
| 양식 | 치즈오븐파스타 | 우유·버터 |
| 일품 | 매콤제육덮밥+핫도그 | 양파·고춧가루·소시지(돼지부속) |
| 양식 | 치즈돈까스 | 양배추 |
| 집밥 | 중식백반 | 도토리·상추 |
| 집밥 | 석식백반 | 미역·고추장 |
| 한그릇 | 중식백반 | 카레가루·우유 |

## 🙏 Question & PR point

- 모든 원산지는 **메뉴명 기반 추정값**입니다. 정확한 원산지는 매장 제공 자료가 있다면 별도 보정 필요해요.
- 카레가루는 보통 인도산이 일반적이라 그렇게 표기했는데, 실제 매장에서 사용하는 브랜드 기준이 다르면 알려주세요.

## 📬 Postman

해당 없음 — 시드 데이터 보완이라 API 변경 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **정기 유지보수**
  * 메뉴 원재료 정보가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->