### PR TITLE
[Feat] N02-menu 백엔드 API 연결 (#72)

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/MenuResponse.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/dto/response/MenuResponse.java
@@ -13,13 +13,17 @@ public record MenuResponse(
         String name,
         Integer price,
         Boolean isSoldOut,
+        Boolean isRecommended,
         String imageUrl,
         Integer spicyLevel,
         TemperatureType temperatureType,
         VegetarianType vegetarianType,
         Season seasonRecommended,
         Set<AllergyType> allergies,
-        Integer calorie
+        Integer calorie,
+        Integer floor,
+        String restaurantName,
+        String operatingHours
 ) {
 
     public static MenuResponse from(Menu menu) {
@@ -28,13 +32,17 @@ public record MenuResponse(
                 menu.getName(),
                 menu.getPrice(),
                 menu.getIsSoldOut(),
+                menu.getIsRecommended(),
                 menu.getImageUrl(),
                 menu.getSpicyLevel(),
                 menu.getTemperatureType(),
                 menu.getVegetarianType(),
                 menu.getSeasonRecommended(),
                 new java.util.HashSet<>(menu.getAllergies()),
-                menu.getNutrition() != null ? menu.getNutrition().getCalorie() : null
+                menu.getNutrition() != null ? menu.getNutrition().getCalorie() : null,
+                menu.getFloor(),
+                menu.getRestaurantName(),
+                menu.getOperatingHours()
         );
     }
 }

--- a/src/main/resources/static/front/js/common/api.js
+++ b/src/main/resources/static/front/js/common/api.js
@@ -1,0 +1,165 @@
+// ========================================================
+// api.js — NUNCHI 공통 백엔드 API 클라이언트
+// 책임:
+//   - 모든 fetch 호출의 단일 진입점
+//   - ApiResponse<T> ({ code, msg, data }) 자동 언래핑 → data 만 반환
+//   - HTTP/비즈니스 에러 표준화 → ApiError 로 throw
+//   - 도메인별 호출 헬퍼 제공 (session / menu / cart / order / payment / recommend)
+//
+// 사용:
+//   <script src="/js/common/api.js"></script>
+//   const session = await Api.session.create({ mode: "NORMAL", language: "ko" });
+//   sessionStorage.setItem("sessionId", session.sessionId);
+//
+// 약속:
+//   - Spring Boot 가 정적 리소스도 함께 서빙하므로 same-origin → BASE_URL 비움
+//   - 페이지 JS 에서 fetch() 직접 호출 금지. 무조건 이 모듈 경유.
+//   - 새 도메인/엔드포인트가 생기면 이 파일에만 추가하고 페이지 JS 는 헬퍼만 호출.
+// ========================================================
+
+(function () {
+    'use strict';
+
+    const LOG = '[Api]';
+    const BASE_URL = ''; // same-origin
+
+    // ---------- 에러 타입 ----------
+    /** 서버가 ApiResponse 포맷으로 돌려준 4xx/5xx 또는 네트워크 실패. */
+    class ApiError extends Error {
+        constructor(code, msg, status, path) {
+            super(msg || '요청 처리 중 오류가 발생했습니다.');
+            this.name = 'ApiError';
+            this.code = code;     // 서버 ApiResponse.code (없으면 HTTP status)
+            this.status = status; // HTTP status
+            this.path = path;
+        }
+    }
+
+    // ---------- 저레벨 fetch 래퍼 ----------
+    async function request(method, path, body) {
+        const url = BASE_URL + path;
+        const init = {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+        };
+        if (body !== undefined && body !== null) {
+            init.body = JSON.stringify(body);
+        }
+
+        let res;
+        try {
+            res = await fetch(url, init);
+        } catch (networkErr) {
+            console.error(LOG, method, path, '네트워크 실패', networkErr);
+            throw new ApiError(0, '서버에 연결할 수 없습니다.', 0, path);
+        }
+
+        // 204 No Content / 본문 없는 응답 방어
+        let json = null;
+        const text = await res.text();
+        if (text) {
+            try { json = JSON.parse(text); }
+            catch (e) {
+                console.error(LOG, method, path, 'JSON 파싱 실패', text);
+                throw new ApiError(res.status, '응답 파싱에 실패했습니다.', res.status, path);
+            }
+        }
+
+        if (!res.ok) {
+            const code = json && typeof json.code === 'number' ? json.code : res.status;
+            const msg  = (json && json.msg) || ('HTTP ' + res.status);
+            console.warn(LOG, method, path, '실패', { status: res.status, code, msg });
+            throw new ApiError(code, msg, res.status, path);
+        }
+
+        // ApiResponse<T> 언래핑: { code, msg, data } → data
+        const data = json && Object.prototype.hasOwnProperty.call(json, 'data') ? json.data : json;
+        if (window.__NUNCHI_API_DEBUG__) {
+            console.debug(LOG, method, path, data);
+        }
+        return data;
+    }
+
+    const get   = (path)        => request('GET',    path);
+    const post  = (path, body)  => request('POST',   path, body);
+    const put   = (path, body)  => request('PUT',    path, body);
+    const patch = (path, body)  => request('PATCH',  path, body);
+    const del   = (path)        => request('DELETE', path);
+
+    // ---------- 도메인 헬퍼 ----------
+
+    // /api/sessions
+    const session = {
+        /** @param {{mode:"NORMAL"|"AVATAR", language?:string}} body */
+        create(body)               { return post('/api/sessions', body); },
+        complete(sessionId)        { return patch(`/api/sessions/${sessionId}/complete`); },
+        saveMessage(sessionId, b)  { return post(`/api/sessions/${sessionId}/messages`, b); },
+        saveToolLog(sessionId, b)  { return post(`/api/sessions/${sessionId}/tool-logs`, b); },
+        getToolLogs(sessionId, limit = 50) {
+            return get(`/api/sessions/${sessionId}/tool-logs?limit=${limit}`);
+        },
+    };
+
+    // /api/menus
+    const menu = {
+        categories()               { return get('/api/menus/categories'); },
+        list(categoryId)           {
+            const q = categoryId != null ? `?categoryId=${categoryId}` : '';
+            return get('/api/menus' + q);
+        },
+        detail(menuId)             { return get(`/api/menus/${menuId}`); },
+        top(limit = 5)             { return get(`/api/menus/top?limit=${limit}`); },
+    };
+
+    // /api/orders/cart, /api/orders/confirm, /api/orders/{id}/cancel
+    const cart = {
+        get(sessionId)             { return get(`/api/orders/cart/${sessionId}`); },
+        /** @param {{sessionId:number, menuId:number, quantity:number, optionIds:number[]}} body */
+        addItem(body)              { return post('/api/orders/cart/items', body); },
+        /** itemId 는 서버가 발급한 UUID 문자열 */
+        updateItem(sessionId, itemId, quantity) {
+            return put(`/api/orders/cart/${sessionId}/items/${itemId}`, { quantity });
+        },
+        removeItem(sessionId, itemId) {
+            return del(`/api/orders/cart/${sessionId}/items/${itemId}`);
+        },
+    };
+
+    const order = {
+        confirm(sessionId)         { return post('/api/orders/confirm', { sessionId }); },
+        cancel(orderId)            { return patch(`/api/orders/${orderId}/cancel`); },
+    };
+
+    // /api/payments
+    const payment = {
+        /** @param {{orderId:number, method:"IC_CARD"|"VEIN"|string}} body */
+        request(body)              { return post('/api/payments', body); },
+        success(paymentId)         { return patch(`/api/payments/${paymentId}/success`); },
+        fail(paymentId)            { return patch(`/api/payments/${paymentId}/fail`); },
+        get(paymentId)             { return get(`/api/payments/${paymentId}`); },
+    };
+
+    // /api/recommendations
+    const recommend = {
+        /** @param {"DEFAULT"|"CATEGORY"|"POPULAR"} type */
+        get(type, categoryId) {
+            const q = categoryId != null
+                ? `?type=${type}&categoryId=${categoryId}`
+                : `?type=${type}`;
+            return get('/api/recommendations' + q);
+        },
+    };
+
+    // ---------- 글로벌 노출 ----------
+    const Api = {
+        ApiError,
+        get, post, put, patch, del,
+        session, menu, cart, order, payment, recommend,
+    };
+
+    window.NunchiApi = Api;
+    window.Api = Api; // 짧은 별칭 (페이지 JS 에서 권장)
+
+    // 디버그 모드 토글: 콘솔에서 window.__NUNCHI_API_DEBUG__ = true
+})();

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -205,10 +205,14 @@
                 .map((i) => `${i.name}(${i.origin})`)
                 .join(" · ") + (meta.ingredients.length > 2 ? " 외" : "");
 
+            const thumbStyle = m.imageUrl
+                ? `style="background-image:url('${m.imageUrl}');background-size:cover;background-position:center;"`
+                : "";
+
             return `
                 <li class="n02__menu-card ${inCart ? "n02__menu-card--in-cart" : ""} ${m.soldOut ? "n02__menu-card--sold-out" : ""}"
                     data-menu="${m.id}">
-                    <div class="n02__menu-card-thumb" data-detail-trigger="${m.id}">
+                    <div class="n02__menu-card-thumb" data-detail-trigger="${m.id}" ${thumbStyle}>
                         ${m.aiPick ? `
                             <span class="n02__menu-card-ai-badge">
                                 <i class="xi xi-lightning"></i>AI 추천
@@ -315,9 +319,14 @@
         $detailPrice.textContent = fmt(m.price);
         $detailDesc.textContent  = meta.description;
 
-        // 사진 placeholder — 메뉴명 텍스트
-        $detailHero.style.background =
-            "linear-gradient(135deg, var(--neutral-200), var(--neutral-300))";
+        // 사진 — 등록된 imageUrl 우선, 없으면 placeholder 그라데이션
+        if (m.imageUrl) {
+            $detailHero.style.background =
+                "url('" + m.imageUrl + "') center/cover no-repeat";
+        } else {
+            $detailHero.style.background =
+                "linear-gradient(135deg, var(--neutral-200), var(--neutral-300))";
+        }
 
         // 메뉴 구성 칩
         $detailComps.innerHTML = meta.components
@@ -613,13 +622,36 @@
     }
 
     // ---------- 초기화 ----------
