### PR TITLE
[Feat] 관리자 페이지 API 구현

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
@@ -2,9 +2,11 @@ package dgu.capstone.nunchi.domain.admin.controller;
 
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminDashboardResponse;
 import dgu.capstone.nunchi.domain.admin.service.AdminDashboardService;
+import dgu.capstone.nunchi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "관리자 대시보드 API", description = "관리자페이지 메인 화면에서 운영 현황 요약 정보를 조회하는 API입니다.")
@@ -15,12 +17,9 @@ public class AdminDashboardController {
 
     private final AdminDashboardService adminDashboardService;
 
-    @Operation(
-            summary = "관리자 대시보드 조회",
-            description = "오늘 주문 수, 오늘 매출, 전체 주문 수, 품절 메뉴 수, 추천 메뉴 수, 최근 주문 목록을 조회합니다."
-    )
+    @Operation(summary = "관리자 대시보드 조회", description = "오늘 주문 수, 오늘 매출, 전체 주문 수, 품절 메뉴 수, 추천 메뉴 수, 최근 주문 목록을 조회합니다.")
     @GetMapping
-    public AdminDashboardResponse getDashboard() {
-        return adminDashboardService.getDashboard();
+    public ResponseEntity<ApiResponse<AdminDashboardResponse>> getDashboard() {
+        return ResponseEntity.ok(ApiResponse.ok(adminDashboardService.getDashboard()));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
@@ -1,4 +1,26 @@
 package dgu.capstone.nunchi.domain.admin.controller;
 
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminDashboardResponse;
+import dgu.capstone.nunchi.domain.admin.service.AdminDashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "관리자 대시보드 API", description = "관리자페이지 메인 화면에서 운영 현황 요약 정보를 조회하는 API입니다.")
+@RestController
+@RequestMapping("/api/admin/dashboard")
+@RequiredArgsConstructor
 public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @Operation(
+            summary = "관리자 대시보드 조회",
+            description = "오늘 주문 수, 오늘 매출, 전체 주문 수, 품절 메뉴 수, 추천 메뉴 수, 최근 주문 목록을 조회합니다."
+    )
+    @GetMapping
+    public AdminDashboardResponse getDashboard() {
+        return adminDashboardService.getDashboard();
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminDashboardController.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.controller;
+
+public class AdminDashboardController {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
@@ -6,12 +6,13 @@ import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuSoldOutUpdateReques
 import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuUpdateRequest;
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminMenuResponse;
 import dgu.capstone.nunchi.domain.admin.service.AdminMenuService;
+import dgu.capstone.nunchi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,88 +25,66 @@ public class AdminMenuController {
 
     private final AdminMenuService adminMenuService;
 
-    @Operation(
-            summary = "관리자 메뉴 목록 조회",
-            description = "관리자페이지에서 전체 메뉴 목록을 조회합니다. 메뉴명, 가격, 이미지 URL, 카테고리, 품절 여부, 추천 여부를 함께 반환합니다."
-    )
+    @Operation(summary = "관리자 메뉴 목록 조회", description = "관리자페이지에서 전체 메뉴 목록을 조회합니다.")
     @GetMapping
-    public List<AdminMenuResponse> getMenus() {
-        return adminMenuService.getMenus();
+    public ResponseEntity<ApiResponse<List<AdminMenuResponse>>> getMenus() {
+        return ResponseEntity.ok(ApiResponse.ok(adminMenuService.getMenus()));
     }
 
-    @Operation(
-            summary = "관리자 메뉴 단건 조회",
-            description = "메뉴 ID를 기준으로 특정 메뉴의 상세 정보를 조회합니다."
-    )
+    @Operation(summary = "관리자 메뉴 단건 조회", description = "메뉴 ID를 기준으로 특정 메뉴 정보를 조회합니다.")
     @GetMapping("/{menuId}")
-    public AdminMenuResponse getMenu(
+    public ResponseEntity<ApiResponse<AdminMenuResponse>> getMenu(
             @Parameter(description = "조회할 메뉴 ID", example = "1")
             @PathVariable Long menuId
     ) {
-        return adminMenuService.getMenu(menuId);
+        return ResponseEntity.ok(ApiResponse.ok(adminMenuService.getMenu(menuId)));
     }
 
-    @Operation(
-            summary = "관리자 메뉴 등록",
-            description = "새로운 메뉴를 등록합니다. 메뉴명, 가격, 이미지 URL, 카테고리 ID, 품절 여부, 추천 여부를 입력받습니다."
-    )
+    @Operation(summary = "관리자 메뉴 등록", description = "새로운 메뉴를 등록합니다.")
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public AdminMenuResponse createMenu(
+    public ResponseEntity<ApiResponse<AdminMenuResponse>> createMenu(
             @Valid @RequestBody AdminMenuCreateRequest request
     ) {
-        return adminMenuService.createMenu(request);
+        return ResponseEntity.ok(ApiResponse.created(adminMenuService.createMenu(request)));
     }
 
-    @Operation(
-            summary = "관리자 메뉴 수정",
-            description = "기존 메뉴의 메뉴명, 가격, 이미지 URL, 카테고리를 수정합니다. 품절 여부와 추천 여부는 별도 API에서 변경합니다."
-    )
+    @Operation(summary = "관리자 메뉴 수정", description = "기존 메뉴의 메뉴명, 가격, 이미지 URL, 카테고리를 수정합니다.")
     @PatchMapping("/{menuId}")
-    public AdminMenuResponse updateMenu(
+    public ResponseEntity<ApiResponse<AdminMenuResponse>> updateMenu(
             @Parameter(description = "수정할 메뉴 ID", example = "1")
             @PathVariable Long menuId,
             @Valid @RequestBody AdminMenuUpdateRequest request
     ) {
-        return adminMenuService.updateMenu(menuId, request);
+        return ResponseEntity.ok(ApiResponse.ok(adminMenuService.updateMenu(menuId, request)));
     }
 
-    @Operation(
-            summary = "메뉴 품절 상태 변경",
-            description = "특정 메뉴의 품절 여부를 변경합니다. 품절 처리된 메뉴는 키오스크 메뉴 조회 및 추천 결과에서 제외될 수 있습니다."
-    )
+    @Operation(summary = "메뉴 품절 상태 변경", description = "특정 메뉴의 품절 여부를 변경합니다.")
     @PatchMapping("/{menuId}/sold-out")
-    public AdminMenuResponse updateSoldOut(
+    public ResponseEntity<ApiResponse<AdminMenuResponse>> updateSoldOut(
             @Parameter(description = "품절 상태를 변경할 메뉴 ID", example = "1")
             @PathVariable Long menuId,
             @Valid @RequestBody AdminMenuSoldOutUpdateRequest request
     ) {
-        return adminMenuService.updateSoldOut(menuId, request);
+        return ResponseEntity.ok(ApiResponse.ok(adminMenuService.updateSoldOut(menuId, request)));
     }
 
-    @Operation(
-            summary = "메뉴 추천 상태 변경",
-            description = "특정 메뉴의 기본 추천 여부를 변경합니다. 추천 상태가 true인 메뉴는 기본 추천 메뉴 조회에 활용됩니다."
-    )
+    @Operation(summary = "메뉴 추천 상태 변경", description = "특정 메뉴의 기본 추천 여부를 변경합니다.")
     @PatchMapping("/{menuId}/recommended")
-    public AdminMenuResponse updateRecommended(
+    public ResponseEntity<ApiResponse<AdminMenuResponse>> updateRecommended(
             @Parameter(description = "추천 상태를 변경할 메뉴 ID", example = "1")
             @PathVariable Long menuId,
             @Valid @RequestBody AdminMenuRecommendedUpdateRequest request
     ) {
-        return adminMenuService.updateRecommended(menuId, request);
+        return ResponseEntity.ok(ApiResponse.ok(adminMenuService.updateRecommended(menuId, request)));
     }
 
-    @Operation(
-            summary = "관리자 메뉴 삭제",
-            description = "메뉴 ID를 기준으로 메뉴를 삭제합니다. 추후 운영 안정성을 위해 실제 삭제 대신 비활성화 방식으로 변경할 수 있습니다."
-    )
+    @Operation(summary = "관리자 메뉴 삭제", description = "메뉴 ID를 기준으로 메뉴를 삭제합니다.")
     @DeleteMapping("/{menuId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMenu(
+    public ResponseEntity<ApiResponse<Void>> deleteMenu(
             @Parameter(description = "삭제할 메뉴 ID", example = "1")
             @PathVariable Long menuId
     ) {
         adminMenuService.deleteMenu(menuId);
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
@@ -1,0 +1,111 @@
+package dgu.capstone.nunchi.domain.admin.controller;
+
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuCreateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuRecommendedUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuSoldOutUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminMenuResponse;
+import dgu.capstone.nunchi.domain.admin.service.AdminMenuService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "관리자 메뉴 API", description = "관리자페이지에서 메뉴를 조회, 등록, 수정, 삭제하고 품절/추천 상태를 관리하는 API입니다.")
+@RestController
+@RequestMapping("/api/admin/menus")
+@RequiredArgsConstructor
+public class AdminMenuController {
+
+    private final AdminMenuService adminMenuService;
+
+    @Operation(
+            summary = "관리자 메뉴 목록 조회",
+            description = "관리자페이지에서 전체 메뉴 목록을 조회합니다. 메뉴명, 가격, 이미지 URL, 카테고리, 품절 여부, 추천 여부를 함께 반환합니다."
+    )
+    @GetMapping
+    public List<AdminMenuResponse> getMenus() {
+        return adminMenuService.getMenus();
+    }
+
+    @Operation(
+            summary = "관리자 메뉴 단건 조회",
+            description = "메뉴 ID를 기준으로 특정 메뉴의 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{menuId}")
+    public AdminMenuResponse getMenu(
+            @Parameter(description = "조회할 메뉴 ID", example = "1")
+            @PathVariable Long menuId
+    ) {
+        return adminMenuService.getMenu(menuId);
+    }
+
+    @Operation(
+            summary = "관리자 메뉴 등록",
+            description = "새로운 메뉴를 등록합니다. 메뉴명, 가격, 이미지 URL, 카테고리 ID, 품절 여부, 추천 여부를 입력받습니다."
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AdminMenuResponse createMenu(
+            @Valid @RequestBody AdminMenuCreateRequest request
+    ) {
+        return adminMenuService.createMenu(request);
+    }
+
+    @Operation(
+            summary = "관리자 메뉴 수정",
+            description = "기존 메뉴의 메뉴명, 가격, 이미지 URL, 카테고리를 수정합니다. 품절 여부와 추천 여부는 별도 API에서 변경합니다."
+    )
+    @PatchMapping("/{menuId}")
+    public AdminMenuResponse updateMenu(
+            @Parameter(description = "수정할 메뉴 ID", example = "1")
+            @PathVariable Long menuId,
+            @Valid @RequestBody AdminMenuUpdateRequest request
+    ) {
+        return adminMenuService.updateMenu(menuId, request);
+    }
+
+    @Operation(
+            summary = "메뉴 품절 상태 변경",
+            description = "특정 메뉴의 품절 여부를 변경합니다. 품절 처리된 메뉴는 키오스크 메뉴 조회 및 추천 결과에서 제외될 수 있습니다."
+    )
+    @PatchMapping("/{menuId}/sold-out")
+    public AdminMenuResponse updateSoldOut(
+            @Parameter(description = "품절 상태를 변경할 메뉴 ID", example = "1")
+            @PathVariable Long menuId,
+            @Valid @RequestBody AdminMenuSoldOutUpdateRequest request
+    ) {
+        return adminMenuService.updateSoldOut(menuId, request);
+    }
+
+    @Operation(
+            summary = "메뉴 추천 상태 변경",
+            description = "특정 메뉴의 기본 추천 여부를 변경합니다. 추천 상태가 true인 메뉴는 기본 추천 메뉴 조회에 활용됩니다."
+    )
+    @PatchMapping("/{menuId}/recommended")
+    public AdminMenuResponse updateRecommended(
+            @Parameter(description = "추천 상태를 변경할 메뉴 ID", example = "1")
+            @PathVariable Long menuId,
+            @Valid @RequestBody AdminMenuRecommendedUpdateRequest request
+    ) {
+        return adminMenuService.updateRecommended(menuId, request);
+    }
+
+    @Operation(
+            summary = "관리자 메뉴 삭제",
+            description = "메뉴 ID를 기준으로 메뉴를 삭제합니다. 추후 운영 안정성을 위해 실제 삭제 대신 비활성화 방식으로 변경할 수 있습니다."
+    )
+    @DeleteMapping("/{menuId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMenu(
+            @Parameter(description = "삭제할 메뉴 ID", example = "1")
+            @PathVariable Long menuId
+    ) {
+        adminMenuService.deleteMenu(menuId);
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminMenuController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,7 +46,9 @@ public class AdminMenuController {
     public ResponseEntity<ApiResponse<AdminMenuResponse>> createMenu(
             @Valid @RequestBody AdminMenuCreateRequest request
     ) {
-        return ResponseEntity.ok(ApiResponse.created(adminMenuService.createMenu(request)));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(adminMenuService.createMenu(request)));
     }
 
     @Operation(summary = "관리자 메뉴 수정", description = "기존 메뉴의 메뉴명, 가격, 이미지 URL, 카테고리를 수정합니다.")
@@ -80,11 +83,11 @@ public class AdminMenuController {
 
     @Operation(summary = "관리자 메뉴 삭제", description = "메뉴 ID를 기준으로 메뉴를 삭제합니다.")
     @DeleteMapping("/{menuId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMenu(
+    public ResponseEntity<Void> deleteMenu(
             @Parameter(description = "삭제할 메뉴 ID", example = "1")
             @PathVariable Long menuId
     ) {
         adminMenuService.deleteMenu(menuId);
-        return ResponseEntity.ok(ApiResponse.noContent());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
@@ -1,4 +1,57 @@
 package dgu.capstone.nunchi.domain.admin.controller;
 
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminOrderStatusUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderDetailResponse;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderResponse;
+import dgu.capstone.nunchi.domain.admin.service.AdminOrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "관리자 주문 API", description = "관리자페이지에서 주문 목록, 주문 상세, 주문 상태를 관리하는 API입니다.")
+@RestController
+@RequestMapping("/api/admin/orders")
+@RequiredArgsConstructor
 public class AdminOrderController {
+
+    private final AdminOrderService adminOrderService;
+
+    @Operation(
+            summary = "관리자 주문 목록 조회",
+            description = "관리자페이지에서 전체 주문 목록을 조회합니다. 주문 ID, 세션 ID, 총 주문 금액, 주문 상태, 주문 상품 개수, 주문 생성 시간을 반환합니다."
+    )
+    @GetMapping
+    public List<AdminOrderResponse> getOrders() {
+        return adminOrderService.getOrders();
+    }
+
+    @Operation(
+            summary = "관리자 주문 상세 조회",
+            description = "주문 ID를 기준으로 주문 상세 정보와 주문 상품 목록을 조회합니다."
+    )
+    @GetMapping("/{orderId}")
+    public AdminOrderDetailResponse getOrder(
+            @Parameter(description = "조회할 주문 ID", example = "1")
+            @PathVariable Long orderId
+    ) {
+        return adminOrderService.getOrder(orderId);
+    }
+
+    @Operation(
+            summary = "관리자 주문 상태 변경",
+            description = "주문 ID를 기준으로 주문 상태를 변경합니다. 가능한 상태값은 PENDING, COMPLETED, CANCELLED입니다."
+    )
+    @PatchMapping("/{orderId}/status")
+    public AdminOrderDetailResponse updateOrderStatus(
+            @Parameter(description = "상태를 변경할 주문 ID", example = "1")
+            @PathVariable Long orderId,
+            @Valid @RequestBody AdminOrderStatusUpdateRequest request
+    ) {
+        return adminOrderService.updateOrderStatus(orderId, request);
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
@@ -4,11 +4,13 @@ import dgu.capstone.nunchi.domain.admin.dto.request.AdminOrderStatusUpdateReques
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderDetailResponse;
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderResponse;
 import dgu.capstone.nunchi.domain.admin.service.AdminOrderService;
+import dgu.capstone.nunchi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,37 +23,28 @@ public class AdminOrderController {
 
     private final AdminOrderService adminOrderService;
 
-    @Operation(
-            summary = "관리자 주문 목록 조회",
-            description = "관리자페이지에서 전체 주문 목록을 조회합니다. 주문 ID, 세션 ID, 총 주문 금액, 주문 상태, 주문 상품 개수, 주문 생성 시간을 반환합니다."
-    )
+    @Operation(summary = "관리자 주문 목록 조회", description = "관리자페이지에서 전체 주문 목록을 조회합니다.")
     @GetMapping
-    public List<AdminOrderResponse> getOrders() {
-        return adminOrderService.getOrders();
+    public ResponseEntity<ApiResponse<List<AdminOrderResponse>>> getOrders() {
+        return ResponseEntity.ok(ApiResponse.ok(adminOrderService.getOrders()));
     }
 
-    @Operation(
-            summary = "관리자 주문 상세 조회",
-            description = "주문 ID를 기준으로 주문 상세 정보와 주문 상품 목록을 조회합니다."
-    )
+    @Operation(summary = "관리자 주문 상세 조회", description = "주문 ID를 기준으로 주문 상세 정보와 주문 상품 목록을 조회합니다.")
     @GetMapping("/{orderId}")
-    public AdminOrderDetailResponse getOrder(
+    public ResponseEntity<ApiResponse<AdminOrderDetailResponse>> getOrder(
             @Parameter(description = "조회할 주문 ID", example = "1")
             @PathVariable Long orderId
     ) {
-        return adminOrderService.getOrder(orderId);
+        return ResponseEntity.ok(ApiResponse.ok(adminOrderService.getOrder(orderId)));
     }
 
-    @Operation(
-            summary = "관리자 주문 상태 변경",
-            description = "주문 ID를 기준으로 주문 상태를 변경합니다. 가능한 상태값은 PENDING, COMPLETED, CANCELLED입니다."
-    )
+    @Operation(summary = "관리자 주문 상태 변경", description = "주문 ID를 기준으로 주문 상태를 변경합니다.")
     @PatchMapping("/{orderId}/status")
-    public AdminOrderDetailResponse updateOrderStatus(
+    public ResponseEntity<ApiResponse<AdminOrderDetailResponse>> updateOrderStatus(
             @Parameter(description = "상태를 변경할 주문 ID", example = "1")
             @PathVariable Long orderId,
             @Valid @RequestBody AdminOrderStatusUpdateRequest request
     ) {
-        return adminOrderService.updateOrderStatus(orderId, request);
+        return ResponseEntity.ok(ApiResponse.ok(adminOrderService.updateOrderStatus(orderId, request)));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminOrderController.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.controller;
+
+public class AdminOrderController {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
@@ -3,9 +3,11 @@ package dgu.capstone.nunchi.domain.admin.controller;
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminPopularMenuResponse;
 import dgu.capstone.nunchi.domain.admin.dto.response.AdminRecommendedMenuResponse;
 import dgu.capstone.nunchi.domain.admin.service.AdminRecommendationService;
+import dgu.capstone.nunchi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,8 +25,10 @@ public class AdminRecommendationController {
             description = "관리자가 추천 메뉴로 설정한 메뉴 목록을 조회합니다. 품절 메뉴는 제외됩니다."
     )
     @GetMapping("/default")
-    public List<AdminRecommendedMenuResponse> getDefaultRecommendations() {
-        return adminRecommendationService.getDefaultRecommendations();
+    public ResponseEntity<ApiResponse<List<AdminRecommendedMenuResponse>>> getDefaultRecommendations() {
+        return ResponseEntity.ok(
+                ApiResponse.ok(adminRecommendationService.getDefaultRecommendations())
+        );
     }
 
     @Operation(
@@ -32,16 +36,20 @@ public class AdminRecommendationController {
             description = "SalesDaily 통계 데이터를 기준으로 오늘 가장 많이 판매된 메뉴를 조회합니다."
     )
     @GetMapping("/popular/today")
-    public List<AdminPopularMenuResponse> getTodayPopularMenus() {
-        return adminRecommendationService.getTodayPopularMenus();
+    public ResponseEntity<ApiResponse<List<AdminPopularMenuResponse>>> getTodayPopularMenus() {
+        return ResponseEntity.ok(
+                ApiResponse.ok(adminRecommendationService.getTodayPopularMenus())
+        );
     }
 
     @Operation(
             summary = "관리자 주문 기반 인기 메뉴 조회",
-            description = "OrderItem 주문 데이터를 기준으로 누적 인기 메뉴를 조회합니다. 판매 수량은 현재 응답에 포함하지 않습니다."
+            description = "OrderItem 주문 데이터를 기준으로 누적 인기 메뉴를 조회합니다."
     )
     @GetMapping("/popular/orders")
-    public List<AdminPopularMenuResponse> getOrderBasedPopularMenus() {
-        return adminRecommendationService.getOrderBasedPopularMenus();
+    public ResponseEntity<ApiResponse<List<AdminPopularMenuResponse>>> getOrderBasedPopularMenus() {
+        return ResponseEntity.ok(
+                ApiResponse.ok(adminRecommendationService.getOrderBasedPopularMenus())
+        );
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.controller;
+
+public class AdminRecommendationController {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminRecommendationController.java
@@ -1,4 +1,47 @@
 package dgu.capstone.nunchi.domain.admin.controller;
 
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminPopularMenuResponse;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminRecommendedMenuResponse;
+import dgu.capstone.nunchi.domain.admin.service.AdminRecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "관리자 추천 API", description = "관리자페이지에서 기본 추천 메뉴와 인기 메뉴 현황을 조회하는 API입니다.")
+@RestController
+@RequestMapping("/api/admin/recommendations")
+@RequiredArgsConstructor
 public class AdminRecommendationController {
+
+    private final AdminRecommendationService adminRecommendationService;
+
+    @Operation(
+            summary = "관리자 기본 추천 메뉴 조회",
+            description = "관리자가 추천 메뉴로 설정한 메뉴 목록을 조회합니다. 품절 메뉴는 제외됩니다."
+    )
+    @GetMapping("/default")
+    public List<AdminRecommendedMenuResponse> getDefaultRecommendations() {
+        return adminRecommendationService.getDefaultRecommendations();
+    }
+
+    @Operation(
+            summary = "관리자 오늘 인기 메뉴 조회",
+            description = "SalesDaily 통계 데이터를 기준으로 오늘 가장 많이 판매된 메뉴를 조회합니다."
+    )
+    @GetMapping("/popular/today")
+    public List<AdminPopularMenuResponse> getTodayPopularMenus() {
+        return adminRecommendationService.getTodayPopularMenus();
+    }
+
+    @Operation(
+            summary = "관리자 주문 기반 인기 메뉴 조회",
+            description = "OrderItem 주문 데이터를 기준으로 누적 인기 메뉴를 조회합니다. 판매 수량은 현재 응답에 포함하지 않습니다."
+    )
+    @GetMapping("/popular/orders")
+    public List<AdminPopularMenuResponse> getOrderBasedPopularMenus() {
+        return adminRecommendationService.getOrderBasedPopularMenus();
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuCreateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuCreateRequest.java
@@ -1,0 +1,33 @@
+package dgu.capstone.nunchi.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 메뉴 등록 요청 DTO")
+public record AdminMenuCreateRequest(
+
+        @Schema(description = "메뉴명", example = "제육덮밥")
+        @NotBlank(message = "메뉴명은 필수입니다.")
+        String name,
+
+        @Schema(description = "메뉴 가격", example = "8500")
+        @NotNull(message = "가격은 필수입니다.")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        Integer price,
+
+        @Schema(description = "메뉴 이미지 URL", example = "https://example.com/jeyuk.jpg")
+        String imageUrl,
+
+        @Schema(description = "카테고리 ID", example = "1")
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Long categoryId,
+
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
+
+        @Schema(description = "기본 추천 여부", example = "true")
+        Boolean isRecommended
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuRecommendedUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuRecommendedUpdateRequest.java
@@ -1,0 +1,13 @@
+package dgu.capstone.nunchi.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "메뉴 추천 상태 변경 요청 DTO")
+public record AdminMenuRecommendedUpdateRequest(
+
+        @Schema(description = "추천 여부", example = "true")
+        @NotNull(message = "추천 여부는 필수입니다.")
+        Boolean isRecommended
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuSoldOutUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuSoldOutUpdateRequest.java
@@ -1,0 +1,13 @@
+package dgu.capstone.nunchi.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "메뉴 품절 상태 변경 요청 DTO")
+public record AdminMenuSoldOutUpdateRequest(
+
+        @Schema(description = "품절 여부", example = "true")
+        @NotNull(message = "품절 여부는 필수입니다.")
+        Boolean isSoldOut
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminMenuUpdateRequest.java
@@ -1,0 +1,27 @@
+package dgu.capstone.nunchi.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 메뉴 수정 요청 DTO")
+public record AdminMenuUpdateRequest(
+
+        @Schema(description = "수정할 메뉴명", example = "매콤 제육덮밥")
+        @NotBlank(message = "메뉴명은 필수입니다.")
+        String name,
+
+        @Schema(description = "수정할 메뉴 가격", example = "9000")
+        @NotNull(message = "가격은 필수입니다.")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        Integer price,
+
+        @Schema(description = "수정할 메뉴 이미지 URL", example = "https://example.com/jeyuk-spicy.jpg")
+        String imageUrl,
+
+        @Schema(description = "수정할 카테고리 ID", example = "1")
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Long categoryId
+) {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminOrderStatusUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminOrderStatusUpdateRequest.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.dto.request;
+
+public record AdminOrderStatusUpdateRequest() {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminOrderStatusUpdateRequest.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/request/AdminOrderStatusUpdateRequest.java
@@ -1,4 +1,14 @@
 package dgu.capstone.nunchi.domain.admin.dto.request;
 
-public record AdminOrderStatusUpdateRequest() {
+import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 주문 상태 변경 요청 DTO")
+public record AdminOrderStatusUpdateRequest(
+
+        @Schema(description = "변경할 주문 상태", example = "COMPLETED")
+        @NotNull(message = "주문 상태는 필수입니다.")
+        OrderStatus orderStatus
+) {
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminDashboardResponse.java
@@ -1,4 +1,28 @@
 package dgu.capstone.nunchi.domain.admin.dto.response;
 
-public record AdminDashboardResponse() {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "관리자 대시보드 응답 DTO")
+public record AdminDashboardResponse(
+
+        @Schema(description = "오늘 주문 수", example = "12")
+        Long todayOrderCount,
+
+        @Schema(description = "오늘 매출", example = "96000")
+        Integer todaySalesAmount,
+
+        @Schema(description = "전체 주문 수", example = "154")
+        Long totalOrderCount,
+
+        @Schema(description = "품절 메뉴 수", example = "3")
+        Long soldOutMenuCount,
+
+        @Schema(description = "추천 메뉴 수", example = "5")
+        Long recommendedMenuCount,
+
+        @Schema(description = "최근 주문 목록")
+        List<AdminOrderResponse> recentOrders
+) {
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminDashboardResponse.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+public record AdminDashboardResponse() {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminMenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminMenuResponse.java
@@ -1,0 +1,46 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 메뉴 응답 DTO")
+public record AdminMenuResponse(
+
+        @Schema(description = "메뉴 ID", example = "1")
+        Long menuId,
+
+        @Schema(description = "메뉴명", example = "제육덮밥")
+        String name,
+
+        @Schema(description = "메뉴 가격", example = "8500")
+        Integer price,
+
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
+
+        @Schema(description = "메뉴 이미지 URL", example = "https://example.com/jeyuk.jpg")
+        String imageUrl,
+
+        @Schema(description = "기본 추천 여부", example = "true")
+        Boolean isRecommended,
+
+        @Schema(description = "카테고리 ID", example = "1")
+        Long categoryId,
+
+        @Schema(description = "카테고리명", example = "덮밥류")
+        String categoryName
+) {
+
+    public static AdminMenuResponse from(Menu menu) {
+        return new AdminMenuResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getIsSoldOut(),
+                menu.getImageUrl(),
+                menu.getIsRecommended(),
+                menu.getCategory().getCategoryId(),
+                menu.getCategory().getName()
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderDetailResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderDetailResponse.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+public record AdminOrderDetailResponse() {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderDetailResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderDetailResponse.java
@@ -1,4 +1,45 @@
 package dgu.capstone.nunchi.domain.admin.dto.response;
 
-public record AdminOrderDetailResponse() {
+import dgu.capstone.nunchi.domain.order.entity.Order;
+import dgu.capstone.nunchi.domain.order.entity.OrderItem;
+import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "관리자 주문 상세 응답 DTO")
+public record AdminOrderDetailResponse(
+
+        @Schema(description = "주문 ID", example = "1")
+        Long orderId,
+
+        @Schema(description = "세션 ID", example = "100")
+        Long sessionId,
+
+        @Schema(description = "총 주문 금액", example = "18000")
+        Integer totalAmount,
+
+        @Schema(description = "주문 상태", example = "COMPLETED")
+        OrderStatus orderStatus,
+
+        @Schema(description = "주문 생성 시간", example = "2026-05-05T12:31:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "주문 상품 목록")
+        List<AdminOrderItemResponse> items
+) {
+
+    public static AdminOrderDetailResponse from(Order order, List<OrderItem> orderItems) {
+        return new AdminOrderDetailResponse(
+                order.getOrderId(),
+                order.getSessionId(),
+                order.getTotalAmount(),
+                order.getOrderStatus(),
+                order.getCreatedAt(),
+                orderItems.stream()
+                        .map(AdminOrderItemResponse::from)
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderItemResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderItemResponse.java
@@ -33,8 +33,8 @@ public record AdminOrderItemResponse(
                 orderItem.getOrderItemId(),
                 orderItem.getMenuId(),
                 orderItem.getMenuName(),
-                orderItem.getQuantity(),
-                orderItem.getUnitPrice(),
+                quantity,
+                unitPrice,
                 quantity * unitPrice
         );
     }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderItemResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderItemResponse.java
@@ -1,0 +1,41 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+import dgu.capstone.nunchi.domain.order.entity.OrderItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 주문 상품 응답 DTO")
+public record AdminOrderItemResponse(
+
+        @Schema(description = "주문 상품 ID", example = "1")
+        Long orderItemId,
+
+        @Schema(description = "메뉴 ID", example = "10")
+        Long menuId,
+
+        @Schema(description = "주문 당시 메뉴명", example = "제육덮밥")
+        String menuName,
+
+        @Schema(description = "수량", example = "2")
+        Integer quantity,
+
+        @Schema(description = "주문 당시 단가", example = "8500")
+        Integer unitPrice,
+
+        @Schema(description = "상품 총 금액", example = "17000")
+        Integer totalPrice
+) {
+
+    public static AdminOrderItemResponse from(OrderItem orderItem) {
+        int quantity = orderItem.getQuantity() != null ? orderItem.getQuantity() : 0;
+        int unitPrice = orderItem.getUnitPrice() != null ? orderItem.getUnitPrice() : 0;
+
+        return new AdminOrderItemResponse(
+                orderItem.getOrderItemId(),
+                orderItem.getMenuId(),
+                orderItem.getMenuName(),
+                orderItem.getQuantity(),
+                orderItem.getUnitPrice(),
+                quantity * unitPrice
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderResponse.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+public record AdminOrderResponse() {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminOrderResponse.java
@@ -1,4 +1,41 @@
 package dgu.capstone.nunchi.domain.admin.dto.response;
 
-public record AdminOrderResponse() {
+import dgu.capstone.nunchi.domain.order.entity.Order;
+import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 주문 목록 응답 DTO")
+public record AdminOrderResponse(
+
+        @Schema(description = "주문 ID", example = "1")
+        Long orderId,
+
+        @Schema(description = "세션 ID", example = "100")
+        Long sessionId,
+
+        @Schema(description = "총 주문 금액", example = "18000")
+        Integer totalAmount,
+
+        @Schema(description = "주문 상태", example = "COMPLETED")
+        OrderStatus orderStatus,
+
+        @Schema(description = "주문 상품 개수", example = "3")
+        Integer itemCount,
+
+        @Schema(description = "주문 생성 시간", example = "2026-05-05T12:31:00")
+        LocalDateTime createdAt
+) {
+
+    public static AdminOrderResponse from(Order order, Integer itemCount) {
+        return new AdminOrderResponse(
+                order.getOrderId(),
+                order.getSessionId(),
+                order.getTotalAmount(),
+                order.getOrderStatus(),
+                itemCount,
+                order.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminPopularMenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminPopularMenuResponse.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+public record AdminPopularMenuResponse() {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminPopularMenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminPopularMenuResponse.java
@@ -1,4 +1,45 @@
 package dgu.capstone.nunchi.domain.admin.dto.response;
 
-public record AdminPopularMenuResponse() {
+import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 인기 메뉴 응답 DTO")
+public record AdminPopularMenuResponse(
+
+        @Schema(description = "메뉴 ID", example = "1")
+        Long menuId,
+
+        @Schema(description = "메뉴명", example = "제육덮밥")
+        String name,
+
+        @Schema(description = "가격", example = "8500")
+        Integer price,
+
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
+
+        @Schema(description = "판매 수량", example = "12")
+        Long totalQuantity
+) {
+
+    public static AdminPopularMenuResponse fromTopMenuResponse(TopMenuResponse topMenuResponse) {
+        return new AdminPopularMenuResponse(
+                topMenuResponse.menuId(),
+                topMenuResponse.name(),
+                topMenuResponse.price(),
+                topMenuResponse.isSoldOut(),
+                topMenuResponse.quantitySold()
+        );
+    }
+
+    public static AdminPopularMenuResponse fromMenu(Menu menu) {
+        return new AdminPopularMenuResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getIsSoldOut(),
+                null
+        );
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminRecommendedMenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/dto/response/AdminRecommendedMenuResponse.java
@@ -1,0 +1,46 @@
+package dgu.capstone.nunchi.domain.admin.dto.response;
+
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 추천 메뉴 응답 DTO")
+public record AdminRecommendedMenuResponse(
+
+        @Schema(description = "메뉴 ID", example = "1")
+        Long menuId,
+
+        @Schema(description = "메뉴명", example = "제육덮밥")
+        String name,
+
+        @Schema(description = "가격", example = "8500")
+        Integer price,
+
+        @Schema(description = "이미지 URL", example = "https://example.com/jeyuk.jpg")
+        String imageUrl,
+
+        @Schema(description = "카테고리 ID", example = "1")
+        Long categoryId,
+
+        @Schema(description = "카테고리명", example = "덮밥류")
+        String categoryName,
+
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
+
+        @Schema(description = "추천 여부", example = "true")
+        Boolean isRecommended
+) {
+
+    public static AdminRecommendedMenuResponse from(Menu menu) {
+        return new AdminRecommendedMenuResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getImageUrl(),
+                menu.getCategory().getCategoryId(),
+                menu.getCategory().getName(),
+                menu.getIsSoldOut(),
+                menu.getIsRecommended()
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
@@ -1,4 +1,70 @@
 package dgu.capstone.nunchi.domain.admin.service;
 
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminDashboardResponse;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderResponse;
+import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.domain.order.entity.OrderItem;
+import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminDashboardService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final MenuRepository menuRepository;
+
+    public AdminDashboardResponse getDashboard() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = LocalDateTime.of(today, LocalTime.MIN);
+        LocalDateTime endOfDay = LocalDateTime.of(today, LocalTime.MAX);
+
+        Long todayOrderCount = orderRepository.countByCreatedAtBetween(startOfDay, endOfDay);
+
+        Integer todaySalesAmount = orderRepository.sumTotalAmountByCreatedAtBetweenAndOrderStatus(
+                startOfDay,
+                endOfDay,
+                OrderStatus.COMPLETED
+        );
+
+        Long totalOrderCount = orderRepository.count();
+
+        Long soldOutMenuCount = menuRepository.countByIsSoldOutTrue();
+
+        Long recommendedMenuCount = menuRepository.countByIsRecommendedTrue();
+
+        List<AdminOrderResponse> recentOrders = orderRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(0, 5))
+                .stream()
+                .map(order -> {
+                    List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
+
+                    int itemCount = orderItems.stream()
+                            .mapToInt(item -> item.getQuantity() != null ? item.getQuantity() : 0)
+                            .sum();
+
+                    return AdminOrderResponse.from(order, itemCount);
+                })
+                .toList();
+
+        return new AdminDashboardResponse(
+                todayOrderCount,
+                todaySalesAmount,
+                totalOrderCount,
+                soldOutMenuCount,
+                recommendedMenuCount,
+                recentOrders
+        );
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -27,7 +28,7 @@ public class AdminDashboardService {
     private final MenuRepository menuRepository;
 
     public AdminDashboardResponse getDashboard() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         LocalDateTime startOfDay = LocalDateTime.of(today, LocalTime.MIN);
         LocalDateTime endOfDay = LocalDateTime.of(today, LocalTime.MAX);
 

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.service;
+
+public class AdminDashboardService {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminMenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminMenuService.java
@@ -1,0 +1,112 @@
+package dgu.capstone.nunchi.domain.admin.service;
+
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuCreateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuRecommendedUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuSoldOutUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminMenuUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminMenuResponse;
+import dgu.capstone.nunchi.domain.menu.entity.Menu;
+import dgu.capstone.nunchi.domain.menu.entity.MenuCategory;
+import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
+import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminMenuService {
+
+    private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
+
+    public List<AdminMenuResponse> getMenus() {
+        return menuRepository.findAll()
+                .stream()
+                .map(AdminMenuResponse::from)
+                .toList();
+    }
+
+    public AdminMenuResponse getMenu(Long menuId) {
+        Menu menu = findMenu(menuId);
+        return AdminMenuResponse.from(menu);
+    }
+
+    @Transactional
+    public AdminMenuResponse createMenu(AdminMenuCreateRequest request) {
+        MenuCategory category = findCategory(request.categoryId());
+
+        Menu menu = Menu.create(
+                request.name(),
+                request.price(),
+                request.imageUrl(),
+                category
+        );
+
+        if (Boolean.TRUE.equals(request.isSoldOut())) {
+            menu.markSoldOut();
+        }
+
+        if (Boolean.TRUE.equals(request.isRecommended())) {
+            menu.updateRecommended(true);
+        }
+
+        Menu savedMenu = menuRepository.save(menu);
+        return AdminMenuResponse.from(savedMenu);
+    }
+
+    @Transactional
+    public AdminMenuResponse updateMenu(Long menuId, AdminMenuUpdateRequest request) {
+        Menu menu = findMenu(menuId);
+        MenuCategory category = findCategory(request.categoryId());
+
+        menu.updateMenu(
+                request.name(),
+                request.price(),
+                request.imageUrl(),
+                category
+        );
+
+        return AdminMenuResponse.from(menu);
+    }
+
+    @Transactional
+    public AdminMenuResponse updateSoldOut(Long menuId, AdminMenuSoldOutUpdateRequest request) {
+        Menu menu = findMenu(menuId);
+
+        if (Boolean.TRUE.equals(request.isSoldOut())) {
+            menu.markSoldOut();
+        } else {
+            menu.markAvailable();
+        }
+
+        return AdminMenuResponse.from(menu);
+    }
+
+    @Transactional
+    public AdminMenuResponse updateRecommended(Long menuId, AdminMenuRecommendedUpdateRequest request) {
+        Menu menu = findMenu(menuId);
+        menu.updateRecommended(request.isRecommended());
+
+        return AdminMenuResponse.from(menu);
+    }
+
+    @Transactional
+    public void deleteMenu(Long menuId) {
+        Menu menu = findMenu(menuId);
+        menuRepository.delete(menu);
+    }
+
+    private Menu findMenu(Long menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다. menuId=" + menuId));
+    }
+
+    private MenuCategory findCategory(Long categoryId) {
+        return menuCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. categoryId=" + categoryId));
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminMenuService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminMenuService.java
@@ -9,6 +9,8 @@ import dgu.capstone.nunchi.domain.menu.entity.Menu;
 import dgu.capstone.nunchi.domain.menu.entity.MenuCategory;
 import dgu.capstone.nunchi.domain.menu.repository.MenuCategoryRepository;
 import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.global.exception.domainException.MenuException;
+import dgu.capstone.nunchi.global.exception.errorcode.MenuErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,11 +104,11 @@ public class AdminMenuService {
 
     private Menu findMenu(Long menuId) {
         return menuRepository.findById(menuId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다. menuId=" + menuId));
+                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND_MENU));
     }
 
     private MenuCategory findCategory(Long categoryId) {
         return menuCategoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. categoryId=" + categoryId));
+                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND_MENU_CATEGORY));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
@@ -1,4 +1,60 @@
 package dgu.capstone.nunchi.domain.admin.service;
 
+import dgu.capstone.nunchi.domain.admin.dto.request.AdminOrderStatusUpdateRequest;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderDetailResponse;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminOrderResponse;
+import dgu.capstone.nunchi.domain.order.entity.Order;
+import dgu.capstone.nunchi.domain.order.entity.OrderItem;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminOrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    public List<AdminOrderResponse> getOrders() {
+        return orderRepository.findAll()
+                .stream()
+                .map(order -> {
+                    List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
+
+                    int itemCount = orderItems.stream()
+                            .mapToInt(item -> item.getQuantity() != null ? item.getQuantity() : 0)
+                            .sum();
+
+                    return AdminOrderResponse.from(order, itemCount);
+                })
+                .toList();
+    }
+
+    public AdminOrderDetailResponse getOrder(Long orderId) {
+        Order order = findOrder(orderId);
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
+
+        return AdminOrderDetailResponse.from(order, orderItems);
+    }
+
+    @Transactional
+    public AdminOrderDetailResponse updateOrderStatus(Long orderId, AdminOrderStatusUpdateRequest request) {
+        Order order = findOrder(orderId);
+        order.updateStatus(request.orderStatus());
+
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
+
+        return AdminOrderDetailResponse.from(order, orderItems);
+    }
+
+    private Order findOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다. orderId=" + orderId));
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
@@ -7,6 +7,8 @@ import dgu.capstone.nunchi.domain.order.entity.Order;
 import dgu.capstone.nunchi.domain.order.entity.OrderItem;
 import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
 import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import dgu.capstone.nunchi.global.exception.domainException.OrderException;
+import dgu.capstone.nunchi.global.exception.errorcode.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +57,6 @@ public class AdminOrderService {
 
     private Order findOrder(Long orderId) {
         return orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다. orderId=" + orderId));
+                .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_FOUND_ORDER));
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminOrderService.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.service;
+
+public class AdminOrderService {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -32,7 +33,7 @@ public class AdminRecommendationService {
 
     public List<AdminPopularMenuResponse> getTodayPopularMenus() {
         List<TopMenuResponse> topMenus = salesDailyRepository.findTopMenusByDate(
-                LocalDate.now(),
+                LocalDate.now(ZoneId.of("Asia/Seoul")),
                 PageRequest.of(0, 5)
         );
 

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
@@ -1,4 +1,50 @@
 package dgu.capstone.nunchi.domain.admin.service;
 
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminPopularMenuResponse;
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminRecommendedMenuResponse;
+import dgu.capstone.nunchi.domain.menu.dto.response.TopMenuResponse;
+import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import dgu.capstone.nunchi.domain.menu.repository.SalesDailyRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminRecommendationService {
+
+    private final MenuRepository menuRepository;
+    private final SalesDailyRepository salesDailyRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    public List<AdminRecommendedMenuResponse> getDefaultRecommendations() {
+        return menuRepository.findByIsRecommendedTrueAndIsSoldOutFalse()
+                .stream()
+                .map(AdminRecommendedMenuResponse::from)
+                .toList();
+    }
+
+    public List<AdminPopularMenuResponse> getTodayPopularMenus() {
+        List<TopMenuResponse> topMenus = salesDailyRepository.findTopMenusByDate(
+                LocalDate.now(),
+                PageRequest.of(0, 5)
+        );
+
+        return topMenus.stream()
+                .map(AdminPopularMenuResponse::fromTopMenuResponse)
+                .toList();
+    }
+
+    public List<AdminPopularMenuResponse> getOrderBasedPopularMenus() {
+        return orderItemRepository.findPopularMenus(PageRequest.of(0, 5))
+                .stream()
+                .map(AdminPopularMenuResponse::fromMenu)
+                .toList();
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminRecommendationService.java
@@ -1,0 +1,4 @@
+package dgu.capstone.nunchi.domain.admin.service;
+
+public class AdminRecommendationService {
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/entity/Menu.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/entity/Menu.java
@@ -101,6 +101,16 @@ public class Menu extends BaseEntity {
                 .build();
     }
 
+    public void updateMenu(String name, Integer price, String imageUrl, MenuCategory category) {
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.category = category;
+    }
+
+    public void updateRecommended(Boolean isRecommended) {
+        this.isRecommended = isRecommended;
+    }
     public void markSoldOut() {
         this.isSoldOut = true;
     }

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
@@ -20,4 +20,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long>, JpaSpecificat
     // 전체 판매 가능 메뉴 조회
     List<Menu> findByIsSoldOutFalse();
 
+    long countByIsSoldOutTrue();
+
+    long countByIsRecommendedTrue();
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/order/entity/Order.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/entity/Order.java
@@ -46,4 +46,8 @@ public class Order extends BaseEntity {
     public void cancel() {
         this.orderStatus = OrderStatus.CANCELLED;
     }
+
+    public void updateStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderRepository.java
@@ -2,11 +2,34 @@ package dgu.capstone.nunchi.domain.order.repository;
 
 import dgu.capstone.nunchi.domain.order.entity.Order;
 import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findBySessionIdAndOrderStatus(Long sessionId, OrderStatus orderStatus);
+
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    long countByOrderStatus(OrderStatus orderStatus);
+
+    List<Order> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("""
+        SELECT COALESCE(SUM(o.totalAmount), 0)
+        FROM Order o
+        WHERE o.createdAt BETWEEN :start AND :end
+          AND o.orderStatus = :orderStatus
+    """)
+    Integer sumTotalAmountByCreatedAtBetweenAndOrderStatus(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("orderStatus") OrderStatus orderStatus
+    );
 }

--- a/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
+++ b/src/main/java/dgu/capstone/nunchi/global/exception/errorcode/MenuErrorCode.java
@@ -18,6 +18,7 @@ public enum MenuErrorCode implements ErrorCode {
      * 404 NOT_FOUND
      */
     NOT_FOUND_MENU(HttpStatus.NOT_FOUND, 404, "존재하지 않는 메뉴입니다."),
+    NOT_FOUND_MENU_CATEGORY(HttpStatus.NOT_FOUND, 404, "존재하지 않는 메뉴 카테고리입니다."),
     NOT_FOUND_MENU_OPTION(HttpStatus.NOT_FOUND, 404, "존재하지 않는 메뉴 옵션입니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,6 +25,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
+        jdbc:
+          time_zone: Asia/Seoul
     show-sql: false
     open-in-view: false
 


### PR DESCRIPTION
## 📣 Related Issue

- close #59

## 📝 Summary

관리자페이지에서 사용할 백엔드 API를 구현했습니다.

이번 PR에서는 `/api/admin/**` 경로를 기준으로 관리자 전용 API를 분리하고, 메뉴 관리, 주문 관리, 추천 관리, 대시보드 조회 기능을 추가했습니다.

주요 작업 내용은 다음과 같습니다.

- 관리자 메뉴 관리 API 구현
  - 메뉴 목록 조회
  - 메뉴 단건 조회
  - 메뉴 등록
  - 메뉴 수정
  - 메뉴 삭제
  - 품절 상태 변경
  - 추천 상태 변경

- 관리자 주문 관리 API 구현
  - 주문 목록 조회
  - 주문 상세 조회
  - 주문 상태 변경

- 관리자 추천 관리 API 구현
  - 기본 추천 메뉴 조회
  - 오늘 인기 메뉴 조회
  - 주문 기반 인기 메뉴 조회

- 관리자 대시보드 API 구현
  - 오늘 주문 수 조회
  - 오늘 매출 조회
  - 전체 주문 수 조회
  - 품절 메뉴 수 조회
  - 추천 메뉴 수 조회
  - 최근 주문 목록 조회

- 공통 응답 및 예외 처리 정리
  - 기존 프로젝트 응답 형식인 `ApiResponse` 적용
  - `IllegalArgumentException` 대신 `MenuException`, `OrderException` 적용
  - 메뉴 카테고리 없음 예외 코드 추가
  - 대시보드 날짜 기준을 `Asia/Seoul` 기준으로 변경

## 🙏 Question & PR point

- 관리자 API는 기존 키오스크 사용자 API와 분리하기 위해 `/api/admin/**` 경로로 구성했습니다.
- 메뉴, 주문, 추천, 대시보드 기능은 `domain/admin` 아래에 Controller, Service, DTO를 분리해서 구현했습니다.
- 엔티티와 Repository는 기존 `menu`, `order`, `recommendation` 도메인의 구조를 재사용했습니다.
- 메뉴 삭제는 현재 물리 삭제 방식으로 구현되어 있으며, 추후 운영 안정성을 위해 `isActive` 기반 비활성화 방식으로 변경할 수 있습니다.
- 대시보드의 오늘 주문 수와 오늘 매출은 서버 시간 오차를 줄이기 위해 `Asia/Seoul` 기준으로 계산했습니다.
- 인기 메뉴는 `SalesDaily` 기반 오늘 인기 메뉴와 `OrderItem` 기반 주문 누적 인기 메뉴를 분리했습니다.
- 관리자 인증/인가는 별도 이슈(`#61`)에서 관리자 비밀번호 기반 JWT 인증 방식으로 구현할 예정입니다.

## 📬 Postman

Swagger를 통해 다음 API 동작을 확인했습니다.

- `GET /api/admin/menus`
- `GET /api/admin/menus/{menuId}`
- `POST /api/admin/menus`
- `PATCH /api/admin/menus/{menuId}`
- `PATCH /api/admin/menus/{menuId}/sold-out`
- `PATCH /api/admin/menus/{menuId}/recommended`
- `DELETE /api/admin/menus/{menuId}`
- `GET /api/admin/orders`
- `GET /api/admin/orders/{orderId}`
- `PATCH /api/admin/orders/{orderId}/status`
- `GET /api/admin/recommendations/default`
- `GET /api/admin/recommendations/popular/today`
- `GET /api/admin/recommendations/popular/orders`
- `GET /api/admin/dashboard`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드 추가 - 오늘의 주문 수, 매출, 전체 주문 통계, 품절/추천 메뉴 수 조회
  * 관리자 메뉴 관리 기능 추가 - 메뉴 조회, 생성, 수정, 삭제 및 품절/추천 상태 관리
  * 관리자 주문 관리 기능 추가 - 전체 주문 조회, 상세 정보 확인, 주문 상태 업데이트
  * 인기 메뉴 및 추천 메뉴 조회 기능 추가 - 기본 추천 메뉴, 일일 인기 메뉴, 주문 기반 인기 메뉴 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->