### PR TITLE
[Feat] 아바타 모드를 구현하기 위해 필요한 API 추가 및 리팩토링

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/controller/MenuController.java
@@ -1,6 +1,7 @@
 package dgu.capstone.nunchi.domain.menu.controller;
 
 import dgu.capstone.nunchi.domain.menu.dto.request.MenuFilterRequest;
+import dgu.capstone.nunchi.domain.menu.dto.request.MenuSearchRequest;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuFilterResponse;
@@ -45,6 +46,14 @@ public class MenuController {
             @Parameter(description = "카테고리 ID (선택)") @RequestParam(required = false) Long categoryId
     ) {
         return ResponseEntity.ok(ApiResponse.ok(menuService.getMenus(categoryId)));
+    }
+
+    @Operation(summary = "메뉴 이름 검색", description = "FastAPI NER 결과를 menuId로 변환하는 용도. name 파라미터로 부분 검색 (LIKE). 품절 메뉴 제외.")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<MenuResponse>>> searchMenus(
+            @ModelAttribute MenuSearchRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(menuService.searchMenus(request)));
     }
 
     @Operation(summary = "메뉴 필터 조회", description = "AI 추천 에이전트용 동적 필터. 모든 파라미터 선택사항. excludeAllergies는 AllergyType enum 이름 콤마 구분 (예: MILK,EGG,WHEAT)")

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuSearchRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuSearchRequest.java
@@ -1,5 +1,7 @@
 package dgu.capstone.nunchi.domain.menu.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record MenuSearchRequest(
-        String name   // 메뉴 이름 부분 검색 (LIKE %name%)
+        @NotBlank(message = "검색어를 입력해주세요.") String name
 ) {}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuSearchRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/request/MenuSearchRequest.java
@@ -1,4 +1,5 @@
 package dgu.capstone.nunchi.domain.menu.dto.request;
 
-public record MenuSearchRequest() {
-}
+public record MenuSearchRequest(
+        String name   // 메뉴 이름 부분 검색 (LIKE %name%)
+) {}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
@@ -106,9 +106,13 @@ public class MenuSpecification {
         );
     }
 
-    // 메뉴 이름 부분 검색 (대소문자 무시, LIKE %name%)
+    // 메뉴 이름 부분 검색 (대소문자 무시, LIKE %name% / %, _ 이스케이프 처리)
     public static Specification<Menu> nameContains(String name) {
-        return (root, query, cb) -> cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+        String escaped = name.toLowerCase()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return (root, query, cb) -> cb.like(cb.lower(root.get("name")), "%" + escaped + "%", '\\');
     }
 
     // 지정 알레르기를 하나라도 포함하는 메뉴를 서브쿼리 NOT IN으로 제외

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuSpecification.java
@@ -106,6 +106,11 @@ public class MenuSpecification {
         );
     }
 