-    function bootstrap() {
+    async function bootstrap() {
         loadSession();
+        sessionStorage.setItem("currentStep", "N02");
 
-        // 매장 브랜드명
+        // 매장 브랜드명 (API 로드 전에도 표시)
         $brand.textContent = window.MenuData.data.brand;
 
-        // 기본 위치 = 1층 / 첫 식당 (세션값이 유효하면 그대로)
+        // 채팅/이벤트는 데이터 로드와 무관하게 먼저 세팅
+        renderChatInitial();
+        renderCartBar();
+        bindEvents();
+
+        // 백엔드에서 메뉴 트리 로드
+        try {
+            await window.MenuData.load();
+        } catch (e) {
+            console.error("[N02] 메뉴 로드 실패", e);
+            $menuEmpty.hidden = false;
+            $menuEmpty.querySelector("p").textContent =
+                "메뉴를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.";
+            return;
+        }
+
+        // 데이터가 비어 있으면 빈 상태
+        if (!window.MenuData.data.floors.length) {
+            $menuEmpty.hidden = false;
+            return;
+        }
+
+        // 기본 위치 = 첫 층 / 첫 식당 (세션값이 유효하면 그대로)
         if (!state.currentFloorId || !getFloor(state.currentFloorId)) {
             state.currentFloorId = window.MenuData.data.floors[0].id;
         }
@@ -628,15 +660,11 @@
             state.currentStoreId = f && f.stores[0] ? f.stores[0].id : null;
         }
         persistFloorStore();
-        sessionStorage.setItem("currentStep", "N02");
 
         renderFloorTabs();
         renderStoreList();
         renderMenuGrid();
         renderCartBar();
-        renderChatInitial();
-
-        bindEvents();
 
         // 운영 상태는 1분마다 갱신
         setInterval(renderStoreList, 60 * 1000);

--- a/src/main/resources/static/front/js/flowN/menu-data.js
+++ b/src/main/resources/static/front/js/flowN/menu-data.js
@@ -1,132 +1,134 @@
 // ========================================================
-// menu-data.js — 상록원 식당 · 메뉴 데이터 단일 소스
+// menu-data.js — 상록원 식당 · 메뉴 데이터 어댑터
 // 사용처: N02-menu (목록 + 상세 오버레이) 및 향후 P01 요약
 //
-// 구조:
-//   window.__MENU_DATA__ = {
-//       brand, floors[ { id, label, stores[ { id, name, hours, menus[] } ] } ]
-//   }
+// 책임:
+//   - GET /api/menus 호출 → floors[ stores[ menus[] ] ] 트리 변환
+//   - 운영시간 문자열 형식 정규화 ("11:00-14:00,15:00-16:00" → "11:00~14:00 / 15:00~16:00")
+//   - 카테고리 키워드 기반 메뉴 메타(설명/구성/원산지/영양) 추정 — 백엔드 메타 보강 전까지 사용
 //
-// 메뉴 객체 필드:
-//   id          숫자 ID
-//   name        메뉴명
-//   price       원
-//   aiPick      (옵션) AI 추천 뱃지
-//   badge       (옵션) "한정판매" 등 추가 뱃지 텍스트
-//   dailyDate   (옵션, store 레벨에서도 사용) "03/25(수)" 등 변동 메뉴 날짜 표기
-//               → store 레벨에 있으면 N02 매장 사이드바에 "오늘 (MM/DD 요일)" 라벨로 표시
-//               → TODO(후속): 백엔드 일별 메뉴 API 연동 후 하드코딩 값 제거
-//   soldOut     (옵션) 품절
-//
-// 상세(메뉴구성/원산지/영양정보)는 buildMenuMeta(menu) 가
-// 메뉴명 키워드를 기반으로 카테고리를 추정해 자동 생성한다.
+// 외부 노출:
+//   await window.MenuData.load();     // 최초 1회 호출
+//   window.MenuData.data              // { brand, floors[] }
+//   window.MenuData.findMenuById(id)  // {menu, store, floor}
+//   window.MenuData.buildMenuMeta(m)  // {description, components, ingredients, nutrition}
+//   window.MenuData.isOpenNow(hours)  // boolean
+//   window.MenuData.formatPrice(won)  // "₩ 5,000"
 // ========================================================
 
 (function () {
     'use strict';
 
-    // -------- 1. 사용자 제공 실제 메뉴 데이터 --------
+    // -------- 1. 빈 데이터 컨테이너 (load() 호출 전) --------
     const DATA = {
         brand: "상록원",
-        floors: [
-            {
-                id: "F1", label: "1층",
-                stores: [
-                    {
-                        id: "sotn-noodle",
-                        name: "솥앤누들",
-                        hours: "11:00~19:00",
-                        menus: [
-                            { id: 101, name: "삼겹살김치철판",  price: 6000 },
-                            { id: 102, name: "치즈불닭철판",    price: 7000, aiPick: true },
-                            { id: 103, name: "데리야끼치킨솥밥", price: 5700 },
-                            { id: 104, name: "숯불삼겹솥밥",    price: 5000 },
-                            { id: 105, name: "우삼겹솥밥",      price: 6500 },
-                            { id: 106, name: "콘치즈솥밥",      price: 5000 },
-                            { id: 107, name: "우동",            price: 5000 },
-                            { id: 108, name: "우동·돈가스 set", price: 6800 },
-                            { id: 109, name: "우동·알밥 set",   price: 6500 },
-                            { id: 110, name: "철판치즈돈가스",  price: 7000 },
-                            { id: 111, name: "낙지삼겹솥밥",    price: 6500 },
-                        ],
-                    },
-                    {
-                        id: "bunsik",
-                        name: "분식당",
-                        hours: "10:00~14:00",
-                        menus: [
-                            { id: 121, name: "추억의도시락", price: 4000 },
-                            { id: 122, name: "계란라면",     price: 3800 },
-                            { id: 123, name: "치즈라면",     price: 4000 },
-                            { id: 124, name: "해장라면",     price: 4000 },
-                            { id: 125, name: "공기밥",       price: 1000 },
-                        ],
-                    },
-                ],
-            },
-            {
-                id: "F2", label: "2층",
-                stores: [
-                    {
-                        id: "ilpum",
-                        name: "일품",
-                        hours: "11:00~14:00 / 15:00~16:00",
-                        dailyDate: "03/25(수)",
-                        menus: [
-                            { id: 201, name: "매콤제육덮밥·핫도그·자율배식·배추김치/단무지", price: 4500 },
-                        ],
-                    },
-                    {
-                        id: "yang",
-                        name: "양식",
-                        hours: "11:00~14:00",
-                        dailyDate: "03/25(수)",
-                        menus: [
-                            { id: 211, name: "치즈돈까스",            price: 6300 },
-                            { id: 212, name: "토마토파스타·마늘빵",   price: 6000 },
-                            { id: 213, name: "치즈오븐파스타",        price: 6500, badge: "한정판매" },
-                        ],
-                    },
-                    {
-                        id: "deojinguk",
-                        name: "더진국",
-                        hours: "11:00~14:00 / 15:00~16:00",
-                        menus: [
-                            { id: 221, name: "수육국밥·순대국밥", price: 6800 },
-                            { id: 222, name: "얼큰국밥",          price: 7000 },
-                        ],
-                    },
-                ],
-            },
-            {
-                id: "F3", label: "3층",
-                stores: [
-                    {
-                        id: "jipbap",
-                        name: "집밥",
-                        hours: "11:00~14:00 / 17:00~19:00",
-                        dailyDate: "03/25(수)",
-                        menus: [
-                            { id: 301, name: "[중식] 샤브칼국수·삼겹살수육·도토리묵상추무침·샐러드·배추김치", price: 7000 },
-                            { id: 302, name: "[석식] 파채고추장삼겹살·치킨너겟·미역줄기볶음·샐러드·배추김치", price: 7000 },
-                        ],
-                    },
-                    {
-                        id: "hangreut",
-                        name: "한그릇",
-                        hours: "12:00~14:00",
-                        dailyDate: "03/25(수)",
-                        menus: [
-                            { id: 311, name: "[중식] 카레&그릴소세지·통새우볼튀김·마시는요플레·배추김치", price: 7000, badge: "한정판매" },
-                        ],
-                    },
-                ],
-            },
-        ],
+        floors: [],
     };
 
-    // -------- 2. 메뉴 카테고리 추정 --------
-    // 가장 먼저 매칭된 카테고리를 사용 (배열 순서 = 우선순위)
+    // -------- 2. 운영시간 형식 변환 (DB → 화면 표기) --------
+    // DB:    "11:00-14:00,15:00-16:00"
+    // 화면:  "11:00~14:00 / 15:00~16:00"
+    function normalizeHours(raw) {
+        if (!raw) return "";
+        return String(raw)
+            .split(",")
+            .map((s) => s.trim().replace(/-/g, "~"))
+            .filter(Boolean)
+            .join(" / ");
+    }
+
+    // -------- 3. 층 라벨 ("1층", "지하1층" 등) --------
+    function floorLabel(floorNum) {
+        if (floorNum == null) return "기타";
+        if (floorNum < 0) return "지하" + Math.abs(floorNum) + "층";
+        return floorNum + "층";
+    }
+
+    function floorId(floorNum) {
+        if (floorNum == null) return "F0";
+        if (floorNum < 0) return "B" + Math.abs(floorNum);
+        return "F" + floorNum;
+    }
+
+    function storeIdFrom(floorNum, restaurantName) {
+        const safe = String(restaurantName || "unknown")
+            .replace(/\s+/g, "-")
+            .toLowerCase();
+        return floorId(floorNum) + "-" + safe;
+    }
+
+    // -------- 4. API 응답 → floors[ stores[ menus[] ] ] 그룹핑 --------
+    // floor / restaurantName 가 null 인 메뉴는 "추가메뉴" 로 분류되어 N02 트리에서 제외.
+    // (추가메뉴는 향후 별도 UI 에서 표시)
+    function groupMenus(apiMenus) {
+        // floor → restaurantName → menus[]
+        const floorMap = new Map();
+
+        for (const m of apiMenus) {
+            if (m.floor == null || !m.restaurantName) continue;
+
+            const fNum  = m.floor;
+            const rName = m.restaurantName;
+            const fKey  = floorId(fNum);
+
+            if (!floorMap.has(fKey)) {
+                floorMap.set(fKey, {
+                    id:     fKey,
+                    num:    fNum,
+                    label:  floorLabel(fNum),
+                    stores: new Map(),
+                });
+            }
+            const floor = floorMap.get(fKey);
+
+            const sKey = storeIdFrom(fNum, rName);
+            if (!floor.stores.has(sKey)) {
+                floor.stores.set(sKey, {
+                    id:    sKey,
+                    name:  rName,
+                    hours: normalizeHours(m.operatingHours),
+                    menus: [],
+                });
+            }
+            const store = floor.stores.get(sKey);
+
+            store.menus.push({
+                id:       m.menuId,
+                name:     m.name,
+                price:    m.price,
+                imageUrl: m.imageUrl,
+                aiPick:   !!m.isRecommended,
+                soldOut:  !!m.isSoldOut,
+                allergies:    m.allergies || [],
+                spicyLevel:   m.spicyLevel,
+                temperature:  m.temperatureType,
+                calorie:      m.calorie,
+            });
+        }
+
+        // Map → 정렬된 배열 (층 번호 오름차순)
+        const floors = Array.from(floorMap.values())
+            .sort((a, b) => (a.num ?? 99) - (b.num ?? 99))
+            .map((f) => ({
+                id:     f.id,
+                label:  f.label,
+                stores: Array.from(f.stores.values()),
+            }));
+
+        return floors;
+    }
+
+    // -------- 5. API 로드 --------
+    async function load() {
+        if (!window.Api || !window.Api.menu) {
+            throw new Error("Api 모듈이 로드되지 않았습니다. api.js 를 먼저 포함해 주세요.");
+        }
+        const apiMenus = await window.Api.menu.list();
+        DATA.floors = groupMenus(apiMenus || []);
+        return DATA;
+    }
+
+    // -------- 6. 메뉴 카테고리 추정 (메뉴명 키워드) --------
     const CATEGORY_RULES = [
         { id: "ramen",       keywords: ["라면"] },
         { id: "udon",        keywords: ["우동"] },
@@ -143,7 +145,7 @@
     ];
 
     function detectCategory(menu) {
-        const name = menu.name;
+        const name = menu.name || "";
         for (const rule of CATEGORY_RULES) {
             if (rule.keywords.some((kw) => name.toLowerCase().indexOf(kw.toLowerCase()) >= 0)) {
                 return rule.id;
@@ -152,10 +154,7 @@
         return "etc";
     }
 
-    // -------- 3. 카테고리별 데모 메타데이터 템플릿 --------
-    // - components: 메뉴구성 칩에 표시될 구성품
-    // - ingredients: 원재료/원산지 (기본 국내산, true면 수입산으로 표시)
-    // - nutritionRatio: 가격에 비례해서 칼로리/영양소 추정에 쓰임 (대략적)
+    // -------- 7. 카테고리별 메타 템플릿 (백엔드 메타 보강 전 임시) --------
     const META_BY_CATEGORY = {
         ramen: {
             description: "얼큰한 국물에 쫄깃한 면발을 즐기는 따끈한 한 그릇",
@@ -309,18 +308,17 @@
         },
     };
 
-    // -------- 4. 메타 빌더 --------
+    // -------- 8. 메타 빌더 --------
     function buildMenuMeta(menu) {
         const cat = detectCategory(menu);
         const tpl = META_BY_CATEGORY[cat] || META_BY_CATEGORY.etc;
 
-        // 가격에 비례해서 영양소를 ±10% 흔들어 다양성 부여 (결정론적)
-        const seed = (menu.id % 7) - 3;          // -3 ~ +3
-        const factor = 1 + (seed * 0.03);        // 0.91 ~ 1.09
-
+        // 영양: 백엔드 calorie 가 있으면 그걸 사용, 없으면 카테고리 베이스에 ID 기반 ±10% 흔들림
+        const seed = (Number(menu.id) % 7) - 3;
+        const factor = 1 + (seed * 0.03);
         const n = tpl.nutritionBase;
         const nutrition = {
-            kcal:    Math.round(n.kcal    * factor / 10) * 10,
+            kcal:    menu.calorie != null ? menu.calorie : Math.round(n.kcal * factor / 10) * 10,
             protein: Math.round(n.protein * factor),
             carb:    Math.round(n.carb    * factor),
             fat:     Math.round(n.fat     * factor),
@@ -335,7 +333,7 @@
         };
     }
 
-    // -------- 5. 운영 시간 파싱 → 현재 운영중 여부 --------
+    // -------- 9. 운영 시간 파싱 → 현재 운영중 여부 --------
     // hours 예: "11:00~19:00", "11:00~14:00 / 15:00~16:00"
     function parseHoursToRanges(hoursStr) {
         if (!hoursStr) return [];
@@ -350,23 +348,26 @@
     }
 
     function isOpenNow(hoursStr, now) {
+        const ranges = parseHoursToRanges(hoursStr);
+        if (ranges.length === 0) return true; // 운영시간 미등록은 일단 운영중으로 표시
         const date = now || new Date();
         const cur = date.getHours() * 60 + date.getMinutes();
-        return parseHoursToRanges(hoursStr).some(function (r) {
+        return ranges.some(function (r) {
             return cur >= r.startMin && cur < r.endMin;
         });
     }
 
-    // -------- 6. 헬퍼 --------
+    // -------- 10. 헬퍼 --------
     function formatPrice(won) {
-        return "₩ " + Number(won).toLocaleString("ko-KR");
+        return "₩ " + Number(won || 0).toLocaleString("ko-KR");
     }
 
     function findMenuById(id) {
+        const target = Number(id);
         for (const f of DATA.floors) {
             for (const s of f.stores) {
                 for (const m of s.menus) {
-                    if (m.id === id) {
+                    if (Number(m.id) === target) {
                         return { menu: m, store: s, floor: f };
                     }
                 }
@@ -375,10 +376,11 @@
         return null;
     }
 
-    // -------- 7. 외부 노출 --------
+    // -------- 11. 외부 노출 --------
     window.__MENU_DATA__ = DATA;
     window.MenuData = {
         data: DATA,
+        load: load,
         buildMenuMeta: buildMenuMeta,
         isOpenNow: isOpenNow,
         formatPrice: formatPrice,

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -283,6 +283,7 @@
 </main>
 
 <script src="/lib/jquery-3.7.0.min.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/flowN/menu-data.js"></script>
 <script src="/js/flowN/N02-menu.js"></script>
 </body>


### PR DESCRIPTION
- MenuResponse 에 floor / restaurantName / operatingHours / isRecommended 필드 추가
- menu-data.js 를 GET /api/menus 호출 어댑터로 재작성 (하드코딩 제거, floor→store→menu 트리 그룹핑, 운영시간 형식 정규화)
- N02-menu.js bootstrap 비동기화 + 카드/상세에 imageUrl 반영, 로드 실패 시 빈 상태
- N02-menu.html 에 /js/common/api.js 추가
- floor 또는 restaurantName 미라벨링 메뉴는 N02 트리에서 제외 (추가메뉴 영역 별도 예정)

## 📣 Related Issue

- close #72

## 📝 Summary

### 백엔드
- `MenuResponse` DTO 에 `floor` / `restaurantName` / `operatingHours` / `isRecommended` 필드 추가하여 `GET /api/menus` 응답에 노출

### 프론트엔드
- `menu-data.js` 를 API 어댑터로 재작성
  - 하드코딩된 더미 데이터 제거
  - `Api.menu.list()` 응답을 `floor → store → menu` 트리로 동적 그룹핑
  - 운영시간 형식 정규화 (`-` → `~`, `,` → ` / `)
- `N02-menu.js` `bootstrap()` 비동기화 + 로드 실패 시 빈 상태 표시
- 메뉴 카드 썸네일 / 상세 hero 에 `imageUrl` 반영
- `N02-menu.html` 에 `/js/common/api.js` 스크립트 포함
- `floor` 또는 `restaurantName` 미라벨링 메뉴는 N02 트리에서 제외 (추가메뉴 영역 추후 별도 분리)

### DB 라벨링 보완
- 1층 분식당 식당으로 메뉴 5개 편성 (스팸도시락 / 계란라면 / 치즈라면 / 해장라면 / 공기밥, 운영시간 `10:00-14:00`)

## 🙏 Question & PR point

- `MenuResponse` 에 새 필드 4개를 추가했습니다. 이 DTO 를 사용하는 곳은 `MenuService.getMenus()` / `searchMenus()` 두 군데뿐이며 `MenuResponse.from()` 정적 팩토리만 사용해 영향 범위는 안전합니다.
- `floor` / `restaurantName` 이 `null` 인 메뉴는 N02 화면에 노출되지 않습니다. 음료·소시지·해시브라운 등 부속 메뉴는 추후 "추가메뉴" 영역 작업에서 처리 예정입니다.
- DB 의 `image_url` 중 영문 파일명 경로(`/images/menu/jangjorim_butter.jpg` 등)는 정적 리소스에 실제 파일이 없어 404 입니다. 한글 카테고리 폴더 경로(`/images/menu/덮밥류/가츠동.png`)만 정상 로드됩니다 — DB 데이터 정정 후속 필요.
- 1층 솥앤누들 등 일부 식당의 `operating_hours` 가 비어 있어 "운영중" 으로만 표기됩니다 (어댑터의 안전 fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메뉴 시스템이 실시간 서버 데이터를 로드하도록 개선되었습니다.
  * 메뉴 항목에 실제 이미지가 표시됩니다.
  * 메뉴 상세 정보 추가: 매운맛 수준, 채식 여부, 칼로리, 알레르기, 층 정보, 영업 시간.

* **버그 수정**
  * 메뉴 로드 실패 시 오류 상태 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->