+    // 메뉴 이름 부분 검색 (대소문자 무시, LIKE %name%)
+    public static Specification<Menu> nameContains(String name) {
+        return (root, query, cb) -> cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+    }
+
     // 지정 알레르기를 하나라도 포함하는 메뉴를 서브쿼리 NOT IN으로 제외
     public static Specification<Menu> excludeAllergies(List<AllergyType> allergyList) {
         return (root, query, cb) -> {

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -114,12 +114,13 @@ public class MenuService {
 
     // 이름 퍼지 검색 (FastAPI NER 결과 → menuId 변환용)
     public List<MenuResponse> searchMenus(MenuSearchRequest request) {
-        if (request.name() == null || request.name().isBlank()) {
+        String keyword = request.name() == null ? "" : request.name().trim();
+        if (keyword.isBlank()) {
             throw new MenuException(MenuErrorCode.INVALID_SEARCH_KEYWORD);
         }
         Specification<Menu> spec = Specification.where(MenuSpecification.notSoldOut())
                 .and(MenuSpecification.fetchCategory())
-                .and(MenuSpecification.nameContains(request.name()));
+                .and(MenuSpecification.nameContains(keyword));
         return menuRepository.findAll(spec).stream()
                 .map(MenuResponse::from)
                 .toList();

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/service/MenuService.java
@@ -1,6 +1,7 @@
 package dgu.capstone.nunchi.domain.menu.service;
 
 import dgu.capstone.nunchi.domain.menu.dto.request.MenuFilterRequest;
+import dgu.capstone.nunchi.domain.menu.dto.request.MenuSearchRequest;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuCategoryResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuDetailResponse;
 import dgu.capstone.nunchi.domain.menu.dto.response.MenuFilterResponse;
@@ -109,6 +110,19 @@ public class MenuService {
         Stream<Menu> stream = menus.stream();
         if (req.limit() != null) stream = stream.limit(req.limit());
         return stream.map(MenuFilterResponse::from).toList();
+    }
+
+    // 이름 퍼지 검색 (FastAPI NER 결과 → menuId 변환용)
+    public List<MenuResponse> searchMenus(MenuSearchRequest request) {
+        if (request.name() == null || request.name().isBlank()) {
+            throw new MenuException(MenuErrorCode.INVALID_SEARCH_KEYWORD);
+        }
+        Specification<Menu> spec = Specification.where(MenuSpecification.notSoldOut())
+                .and(MenuSpecification.fetchCategory())
+                .and(MenuSpecification.nameContains(request.name()));
+        return menuRepository.findAll(spec).stream()
+                .map(MenuResponse::from)
+                .toList();
     }
 
     // 메뉴 상세 조회 (옵션그룹 + 옵션 포함, N+1 방지)

--- a/src/main/java/dgu/capstone/nunchi/domain/order/controller/OrderController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/controller/OrderController.java
@@ -68,6 +68,15 @@ public class OrderController {
         return ResponseEntity.ok(ApiResponse.ok(orderService.confirmOrder(request.sessionId())));
     }
 
+    @Operation(summary = "장바구니 전체 비우기", description = "세션의 Redis 장바구니를 전체 초기화합니다. 루프백 재시작 또는 세션 취소 시 사용.")
+    @DeleteMapping("/cart/{sessionId}")
+    public ResponseEntity<ApiResponse<Void>> clearCart(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId
+    ) {
+        orderService.clearCart(sessionId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
     @Operation(summary = "주문 취소", description = "주문을 취소 상태로 변경합니다.")
     @PatchMapping("/{orderId}/cancel")
     public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(

--- a/src/main/java/dgu/capstone/nunchi/domain/order/controller/OrderController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/controller/OrderController.java
@@ -74,7 +74,7 @@ public class OrderController {
             @Parameter(description = "세션 ID") @PathVariable Long sessionId
     ) {
         orderService.clearCart(sessionId);
-        return ResponseEntity.ok(ApiResponse.ok(null));
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @Operation(summary = "주문 취소", description = "주문을 취소 상태로 변경합니다.")

--- a/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
@@ -17,10 +17,13 @@ import dgu.capstone.nunchi.domain.order.repository.CartRedisRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderItemOptionRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import dgu.capstone.nunchi.domain.session.repository.KioskSessionRepository;
 import dgu.capstone.nunchi.global.exception.domainException.MenuException;
 import dgu.capstone.nunchi.global.exception.domainException.OrderException;
+import dgu.capstone.nunchi.global.exception.domainException.SessionException;
 import dgu.capstone.nunchi.global.exception.errorcode.MenuErrorCode;
 import dgu.capstone.nunchi.global.exception.errorcode.OrderErrorCode;
+import dgu.capstone.nunchi.global.exception.errorcode.SessionErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +43,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final OrderItemOptionRepository orderItemOptionRepository;
+    private final KioskSessionRepository kioskSessionRepository;
 
     /** 장바구니 조회 */
     public CartResponse getCart(Long sessionId) {
@@ -189,6 +193,15 @@ public class OrderService {
         cartRedisRepository.deleteCart(sessionId);
 
         return OrderResponse.from(order, itemResponses);
+    }
+
+    /** 장바구니 전체 비우기 */
+    @Transactional
+    public void clearCart(Long sessionId) {
+        if (!kioskSessionRepository.existsById(sessionId)) {
+            throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
+        }
+        cartRedisRepository.deleteCart(sessionId);
     }
 
     /** 주문 취소 */

--- a/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
@@ -17,13 +17,10 @@ import dgu.capstone.nunchi.domain.order.repository.CartRedisRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderItemOptionRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
-import dgu.capstone.nunchi.domain.session.repository.KioskSessionRepository;
 import dgu.capstone.nunchi.global.exception.domainException.MenuException;
 import dgu.capstone.nunchi.global.exception.domainException.OrderException;
-import dgu.capstone.nunchi.global.exception.domainException.SessionException;
 import dgu.capstone.nunchi.global.exception.errorcode.MenuErrorCode;
 import dgu.capstone.nunchi.global.exception.errorcode.OrderErrorCode;
-import dgu.capstone.nunchi.global.exception.errorcode.SessionErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +40,6 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final OrderItemOptionRepository orderItemOptionRepository;
-    private final KioskSessionRepository kioskSessionRepository;
 
     /** 장바구니 조회 */
     public CartResponse getCart(Long sessionId) {
@@ -195,12 +191,9 @@ public class OrderService {
         return OrderResponse.from(order, itemResponses);
     }
 
-    /** 장바구니 전체 비우기 */
+    /** 장바구니 전체 비우기 (세션 미존재 시에도 성공 - 멱등성 보장) */
     @Transactional
     public void clearCart(Long sessionId) {
-        if (!kioskSessionRepository.existsById(sessionId)) {
-            throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
-        }
         cartRedisRepository.deleteCart(sessionId);
     }
 

--- a/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
@@ -3,6 +3,7 @@ package dgu.capstone.nunchi.domain.session.controller;
 import dgu.capstone.nunchi.domain.session.dto.request.AiToolCallLogSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.request.SessionStepUpdateRequest;
 import dgu.capstone.nunchi.domain.session.dto.response.AiToolCallLogResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
@@ -55,6 +56,26 @@ public class SessionController {
         ConversationMessageResponse response = sessionService.saveMessage(sessionId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "세션 스텝 업데이트", description = "FastAPI가 기/승/전/결 단계 판별 후 Spring에 동기화. step: BROWSE(기) / SELECT(승) / CONFIGURE(전) / CHECKOUT(결)")
+    @PatchMapping("/{sessionId}/step")
+    public ResponseEntity<ApiResponse<SessionResponse>> updateStep(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @RequestBody @Valid SessionStepUpdateRequest request
+    ) {
+        SessionResponse response = sessionService.updateStep(sessionId, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "대화 기록 조회", description = "세션에 연결된 대화 메시지를 시간 순으로 조회. FastAPI 세션 복원 시 사용.")
+    @GetMapping("/{sessionId}/messages")
+    public ResponseEntity<ApiResponse<List<ConversationMessageResponse>>> getMessages(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @Parameter(description = "조회 최대 개수") @RequestParam(defaultValue = "100") int limit
+    ) {
+        List<ConversationMessageResponse> response = sessionService.getMessages(sessionId, limit);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @Operation(summary = "AI 툴 호출 로그 저장", description = "FastAPI가 툴 호출 결과를 session 단위로 저장할 때 호출")

--- a/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/controller/SessionController.java
@@ -13,14 +13,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Tag(name = "Session", description = "세션 관리 API")
+@Validated
 @RestController
 @RequestMapping("/api/sessions")
 @RequiredArgsConstructor
@@ -72,7 +75,7 @@ public class SessionController {
     @GetMapping("/{sessionId}/messages")
     public ResponseEntity<ApiResponse<List<ConversationMessageResponse>>> getMessages(
             @Parameter(description = "세션 ID") @PathVariable Long sessionId,
-            @Parameter(description = "조회 최대 개수") @RequestParam(defaultValue = "100") int limit
+            @Parameter(description = "조회 최대 개수") @Min(1) @RequestParam(defaultValue = "100") int limit
     ) {
         List<ConversationMessageResponse> response = sessionService.getMessages(sessionId, limit);
         return ResponseEntity.ok(ApiResponse.ok(response));
@@ -93,7 +96,7 @@ public class SessionController {
     @GetMapping("/{sessionId}/tool-logs")
     public ResponseEntity<ApiResponse<List<AiToolCallLogResponse>>> getToolCallLogs(
             @Parameter(description = "세션 ID") @PathVariable Long sessionId,
-            @Parameter(description = "조회 최대 개수") @RequestParam(defaultValue = "50") int limit
+            @Parameter(description = "조회 최대 개수") @Min(1) @RequestParam(defaultValue = "50") int limit
     ) {
         List<AiToolCallLogResponse> response = sessionService.getToolCallLogs(sessionId, limit);
         return ResponseEntity.ok(ApiResponse.ok(response));

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/SessionStepUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/request/SessionStepUpdateRequest.java
@@ -1,0 +1,8 @@
+package dgu.capstone.nunchi.domain.session.dto.request;
+
+import dgu.capstone.nunchi.domain.session.entity.OrderStep;
+import jakarta.validation.constraints.NotNull;
+
+public record SessionStepUpdateRequest(
+        @NotNull OrderStep step
+) {}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/SessionResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/dto/response/SessionResponse.java
@@ -9,6 +9,7 @@ public record SessionResponse(
         String mode,
         String status,
         String language,
+        String currentStep,
         LocalDateTime createdAt
 ) {
     public static SessionResponse from(KioskSession session) {
@@ -17,6 +18,7 @@ public record SessionResponse(
                 session.getMode().name(),
                 session.getSessionStatus().name(),
                 session.getLanguage(),
+                session.getCurrentStep(),
                 session.getCreatedAt()
         );
     }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/entity/OrderStep.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/entity/OrderStep.java
@@ -1,0 +1,8 @@
+package dgu.capstone.nunchi.domain.session.entity;
+
+public enum OrderStep {
+    BROWSE,     // 기: 카테고리 탐색 단계
+    SELECT,     // 승: 메뉴 선택 단계
+    CONFIGURE,  // 전: 수량/옵션 설정 단계
+    CHECKOUT    // 결: 주문 요약 및 결제 단계
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/session/repository/ConversationMessageRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/repository/ConversationMessageRepository.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface ConversationMessageRepository extends JpaRepository<ConversationMessage, Long> {
 
     List<ConversationMessage> findAllBySession_SessionIdOrderByCreatedAtAsc(Long sessionId, Pageable pageable);
+
+    // 최근 N개를 내림차순으로 가져온 뒤 서비스에서 역정렬해 시간순 반환
+    List<ConversationMessage> findAllBySession_SessionIdOrderByCreatedAtDesc(Long sessionId, Pageable pageable);
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/repository/ConversationMessageRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/repository/ConversationMessageRepository.java
@@ -1,7 +1,12 @@
 package dgu.capstone.nunchi.domain.session.repository;
 
 import dgu.capstone.nunchi.domain.session.entity.ConversationMessage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ConversationMessageRepository extends JpaRepository<ConversationMessage, Long> {
+
+    List<ConversationMessage> findAllBySession_SessionIdOrderByCreatedAtAsc(Long sessionId, Pageable pageable);
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -67,6 +67,7 @@ public class SessionService {
         return SessionResponse.from(session);
     }
 
+    @Transactional(readOnly = true)
     public List<ConversationMessageResponse> getMessages(Long sessionId, int limit) {
         if (!kioskSessionRepository.existsById(sessionId)) {
             throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import org.springframework.data.domain.PageRequest;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -73,9 +74,10 @@ public class SessionService {
             throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
         }
 
-        return conversationMessageRepository
-                .findAllBySession_SessionIdOrderByCreatedAtAsc(sessionId, PageRequest.of(0, limit))
-                .stream()
+        List<ConversationMessage> messages = conversationMessageRepository
+                .findAllBySession_SessionIdOrderByCreatedAtDesc(sessionId, PageRequest.of(0, limit));
+        Collections.reverse(messages);
+        return messages.stream()
                 .map(ConversationMessageResponse::from)
                 .toList();
     }

--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -3,6 +3,7 @@ package dgu.capstone.nunchi.domain.session.service;
 import dgu.capstone.nunchi.domain.session.dto.request.AiToolCallLogSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.ConversationMessageSaveRequest;
 import dgu.capstone.nunchi.domain.session.dto.request.SessionCreateRequest;
+import dgu.capstone.nunchi.domain.session.dto.request.SessionStepUpdateRequest;
 import dgu.capstone.nunchi.domain.session.dto.response.AiToolCallLogResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.ConversationMessageResponse;
 import dgu.capstone.nunchi.domain.session.dto.response.SessionResponse;
@@ -51,6 +52,31 @@ public class SessionService {
 
         session.complete();
         return SessionResponse.from(session);
+    }
+
+    @Transactional
+    public SessionResponse updateStep(Long sessionId, SessionStepUpdateRequest request) {
+        KioskSession session = kioskSessionRepository.findByIdWithLock(sessionId)
+                .orElseThrow(() -> new SessionException(SessionErrorCode.NOT_FOUND_SESSION));
+
+        if (session.getSessionStatus() != SessionStatus.ACTIVE) {
+            throw new SessionException(SessionErrorCode.SESSION_ALREADY_ENDED);
+        }
+
+        session.updateStep(request.step().name());
+        return SessionResponse.from(session);
+    }
+
+    public List<ConversationMessageResponse> getMessages(Long sessionId, int limit) {
+        if (!kioskSessionRepository.existsById(sessionId)) {
+            throw new SessionException(SessionErrorCode.NOT_FOUND_SESSION);
+        }
+
+        return conversationMessageRepository
+                .findAllBySession_SessionIdOrderByCreatedAtAsc(sessionId, PageRequest.of(0, limit))
+                .stream()
+                .map(ConversationMessageResponse::from)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
@@ -13,6 +13,7 @@ public enum MenuErrorCode implements ErrorCode {
      * 400 BAD_REQUEST
      */
     INVALID_ALLERGY_TYPE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 알레르기 항목입니다. (예: MILK, EGG, WHEAT)"),
+    INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 400, "검색어를 입력해주세요."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
@@ -7,9 +7,6 @@ import org.springframework.http.HttpStatus;
 public enum MenuErrorCode implements ErrorCode {
 
     /**
-     * 404 NOT_FOUND
-     */
-    /**
      * 400 BAD_REQUEST
      */
     INVALID_ALLERGY_TYPE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 알레르기 항목입니다. (예: MILK, EGG, WHEAT)"),


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #52 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 - 아바타 모드 주문 흐름(BROWSE→SELECT→CONFIGURE→CHECKOUT) 지원을 위한 API 4개 추가
    - `GET /api/menus/search?name=` — FastAPI 메뉴명으로 검색할 수 있게                                                                                                             
    - `PATCH /api/sessions/{id}/step` — 기/승/전/결 단계 Spring 동기화를 위한 API            
    - `GET /api/sessions/{id}/messages` — 세션 대화 기록 조회 (LLM 컨텍스트 복원용 API)                                                                                                                
    - `DELETE /api/orders/cart/{sessionId}` — 장바구니 전체 초기화 API                                                                                                                                                                                                                                                                                           
  - `OrderStep` enum 정의 -> 4가지 타입 (BROWSE / SELECT / CONFIGURE / CHECKOUT)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
 - 기존 일반 주문 API는 변경 없음 — 아바타/일반 모드 모두 동일 엔드포인트 재사용합니다!!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메뉴 검색 — 이름 기반 부분 일치(유효성 검사 포함) 검색 추가
  * 장바구니 초기화 — 세션별 장바구니 전체 삭제 기능 추가
  * 주문 단계 관리 — BROWSE→SELECT→CONFIGURE→CHECKOUT 단계 업데이트 기능 추가
  * 대화 이력 조회 — 제한(limit) 지원하는 메시지 조회(페이징) 기능 추가
  * 세션 응답 개선 — 현재 주문 단계 정보 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->