### PR TITLE
[Feat] flowP 결제 플로우 백엔드 연결 + N02 카트 서버 통합

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/service/OrderService.java
@@ -27,7 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -68,21 +70,48 @@ public class OrderService {
             }
         }
 
-        // 새 CartItem 생성
-        CartItem newItem = CartItem.builder()
-                .itemId(UUID.randomUUID().toString())
-                .menuId(menu.getMenuId())
-                .menuName(menu.getName())
-                .unitPrice(menu.getPrice())
-                .quantity(request.quantity())
-                .options(cartOptions)
-                .build();
+        // 같은 메뉴 + 동일 옵션 조합이 이미 있으면 수량만 증가, 없으면 새 라인 추가
+        List<CartItem> items = new ArrayList<>(cartRedisRepository.getItems(request.sessionId()));
+        Set<Long> newOptionIds = cartOptions.stream()
+                .map(CartItem.CartOption::getOptionId)
+                .collect(Collectors.toSet());
 
-        // 기존 장바구니에 추가 후 저장
-        List<CartItem> items = cartRedisRepository.getItems(request.sessionId());
-        items.add(newItem);
+        int existingIdx = -1;
+        for (int i = 0; i < items.size(); i++) {
+            CartItem it = items.get(i);
+            if (!it.getMenuId().equals(menu.getMenuId())) continue;
+            Set<Long> existingOptionIds = (it.getOptions() == null ? List.<CartItem.CartOption>of() : it.getOptions()).stream()
+                    .map(CartItem.CartOption::getOptionId)
+                    .collect(Collectors.toSet());
+            if (existingOptionIds.equals(newOptionIds)) {
+                existingIdx = i;
+                break;
+            }
+        }
+
+        if (existingIdx >= 0) {
+            CartItem prev = items.get(existingIdx);
+            CartItem merged = CartItem.builder()
+                    .itemId(prev.getItemId())
+                    .menuId(prev.getMenuId())
+                    .menuName(prev.getMenuName())
+                    .unitPrice(prev.getUnitPrice())
+                    .quantity(prev.getQuantity() + request.quantity())
+                    .options(prev.getOptions())
+                    .build();
+            items.set(existingIdx, merged);
+        } else {
+            items.add(CartItem.builder()
+                    .itemId(UUID.randomUUID().toString())
+                    .menuId(menu.getMenuId())
+                    .menuName(menu.getName())
+                    .unitPrice(menu.getPrice())
+                    .quantity(request.quantity())
+                    .options(cartOptions)
+                    .build());
+        }
+
         cartRedisRepository.saveItems(request.sessionId(), items);
-
         return CartResponse.from(request.sessionId(), items);
     }
 

--- a/src/main/resources/static/front/js/S01-mode.js
+++ b/src/main/resources/static/front/js/S01-mode.js
@@ -12,7 +12,8 @@
             console.warn("[S01] unknown mode:", mode);
             return;
         }
-        sessionStorage.setItem("mode", mode);
+        // 백엔드 SessionMode enum 형식(대문자)으로 저장
+        sessionStorage.setItem("mode", mode.toUpperCase());
         sessionStorage.setItem("currentStep", "S02");
         location.href = NEXT_URL;
     }

--- a/src/main/resources/static/front/js/S02-dine.js
+++ b/src/main/resources/static/front/js/S02-dine.js
@@ -7,9 +7,10 @@
 
 (function () {
     function getNextUrl() {
-        var mode = sessionStorage.getItem("mode");
-        if (mode === "avatar") return "/flowA/A01-avatar.html";
-        if (mode === "normal") return "/flowN/N02-menu.html";
+        // 백엔드 SessionMode enum 형식(대문자)으로 통일. 옛 소문자 잔여물도 호환.
+        var mode = (sessionStorage.getItem("mode") || "").toUpperCase();
+        if (mode === "AVATAR") return "/flowA/A01-avatar.html";
+        if (mode === "NORMAL") return "/flowN/N02-menu.html";
         // mode 가 없거나 잘못된 값 → 모드 선택으로 복귀
         return "/S01-mode.html";
     }

--- a/src/main/resources/static/front/js/common/api-client.js
+++ b/src/main/resources/static/front/js/common/api-client.js
@@ -84,9 +84,11 @@
             throw new NunchiApiError(msg, { httpStatus: res.status, code, msg, body: payload });
         }
 
-        // 성공 응답이라도 ApiResponse code 가 200 이 아니면 실패로 처리
+        // 성공 응답: ApiResponse.code 가 2xx 이면 통과 (ok=200, created=201, noContent=204 등)
         if (payload && typeof payload === 'object' && 'code' in payload) {
-            if (payload.code !== 200 && payload.code !== '200') {
+            const codeNum = Number(payload.code);
+            const isSuccessCode = Number.isFinite(codeNum) && codeNum >= 200 && codeNum < 300;
+            if (!isSuccessCode) {
                 throw new NunchiApiError(payload.msg || '비즈니스 오류', {
                     httpStatus: res.status, code: payload.code, msg: payload.msg, body: payload
                 });

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -3,13 +3,16 @@
 // 책임:
 //   - 층 탭 / 식당 사이드바 / 메뉴 그리드 렌더링
 //   - 운영시간 기반 자동 운영중·마감 표시
-//   - 카트 추가/수량/삭제 + 카드 강조 + 카트 바 갱신
+//   - 서버 Redis 장바구니 추가/수량/삭제 + 카드 강조 + 카트 바 갱신
 //   - 메뉴 상세 풀스크린 오버레이 오픈/클로즈
 //   - AI 대화 기록 패널 슬라이드 토글
-//   - 모든 액션을 ai-chat 메시지로 로깅
 //
-// 의존: window.MenuData (menu-data.js)
-// 세션 키: cart, currentFloor, currentStore (sessionStorage)
+// 의존: window.MenuData (menu-data.js), window.Api (api.js)
+// 세션 키: sessionId, mode, currentFloor, currentStore, currentStep (sessionStorage)
+// 카트 진실의 원천: 서버 Redis (GET /api/orders/cart/{sessionId})
+//   ─ 클라 sessionStorage 에 카트를 저장하지 않는다.
+//   ─ AI(FastAPI) 가 같은 Redis 카트를 직접 변경할 수 있으므로,
+//     "담았어요" 류 응답 직후에는 Api.cart.get(sessionId) 으로 재동기화 필요.
 // ========================================================
 
 (function () {
@@ -21,9 +24,12 @@
     const state = {
         currentFloorId: null,
         currentStoreId: null,
-        cart: [],            // [{ menuId, qty }]
+        // 서버 CartResponse.items 그대로:
+        // [{ itemId(string UUID), menuId, menuName, unitPrice, quantity, itemTotal, options[] }]
+        cart: [],
         chatLog: [],         // [{ role: "system"|"user"|"tool", text, ts }]
-        sessionId: null,
+        sessionId: null,     // 서버 발급 Long
+        mode: null,          // "NORMAL" | "AVATAR"
         micActive: false,
     };
 
@@ -78,38 +84,47 @@
         return period + " " + h12 + ":" + pad(d.getMinutes());
     }
 
-    function generateSessionId() {
-        return Math.random().toString(36).slice(2, 10);
-    }
-
     // ---------- 세션 로드/저장 ----------
+    // sessionStorage 에는 "서버 데이터에 접근할 키" 만 남긴다.
+    // 카트 본체는 서버 Redis. 새로고침 시 sessionId 로 다시 fetch.
     function loadSession() {
         try {
-            state.cart           = JSON.parse(sessionStorage.getItem("cart") || "[]");
             state.currentFloorId = sessionStorage.getItem("currentFloor");
             state.currentStoreId = sessionStorage.getItem("currentStore");
-            state.sessionId      = sessionStorage.getItem("aiSessionId");
-            if (!state.sessionId) {
-                state.sessionId = generateSessionId();
-                sessionStorage.setItem("aiSessionId", state.sessionId);
-            }
+            state.mode           = sessionStorage.getItem("mode") || "NORMAL";
+
+            const stored = sessionStorage.getItem("sessionId");
+            state.sessionId = stored ? Number(stored) : null;
         } catch (e) {
             console.warn("[N02] 세션 로드 실패", e);
         }
     }
 
-    function persistCart() {
-        try {
-            sessionStorage.setItem("cart", JSON.stringify(state.cart));
-        } catch (e) {
-            console.warn("[N02] 카트 저장 실패", e);
-        }
+    // 서버 세션이 없으면 새로 발급, 있으면 유지
+    async function ensureServerSession() {
+        if (state.sessionId) return state.sessionId;
+
+        // 백엔드 SessionMode enum 은 대문자(NORMAL/AVATAR). 옛 sessionStorage 잔여물 방어.
+        const rawMode = (state.mode || "NORMAL").toUpperCase();
+        const safeMode = (rawMode === "AVATAR") ? "AVATAR" : "NORMAL";
+
+        const created = await window.Api.session.create({
+            mode: safeMode,
+            language: "ko",
+        });
+        state.sessionId = created.sessionId;
+        sessionStorage.setItem("sessionId", String(state.sessionId));
+        return state.sessionId;
     }
 
     function persistFloorStore() {
         try {
             sessionStorage.setItem("currentFloor", state.currentFloorId);
             sessionStorage.setItem("currentStore", state.currentStoreId);
+
+            // 결제 화면들이 매장명 표시용으로 사용
+            const store = getStore(state.currentFloorId, state.currentStoreId);
+            if (store) sessionStorage.setItem("currentStoreName", store.name);
         } catch (e) {
             console.warn("[N02] 위치 저장 실패", e);
         }
@@ -126,20 +141,33 @@
         return f.stores.find((s) => s.id === storeId) || null;
     }
 
+    // 메뉴 카드 뱃지용: 같은 menuId 의 모든 라인 수량 합산
+    // (옵션이 다른 동일 메뉴는 서버에서 별도 itemId 로 분리됨)
     function getCartQty(menuId) {
-        const item = state.cart.find((i) => i.menuId === menuId);
-        return item ? item.qty : 0;
+        return state.cart
+            .filter((i) => i.menuId === menuId)
+            .reduce((sum, i) => sum + i.quantity, 0);
     }
 
     function totalCartCount() {
-        return state.cart.reduce((sum, i) => sum + i.qty, 0);
+        return state.cart.reduce((sum, i) => sum + i.quantity, 0);
     }
 
     function totalCartAmount() {
-        return state.cart.reduce((sum, i) => {
-            const found = window.MenuData.findMenuById(i.menuId);
-            return sum + (found ? found.menu.price * i.qty : 0);
-        }, 0);
+        return state.cart.reduce((sum, i) => sum + (i.itemTotal || 0), 0);
+    }
+
+    // 서버 응답으로 받은 카트로 state.cart 교체 후 UI 재렌더
+    function applyCartResponse(cartResponse) {
+        state.cart = (cartResponse && cartResponse.items) ? cartResponse.items : [];
+        renderMenuGrid();
+        renderCartBar();
+    }
+
+    function logApiError(label, e) {
+        console.error("[N02] " + label, e);
+        const msg = (e && e.message) ? e.message : "요청 실패";
+        pushChatBubble("system", "⚠ " + label + " 실패: " + msg);
     }
 
     // ---------- 렌더링: 층 탭 ----------
@@ -263,35 +291,34 @@
         $cartPayAmount.textContent = "· " + fmt(total);
 
         const html = state.cart.map((item) => {
-            const found = window.MenuData.findMenuById(item.menuId);
-            if (!found) return "";
-            const m = found.menu;
-            const lineTotal = m.price * item.qty;
+            const optionText = (item.options && item.options.length)
+                ? item.options.map((o) => o.optionName).join(" · ")
+                : "";
 
             return `
-                <li class="n02__cart-item" data-cart-item="${m.id}">
-                    <div class="n02__cart-item-thumb">${m.name}</div>
+                <li class="n02__cart-item" data-cart-item="${item.itemId}">
+                    <div class="n02__cart-item-thumb">${item.menuName}</div>
                     <div class="n02__cart-item-name-row">
-                        <span class="n02__cart-item-name">${m.name}</span>
+                        <span class="n02__cart-item-name">${item.menuName}${optionText ? ` <small>(${optionText})</small>` : ""}</span>
                         <button class="n02__cart-item-remove"
                                 type="button"
-                                data-cart-remove="${m.id}"
+                                data-cart-remove="${item.itemId}"
                                 aria-label="삭제">
                             <i class="xi xi-close-thin"></i>
                         </button>
                     </div>
                     <div class="n02__cart-item-bottom">
-                        <span class="n02__cart-item-price">${fmt(lineTotal)}</span>
+                        <span class="n02__cart-item-price">${fmt(item.itemTotal)}</span>
                         <div class="qty-stepper">
                             <button class="qty-stepper__btn qty-stepper__btn--minus"
                                     type="button"
-                                    data-cart-qty="${m.id}"
+                                    data-cart-qty="${item.itemId}"
                                     data-delta="-1"
                                     aria-label="수량 감소">−</button>
-                            <span class="qty-stepper__value">${item.qty}</span>
+                            <span class="qty-stepper__value">${item.quantity}</span>
                             <button class="qty-stepper__btn"
                                     type="button"
-                                    data-cart-qty="${m.id}"
+                                    data-cart-qty="${item.itemId}"
                                     data-delta="1"
                                     aria-label="수량 증가">+</button>
                         </div>
@@ -361,55 +388,73 @@
         $detail.setAttribute("aria-hidden", "true");
     }
 
-    // ---------- 카트 조작 ----------
-    function addToCart(menuId, opts) {
+    // ---------- 카트 조작 (모두 서버 Api.cart.* 호출) ----------
+    async function addToCart(menuId, opts) {
         opts = opts || {};
         const found = window.MenuData.findMenuById(menuId);
         if (!found || found.menu.soldOut) return;
 
-        const existing = state.cart.find((i) => i.menuId === menuId);
-        if (existing) {
-            existing.qty += 1;
-        } else {
-            state.cart.push({ menuId: menuId, qty: 1 });
-        }
-        persistCart();
-        renderMenuGrid();
-        renderCartBar();
+        try {
+            const sessionId = await ensureServerSession();
+            const res = await window.Api.cart.addItem({
+                sessionId: sessionId,
+                menuId: menuId,
+                quantity: 1,
+                optionIds: [],
+            });
+            applyCartResponse(res);
 
-        // AI 채팅에 로그 (사용자 액션 → 시스템 응답 + 툴 호출)
-        if (!opts.silent) {
-            pushChatBubble("system", `${found.menu.name}을(를) 장바구니에 담았어요! ${fmt(found.menu.price)}`);
-            pushChatBubble("tool",   `🛒 ${found.menu.name} 담기 실행`);
+            if (!opts.silent) {
+                pushChatBubble("system", `${found.menu.name}을(를) 장바구니에 담았어요! ${fmt(found.menu.price)}`);
+                pushChatBubble("tool",   `🛒 ${found.menu.name} 담기 실행`);
+            }
+        } catch (e) {
+            logApiError("장바구니 추가", e);
         }
     }
 
-    function changeCartQty(menuId, delta) {
-        const item = state.cart.find((i) => i.menuId === menuId);
+    async function changeCartQty(itemId, delta) {
+        const item = state.cart.find((i) => i.itemId === itemId);
         if (!item) return;
-        item.qty += delta;
-        if (item.qty <= 0) {
-            removeFromCart(menuId, { silent: true });
+        const next = item.quantity + delta;
+        if (next <= 0) {
+            await removeFromCart(itemId, { silent: true });
             return;
         }
-        persistCart();
-        renderMenuGrid();
-        renderCartBar();
-    }
-
-    function removeFromCart(menuId, opts) {
-        opts = opts || {};
-        const idx = state.cart.findIndex((i) => i.menuId === menuId);
-        if (idx < 0) return;
-        const found = window.MenuData.findMenuById(menuId);
-        state.cart.splice(idx, 1);
-        persistCart();
-        renderMenuGrid();
-        renderCartBar();
-        if (!opts.silent && found) {
-            pushChatBubble("system", `${found.menu.name}을(를) 장바구니에서 뺐어요.`);
+        try {
+            const res = await window.Api.cart.updateItem(state.sessionId, itemId, next);
+            applyCartResponse(res);
+        } catch (e) {
+            logApiError("수량 변경", e);
         }
     }
+
+    async function removeFromCart(itemId, opts) {
+        opts = opts || {};
+        const item = state.cart.find((i) => i.itemId === itemId);
+        try {
+            const res = await window.Api.cart.removeItem(state.sessionId, itemId);
+            applyCartResponse(res);
+            if (!opts.silent && item) {
+                pushChatBubble("system", `${item.menuName}을(를) 장바구니에서 뺐어요.`);
+            }
+        } catch (e) {
+            logApiError("장바구니 삭제", e);
+        }
+    }
+
+    // AI 가 서버 카트를 직접 변경한 직후 호출되는 동기화 헬퍼
+    // (FastAPI 응답 처리 코드에서 사용 예정)
+    async function syncCartFromServer() {
+        if (!state.sessionId) return;
+        try {
+            const res = await window.Api.cart.get(state.sessionId);
+            applyCartResponse(res);
+        } catch (e) {
+            logApiError("카트 동기화", e);
+        }
+    }
+    window.__N02_syncCart = syncCartFromServer;
 
     // ---------- AI 채팅 패널 ----------
     function openChat() {
@@ -499,13 +544,7 @@
         try {
             sessionStorage.setItem("currentStep", "P01");
         } catch (e) { /* noop */ }
-        // P01 페이지가 아직 없으면 안내
-        // location.href = PAY_NEXT_URL;
-        alert(
-            "결제 단계로 이동합니다.\n" +
-            "총 " + totalCartCount() + "개 · " + fmt(totalCartAmount()) +
-            "\n(P01 페이지는 아직 구현 전입니다)"
-        );
+        location.href = PAY_NEXT_URL;
     }
 
     // ---------- 이벤트 위임 ----------
@@ -555,18 +594,18 @@
             }
         });
 
-        // 카트 바 — 수량 / 삭제
+        // 카트 바 — 수량 / 삭제 (itemId 는 서버 발급 string UUID)
         $cartTrack.addEventListener("click", (e) => {
             const qtyBtn = e.target.closest("[data-cart-qty]");
             if (qtyBtn) {
-                const id = parseInt(qtyBtn.getAttribute("data-cart-qty"), 10);
-                const delta = parseInt(qtyBtn.getAttribute("data-delta"), 10);
-                changeCartQty(id, delta);
+                const itemId = qtyBtn.getAttribute("data-cart-qty");
+                const delta  = parseInt(qtyBtn.getAttribute("data-delta"), 10);
+                changeCartQty(itemId, delta);
                 return;
             }
             const rmBtn = e.target.closest("[data-cart-remove]");
             if (rmBtn) {
-                removeFromCart(parseInt(rmBtn.getAttribute("data-cart-remove"), 10));
+                removeFromCart(rmBtn.getAttribute("data-cart-remove"));
                 return;
             }
         });
@@ -634,18 +673,20 @@
         renderCartBar();
         bindEvents();
 
-        // 백엔드에서 메뉴 트리 로드
+        // 백엔드에서 메뉴 트리 로드 + 서버 세션/카트 동기화 (병렬)
         try {
-            await window.MenuData.load();
+            await Promise.all([
+                window.MenuData.load(),
+                ensureServerSession().then(() => syncCartFromServer()),
+            ]);
         } catch (e) {
-            console.error("[N02] 메뉴 로드 실패", e);
+            console.error("[N02] 초기 로드 실패", e);
             $menuEmpty.hidden = false;
             $menuEmpty.querySelector("p").textContent =
-                "메뉴를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.";
+                "데이터를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.";
             return;
         }
 
-        // 데이터가 비어 있으면 빈 상태
         if (!window.MenuData.data.floors.length) {
             $menuEmpty.hidden = false;
             return;

--- a/src/main/resources/static/front/js/flowP/P01-summary.js
+++ b/src/main/resources/static/front/js/flowP/P01-summary.js
@@ -1,32 +1,21 @@
 /* ========================================================
-   P01-summary.js — 주문 요약/확인 (Step 1/3)
-   - sessionStorage.cart 를 읽어 리스트·합계 렌더
-   - 수량 ± / 삭제 / 주문 확인 완료 → P02
-   - cart 가 비어있으면 데모 mock 데이터로 렌더 (디자인 확인 편의)
-   - cart 아이템 형식: { id, name, price, qty, storeName?, imageUrl? }
+   P01-summary.js — 주문 요약 / 확인 (Step 1/3)
+   - 서버 Redis 장바구니 (GET /api/orders/cart/{sessionId}) 를 진실의 원천으로 사용
+   - 수량 ±  / 삭제 → Cart API 호출 후 응답으로 재렌더
+   - "주문 확인 완료" → POST /api/orders/confirm → orderId 저장 → P02
    ======================================================== */
 
 (function () {
     'use strict';
 
     /* ---------- Session helpers ---------- */
-    const SESSION_KEY = 'cart';
-    const STORE_KEY   = 'currentStoreName';
+    const SESSION_ID_KEY = 'sessionId';
+    const STORE_KEY      = 'currentStoreName';
 
-    const MOCK_CART = [
-        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
-    ];
-
-    function loadCart() {
-        try {
-            const raw = sessionStorage.getItem(SESSION_KEY);
-            if (!raw) return null;
-            const parsed = JSON.parse(raw);
-            return Array.isArray(parsed) ? parsed : null;
-        } catch (_) { return null; }
-    }
-    function saveCart(cart) {
-        try { sessionStorage.setItem(SESSION_KEY, JSON.stringify(cart)); } catch (_) {}
+    function getSessionId() {
+        const raw = sessionStorage.getItem(SESSION_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
     }
 
     /* ---------- Formatters ---------- */
@@ -34,8 +23,7 @@
     const fmtWon = (n) => '₩' + nf.format(Math.max(0, n | 0));
 
     /* ---------- DOM refs ---------- */
-    const $ = (sel, root = document) => root.querySelector(sel);
-    const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+    const $  = (sel, root = document) => root.querySelector(sel);
 
     const listEl   = $('[data-bind="items"]');
     const countEl  = $('[data-bind="count"]');
@@ -45,25 +33,20 @@
     const backEl   = $('[data-action="back"]');
     const itemTpl  = $('#tpl-p01-item');
 
-    /* ---------- State ---------- */
-    let cart = loadCart();
-    if (!cart || cart.length === 0) {
-        cart = MOCK_CART.slice();
-    }
+    /* ---------- State (서버 응답 그대로) ---------- */
+    // items: [{ itemId, menuId, menuName, unitPrice, quantity, itemTotal, options[] }]
+    let items = [];
 
     /* ---------- Render ---------- */
     function renderStoreName() {
-        const storeName =
-            (sessionStorage.getItem(STORE_KEY)) ||
-            (cart[0] && cart[0].storeName) ||
-            '상록원';
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
         if (storeEl) storeEl.textContent = storeName;
     }
 
     function renderList() {
         listEl.innerHTML = '';
 
-        if (cart.length === 0) {
+        if (!items.length) {
             const empty = document.createElement('li');
             empty.className = 'p01__empty';
             empty.textContent = '장바구니가 비어있어요';
@@ -71,33 +54,24 @@
             return;
         }
 
-        cart.forEach((item, idx) => {
+        items.forEach((it) => {
             const node = itemTpl.content.firstElementChild.cloneNode(true);
-            node.dataset.index = String(idx);
+            node.dataset.itemId = it.itemId;
 
-            $('[data-name]', node).textContent  = item.name || '';
-            $('[data-price]', node).textContent = fmtWon(item.price);
-            $('[data-qty-value]', node).textContent = String(item.qty || 1);
-
-            if (item.imageUrl) {
-                const thumb = $('[data-thumb]', node);
-                thumb.innerHTML = '';
-                const img = document.createElement('img');
-                img.src = item.imageUrl;
-                img.alt = item.name || '';
-                thumb.appendChild(img);
-            }
+            $('[data-name]', node).textContent  = it.menuName || '';
+            $('[data-price]', node).textContent = fmtWon(it.itemTotal);
+            $('[data-qty-value]', node).textContent = String(it.quantity || 1);
 
             const decBtn = $('[data-qty-dec]', node);
-            if ((item.qty || 1) <= 1) decBtn.disabled = true;
+            if ((it.quantity || 1) <= 1) decBtn.disabled = true;
 
             listEl.appendChild(node);
         });
     }
 
     function renderSummary() {
-        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
-        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+        const totalQty   = items.reduce((s, it) => s + (it.quantity || 0), 0);
+        const totalPrice = items.reduce((s, it) => s + (it.itemTotal || 0), 0);
 
         countEl.textContent = totalQty + '개';
         totalEl.textContent = fmtWon(totalPrice);
@@ -111,31 +85,80 @@
         renderSummary();
     }
 
+    function applyCart(cartResponse) {
+        items = (cartResponse && cartResponse.items) ? cartResponse.items : [];
+        renderAll();
+    }
+
+    function logApiError(label, e) {
+        console.warn('[P01] ' + label + ' 실패', e);
+    }
+
+    /* ---------- API ---------- */
+    async function fetchCart() {
+        const sid = getSessionId();
+        if (!sid) {
+            // 세션이 없으면 N02 부터 다시 시작
+            location.href = '/flowN/N02-menu.html';
+            return;
+        }
+        try {
+            const res = await window.NunchiApi.Cart.get(sid);
+            applyCart(res);
+        } catch (e) {
+            logApiError('카트 조회', e);
+            applyCart({ items: [] });
+        }
+    }
+
+    async function changeQty(itemId, nextQty) {
+        const sid = getSessionId();
+        if (!sid) return;
+        try {
+            const res = await window.NunchiApi.Cart.updateItem(sid, itemId, nextQty);
+            applyCart(res);
+        } catch (e) {
+            logApiError('수량 변경', e);
+        }
+    }
+
+    async function removeItem(itemId) {
+        const sid = getSessionId();
+        if (!sid) return;
+        try {
+            const res = await window.NunchiApi.Cart.removeItem(sid, itemId);
+            applyCart(res);
+        } catch (e) {
+            logApiError('삭제', e);
+        }
+    }
+
+    function goNext() {
+        if (items.length === 0) return;
+        // confirmOrder 는 결제수단 선택 직후 P02 에서 호출 (그래야 P02 까지 카트가 살아있음)
+        location.href = '/flowP/P02-payment.html';
+    }
+
     /* ---------- Events ---------- */
     listEl.addEventListener('click', (e) => {
         const itemEl = e.target.closest('[data-item]');
         if (!itemEl) return;
-        const idx = Number(itemEl.dataset.index);
-        if (Number.isNaN(idx) || !cart[idx]) return;
+        const itemId = itemEl.dataset.itemId;
+        const found = items.find((it) => it.itemId === itemId);
+        if (!found) return;
 
         if (e.target.closest('[data-qty-inc]')) {
-            cart[idx].qty = (cart[idx].qty || 1) + 1;
-            saveCart(cart);
-            renderAll();
+            changeQty(itemId, found.quantity + 1);
             return;
         }
         if (e.target.closest('[data-qty-dec]')) {
-            const nextQty = (cart[idx].qty || 1) - 1;
-            if (nextQty < 1) return;
-            cart[idx].qty = nextQty;
-            saveCart(cart);
-            renderAll();
+            const next = found.quantity - 1;
+            if (next < 1) return;
+            changeQty(itemId, next);
             return;
         }
         if (e.target.closest('[data-del]')) {
-            cart.splice(idx, 1);
-            saveCart(cart);
-            renderAll();
+            removeItem(itemId);
             return;
         }
     });
@@ -145,12 +168,9 @@
         else location.href = '/flowN/N02-menu.html';
     });
 
-    ctaEl.addEventListener('click', () => {
-        if (cart.length === 0) return;
-        saveCart(cart);
-        location.href = '/flowP/P02-payment.html';
-    });
+    ctaEl.addEventListener('click', goNext);
 
     /* ---------- Init ---------- */
     renderAll();
+    fetchCart();
 })();

--- a/src/main/resources/static/front/js/flowP/P02-payment.js
+++ b/src/main/resources/static/front/js/flowP/P02-payment.js
@@ -1,33 +1,33 @@
 /* ========================================================
    P02-payment.js — 결제 수단 선택 (Step 2/3)
-   - sessionStorage.cart 로 금액/수량 요약
-   - IC카드 / 정맥인증 중 하나 선택 (라디오)
-   - 선택 시 sessionStorage.paymentMethod 저장
-   - CTA 클릭 시 분기
-       ic   → /flowP/P04-processing.html (카드 결제 처리)
-       vein → /flowP/P03-vein.html        (정맥 인증)
-   - cart 가 비어있으면 P01 과 동일한 mock 로 렌더 (디자인 확인 편의)
+   - 서버 카트 (GET /api/orders/cart/{sessionId}) 로 금액/수량 요약
+   - IC카드 / 정맥인증 중 하나 선택
+   - CTA 클릭 시
+       1) POST /api/payments { orderId, method } 로 결제 생성 → paymentId 저장
+       2) ic   → /flowP/P04-processing.html
+          vein → /flowP/P03-vein.html
+   - orderId / sessionId 없으면 P01 또는 N02 로 복귀
    ======================================================== */
 
 (function () {
     'use strict';
 
     /* ---------- Session helpers ---------- */
-    const CART_KEY    = 'cart';
-    const STORE_KEY   = 'currentStoreName';
-    const METHOD_KEY  = 'paymentMethod';
+    const SESSION_ID_KEY = 'sessionId';
+    const ORDER_ID_KEY   = 'orderId';
+    const PAYMENT_ID_KEY = 'paymentId';
+    const STORE_KEY      = 'currentStoreName';
+    const METHOD_KEY     = 'paymentMethod';
 
-    const MOCK_CART = [
-        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
-    ];
-
-    function loadCart() {
-        try {
-            const raw = sessionStorage.getItem(CART_KEY);
-            if (!raw) return null;
-            const parsed = JSON.parse(raw);
-            return Array.isArray(parsed) ? parsed : null;
-        } catch (_) { return null; }
+    function getSessionId() {
+        const raw = sessionStorage.getItem(SESSION_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
+    }
+    function getOrderId() {
+        const raw = sessionStorage.getItem(ORDER_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
     }
 
     /* ---------- Formatters ---------- */
@@ -48,24 +48,18 @@
     const methodEls = $$('.method-card[data-method]');
 
     /* ---------- State ---------- */
-    let cart = loadCart();
-    if (!cart || cart.length === 0) {
-        cart = MOCK_CART.slice();
-    }
+    let cartItems = [];
     let selectedMethod = null;
 
     /* ---------- Render ---------- */
     function renderStoreName() {
-        const storeName =
-            sessionStorage.getItem(STORE_KEY) ||
-            (cart[0] && cart[0].storeName) ||
-            '상록원';
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
         if (storeEl) storeEl.textContent = storeName;
     }
 
     function renderSummary() {
-        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
-        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+        const totalQty   = cartItems.reduce((s, it) => s + (it.quantity || 0), 0);
+        const totalPrice = cartItems.reduce((s, it) => s + (it.itemTotal || 0), 0);
 
         if (countEl) countEl.textContent = totalQty + '개';
         if (totalEl) totalEl.textContent = fmtWon(totalPrice);
@@ -108,6 +102,23 @@
         renderSelection();
     }
 
+    /* ---------- API ---------- */
+    async function fetchCart() {
+        const sid = getSessionId();
+        if (!sid) {
+            location.href = '/flowN/N02-menu.html';
+            return;
+        }
+        try {
+            const res = await window.NunchiApi.Cart.get(sid);
+            cartItems = (res && res.items) ? res.items : [];
+        } catch (e) {
+            console.warn('[P02] 카트 조회 실패', e);
+            cartItems = [];
+        }
+        renderSummary();
+    }
+
     /* ---------- Events ---------- */
     methodEls.forEach((el) => {
         el.addEventListener('click', () => {
@@ -126,30 +137,11 @@
     }
 
     if (ctaEl) {
-        ctaEl.addEventListener('click', async () => {
+        // 결제수단 선택 후 결제 화면(P03/P04) 으로 단순 이동.
+        // 백엔드 호출(confirmOrder/payment.create) 은 인증/카드 승인 직전에 한 번에 묶어서.
+        ctaEl.addEventListener('click', () => {
             if (!selectedMethod) return;
             try { sessionStorage.setItem(METHOD_KEY, selectedMethod); } catch (_) {}
-
-            // 백엔드 결제 생성 — orderId 가 있을 때만 (avatar 모드에서 진입한 경우)
-            const orderId = Number(sessionStorage.getItem('orderId'));
-            const backendMethod = (selectedMethod === 'vein') ? 'VEIN_AUTH' : 'IC_CARD';
-            if (orderId && window.NunchiApi) {
-                ctaEl.disabled = true;
-                try {
-                    const payment = await window.NunchiApi.Payments.create(orderId, backendMethod);
-                    if (!payment || !payment.paymentId) {
-                        // paymentId 없는 응답 = 결제 레코드 미생성. 다음 단계로 가지 않는다.
-                        console.warn('[P02] 결제 생성 응답에 paymentId 없음');
-                        return;
-                    }
-                    sessionStorage.setItem('paymentId', String(payment.paymentId));
-                } catch (e) {
-                    console.warn('[P02] 결제 생성 실패 — 진행 중단', e);
-                    return;
-                } finally {
-                    ctaEl.disabled = false;
-                }
-            }
 
             if (selectedMethod === 'ic') {
                 location.href = '/flowP/P04-processing.html';
@@ -161,4 +153,5 @@
 
     /* ---------- Init ---------- */
     renderAll();
+    fetchCart();
 })();

--- a/src/main/resources/static/front/js/flowP/P03-vein.js
+++ b/src/main/resources/static/front/js/flowP/P03-vein.js
@@ -91,11 +91,64 @@
         } else if (nextState === 'success') {
             setProgress(100);
             try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
-            successTimer = setTimeout(() => {
-                location.href = '/flowP/P05-complete.html';
-            }, 2000);
+            finalizePaymentThenGoComplete();
         } else if (nextState === 'fail') {
             try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+        }
+    }
+
+    /* ---------- 백엔드 결제 확정 (성공 분기 1회 가드) ----------
+       인증 성공 직전까지 confirmOrder/payment.create 를 미뤘다 한 번에 호출:
+         1) POST /api/orders/confirm   → orderId
+         2) POST /api/payments         → paymentId
+         3) PATCH /api/payments/{id}/success
+         4) sessionStorage.orderSummary 저장 후 P05 이동
+       어느 단계든 실패하면 카트는 그대로(아직 confirm 전이거나 markFail 가드) → P06 이동 */
+    let finalizing = false;
+    async function finalizePaymentThenGoComplete() {
+        if (finalizing) return;
+        finalizing = true;
+
+        const sid = Number(sessionStorage.getItem('sessionId'));
+        if (!sid) {
+            location.href = '/flowN/N02-menu.html';
+            return;
+        }
+
+        let orderId = null, paymentId = null;
+        try {
+            const order = await window.NunchiApi.Orders.confirm(sid);
+            if (!order || !order.orderId) throw new Error('confirm 응답에 orderId 없음');
+            orderId = order.orderId;
+            sessionStorage.setItem('orderId', String(orderId));
+
+            // 결제 완료 화면용 요약
+            try {
+                sessionStorage.setItem('orderSummary', JSON.stringify({
+                    totalAmount: order.totalAmount,
+                    itemCount:   (order.items || []).length,
+                    firstName:   (order.items && order.items[0] && order.items[0].menuName) || '',
+                    totalQty:    (order.items || []).reduce((s, it) => s + (it.quantity || 0), 0),
+                }));
+            } catch (_) {}
+
+            const payment = await window.NunchiApi.Payments.create(orderId, 'VEIN_AUTH');
+            if (!payment || !payment.paymentId) throw new Error('payment.create 응답에 paymentId 없음');
+            paymentId = payment.paymentId;
+            sessionStorage.setItem('paymentId', String(paymentId));
+
+            await window.NunchiApi.Payments.markSuccess(paymentId);
+
+            successTimer = setTimeout(() => {
+                location.href = '/flowP/P05-complete.html';
+            }, 1200);
+        } catch (e) {
+            console.warn('[P03] 결제 확정 실패', e);
+            // 결제 레코드까지는 만들어진 경우 markFail
+            if (paymentId) {
+                window.NunchiApi.Payments.markFail(paymentId).catch(() => {});
+            }
+            location.href = '/flowP/P06-fail.html?reason=vein_unregistered';
         }
     }
 
@@ -139,30 +192,20 @@
         if (storeEl) storeEl.textContent = storeName;
     }
 
-    /* ---------- Events ---------- */
-    if (backEl) {
-        backEl.addEventListener('click', () => {
-            clearAllTimers();
-            if (history.length > 1) history.back();
-            else location.href = '/flowP/P02-payment.html';
-        });
+    /* ---------- Events ----------
+       성공 단계에 진입하기 전이라면 confirm 도 하기 전이므로 카트가 그대로 살아있음.
+       모든 복귀(뒤로/취소/결제수단 변경) 는 history.back() 으로 — location.href 로 새 entry 를
+       쌓으면 P02 에서 뒤로가기 시 P03 으로 되돌아오는 문제가 생긴다. */
+    function goPrev() {
+        clearAllTimers();
+        if (history.length > 1) history.back();
+        else location.href = '/flowP/P02-payment.html';
     }
-    if (cancelEl) {
-        cancelEl.addEventListener('click', () => {
-            clearAllTimers();
-            location.href = '/flowP/P02-payment.html';
-        });
-    }
-    if (switchEl) {
-        switchEl.addEventListener('click', () => {
-            clearAllTimers();
-            location.href = '/flowP/P02-payment.html';
-        });
-    }
+    if (backEl)   backEl.addEventListener('click',   goPrev);
+    if (cancelEl) cancelEl.addEventListener('click', goPrev);
+    if (switchEl) switchEl.addEventListener('click', goPrev);
     if (retryEl) {
-        retryEl.addEventListener('click', () => {
-            setState('prepare');
-        });
+        retryEl.addEventListener('click', () => { setState('prepare'); });
     }
 
     window.addEventListener('beforeunload', clearAllTimers);

--- a/src/main/resources/static/front/js/flowP/P04-processing.js
+++ b/src/main/resources/static/front/js/flowP/P04-processing.js
@@ -33,22 +33,15 @@
     const cancelEl = $('[data-action="cancel"]');
 
     /* ---------- Session ---------- */
-    const CART_KEY   = 'cart';
+    const SESSION_ID_KEY = 'sessionId';
     const STORE_KEY  = 'currentStoreName';
     const METHOD_KEY = 'paymentMethod';
     const STATUS_KEY = 'paymentStatus';
 
-    const MOCK_CART = [
-        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
-    ];
-
-    function loadCart() {
-        try {
-            const raw = sessionStorage.getItem(CART_KEY);
-            if (!raw) return MOCK_CART.slice();
-            const parsed = JSON.parse(raw);
-            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
-        } catch (_) { return MOCK_CART.slice(); }
+    function getSessionId() {
+        const raw = sessionStorage.getItem(SESSION_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
     }
 
     function getQuery(name) {
@@ -133,6 +126,7 @@
                 const forced = getQuery('result');
                 if (forced === 'timeout' || forced === 'card_error' || forced === 'declined') {
                     try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+                    // 아직 confirm/payment 호출 전이므로 카트 그대로 살아있음. 단순 P06 이동.
                     location.href = '/flowP/P06-fail.html?reason=' + encodeURIComponent(forced);
                     return;
                 }
@@ -143,51 +137,100 @@
             setProgress(100);
             try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
 
-            // 실제 전이 이벤트일 때만 백엔드 결제 성공 마킹.
-            // URL 로 강제 진입(?state=approved) 한 디자인 확인 시에는 호출하지 않음.
+            // 실제 승인 직전에 confirmOrder + payment.create + markSuccess 한 번에 호출.
             if (transition) {
-                const paymentId = Number(sessionStorage.getItem('paymentId'));
-                if (paymentId && window.NunchiApi) {
-                    window.NunchiApi.Payments.markSuccess(paymentId)
-                        .catch((e) => console.warn('[P04] markSuccess 실패', e));
-                }
+                finalizePaymentThenGoComplete();
+            } else {
+                approvedTimer = setTimeout(() => {
+                    location.href = '/flowP/P05-complete.html';
+                }, 1200);
             }
-
-            approvedTimer = setTimeout(() => {
-                location.href = '/flowP/P05-complete.html';
-            }, 2000);
         }
     }
 
-    /* ---------- Init render ---------- */
+    /* ---------- 백엔드 결제 확정 (승인 분기) ---------- */
+    let finalizing = false;
+    async function finalizePaymentThenGoComplete() {
+        if (finalizing) return;
+        finalizing = true;
+
+        const sid = getSessionId();
+        if (!sid) {
+            location.href = '/flowN/N02-menu.html';
+            return;
+        }
+
+        let orderId = null, paymentId = null;
+        try {
+            const order = await window.NunchiApi.Orders.confirm(sid);
+            if (!order || !order.orderId) throw new Error('confirm 응답에 orderId 없음');
+            orderId = order.orderId;
+            sessionStorage.setItem('orderId', String(orderId));
+
+            try {
+                sessionStorage.setItem('orderSummary', JSON.stringify({
+                    totalAmount: order.totalAmount,
+                    itemCount:   (order.items || []).length,
+                    firstName:   (order.items && order.items[0] && order.items[0].menuName) || '',
+                    totalQty:    (order.items || []).reduce((s, it) => s + (it.quantity || 0), 0),
+                }));
+            } catch (_) {}
+
+            const payment = await window.NunchiApi.Payments.create(orderId, 'IC_CARD');
+            if (!payment || !payment.paymentId) throw new Error('payment.create 응답에 paymentId 없음');
+            paymentId = payment.paymentId;
+            sessionStorage.setItem('paymentId', String(paymentId));
+
+            await window.NunchiApi.Payments.markSuccess(paymentId);
+
+            approvedTimer = setTimeout(() => {
+                location.href = '/flowP/P05-complete.html';
+            }, 1200);
+        } catch (e) {
+            console.warn('[P04] 결제 확정 실패', e);
+            if (paymentId) {
+                window.NunchiApi.Payments.markFail(paymentId).catch(() => {});
+            }
+            location.href = '/flowP/P06-fail.html?reason=declined';
+        }
+    }
+
+    /* ---------- Init render ----------
+       이 화면 진입 시점엔 아직 confirm 전이라 서버 카트가 살아있음 → 카트 합계 그대로 표시 */
     function renderStoreAndTotal() {
         const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
         if (storeEl) storeEl.textContent = storeName;
-
-        const cart = loadCart();
-        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
-        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
     }
 
-    /* ---------- Events ---------- */
-    if (backEl) {
-        backEl.addEventListener('click', () => {
-            clearAllTimers();
-            if (history.length > 1) history.back();
-            else location.href = '/flowP/P02-payment.html';
-        });
+    async function fetchTotalFromCart() {
+        const sid = getSessionId();
+        if (!sid || !window.NunchiApi) return;
+        try {
+            const res = await window.NunchiApi.Cart.get(sid);
+            const total = (res && typeof res.totalAmount === 'number') ? res.totalAmount : 0;
+            if (totalEl) totalEl.textContent = fmtWon(total);
+        } catch (e) {
+            console.warn('[P04] 카트 조회 실패', e);
+        }
     }
-    if (cancelEl) {
-        cancelEl.addEventListener('click', () => {
-            clearAllTimers();
-            location.href = '/flowP/P02-payment.html';
-        });
+
+    /* ---------- Events ----------
+       승인 직전 단계에 들어가기 전이면 confirm 도 안 한 상태이므로 카트 그대로 → 자유 복귀.
+       모든 복귀(뒤로/취소) 는 history.back() — location.href 로 새 entry 쌓으면 P02 에서
+       뒤로가기 시 P04 로 되돌아오는 문제가 생긴다. */
+    function goPrev() {
+        clearAllTimers();
+        if (history.length > 1) history.back();
+        else location.href = '/flowP/P02-payment.html';
     }
+    if (backEl)   backEl.addEventListener('click',   goPrev);
+    if (cancelEl) cancelEl.addEventListener('click', goPrev);
 
     window.addEventListener('beforeunload', clearAllTimers);
 
     /* ---------- Boot ---------- */
     renderStoreAndTotal();
+    fetchTotalFromCart();
     try { sessionStorage.setItem(METHOD_KEY, 'ic'); } catch (_) {}
 
     // 초기 진입은 항상 비-전이(transition=false) — markSuccess 중복 호출 방지

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -25,29 +25,31 @@
     const homeEls = Array.from(document.querySelectorAll('[data-action="home"]'));
 
     /* ---------- Session ---------- */
-    const CART_KEY    = 'cart';
-    const STORE_KEY   = 'currentStoreName';
-    const METHOD_KEY  = 'paymentMethod';
-    const STATUS_KEY  = 'paymentStatus';
-    const ORDERNO_KEY = 'orderNumber';
+    const SESSION_ID_KEY = 'sessionId';
+    const STORE_KEY      = 'currentStoreName';
+    const METHOD_KEY     = 'paymentMethod';
+    const STATUS_KEY     = 'paymentStatus';
+    const ORDERNO_KEY    = 'orderNumber';
+    const ORDER_SUMMARY_KEY = 'orderSummary';
 
     const FLOW_KEYS_TO_CLEAR = [
-        CART_KEY, STORE_KEY, METHOD_KEY, STATUS_KEY, ORDERNO_KEY,
-        'mode', 'dineOption', 'currentFloor', 'currentStore',
-        'aiSessionId', 'currentStep', 'orderId', 'paymentId'
+        STORE_KEY, METHOD_KEY, STATUS_KEY, ORDERNO_KEY, ORDER_SUMMARY_KEY,
+        SESSION_ID_KEY, 'mode', 'dineOption', 'currentFloor', 'currentStore',
+        'currentStep', 'orderId', 'paymentId'
     ];
 
-    const MOCK_CART = [
-        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
-    ];
-
-    function loadCart() {
+    function loadOrderSummary() {
         try {
-            const raw = sessionStorage.getItem(CART_KEY);
-            if (!raw) return MOCK_CART.slice();
-            const parsed = JSON.parse(raw);
-            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
-        } catch (_) { return MOCK_CART.slice(); }
+            const raw = sessionStorage.getItem(ORDER_SUMMARY_KEY);
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch (_) { return null; }
+    }
+
+    function getSessionId() {
+        const raw = sessionStorage.getItem(SESSION_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
     }
 
     /* ---------- Utils ---------- */
@@ -89,18 +91,15 @@
         if (orderTimeEl) orderTimeEl.textContent = formatOrderTime();
         if (methodLabelEl) methodLabelEl.textContent = getMethodLabel();
 
-        const cart = loadCart();
-        const totalQty   = cart.reduce((s, it) => s + (it.qty || 0), 0);
-        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
+        const summary = loadOrderSummary() || { totalAmount: 0, itemCount: 0, firstName: '', totalQty: 0 };
 
         if (itemsSummaryEl) {
-            const firstName = cart[0] ? (cart[0].name || '') : '';
-            const extra = cart.length > 1 ? ` 외 ${cart.length - 1}건` : '';
-            itemsSummaryEl.textContent = firstName
-                ? `${firstName}${extra} (총 ${totalQty}개)`
-                : `${totalQty}개`;
+            const extra = summary.itemCount > 1 ? ` 외 ${summary.itemCount - 1}건` : '';
+            itemsSummaryEl.textContent = summary.firstName
+                ? `${summary.firstName}${extra} (총 ${summary.totalQty}개)`
+                : `${summary.totalQty}개`;
         }
-        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+        if (totalEl) totalEl.textContent = fmtWon(summary.totalAmount);
     }
 
     /* ---------- Receipt progress done ---------- */
@@ -151,11 +150,9 @@
     renderAll();
     try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
 
-    // 세션 종료 — sessionStorage 정리 전에 sessionId 캡처
-    // sessionId 는 백엔드 Long. JS Number 정밀도(2^53) 한계로 변환 시 큰 값에서 손실 가능 →
-    // 문자열 그대로 전달 (api-client 의 encodeURIComponent 가 String/Number 둘 다 처리).
+    // 세션 종료 — 정리 전에 sessionId 캡처해서 PATCH /api/sessions/{id}/complete 호출
     (function completeBackendSession() {
-        const sessionId = sessionStorage.getItem('aiSessionId');
+        const sessionId = sessionStorage.getItem(SESSION_ID_KEY);
         if (sessionId && window.NunchiApi) {
             window.NunchiApi.Sessions.complete(sessionId)
                 .catch((e) => console.warn('[P05] session.complete 실패', e));

--- a/src/main/resources/static/front/js/flowP/P06-fail.js
+++ b/src/main/resources/static/front/js/flowP/P06-fail.js
@@ -37,28 +37,24 @@
     const homeEl   = $('[data-action="home"]');
 
     /* ---------- Session ---------- */
-    const CART_KEY   = 'cart';
-    const STORE_KEY  = 'currentStoreName';
-    const METHOD_KEY = 'paymentMethod';
-    const STATUS_KEY = 'paymentStatus';
+    const SESSION_ID_KEY    = 'sessionId';
+    const STORE_KEY         = 'currentStoreName';
+    const METHOD_KEY        = 'paymentMethod';
+    const STATUS_KEY        = 'paymentStatus';
+    const ORDER_SUMMARY_KEY = 'orderSummary';
 
     const FLOW_KEYS_TO_CLEAR = [
-        CART_KEY, STORE_KEY, METHOD_KEY, STATUS_KEY, 'orderNumber',
-        'mode', 'dineOption', 'currentFloor', 'currentStore',
-        'aiSessionId', 'currentStep', 'orderId', 'paymentId'
+        STORE_KEY, METHOD_KEY, STATUS_KEY, ORDER_SUMMARY_KEY, 'orderNumber',
+        SESSION_ID_KEY, 'mode', 'dineOption', 'currentFloor', 'currentStore',
+        'currentStep', 'orderId', 'paymentId'
     ];
 
-    const MOCK_CART = [
-        { id: 'mock-shabu', name: '샤브칼국수 세트', price: 7000, qty: 1, storeName: '상록원' }
-    ];
-
-    function loadCart() {
+    function loadOrderSummary() {
         try {
-            const raw = sessionStorage.getItem(CART_KEY);
-            if (!raw) return MOCK_CART.slice();
-            const parsed = JSON.parse(raw);
-            return (Array.isArray(parsed) && parsed.length) ? parsed : MOCK_CART.slice();
-        } catch (_) { return MOCK_CART.slice(); }
+            const raw = sessionStorage.getItem(ORDER_SUMMARY_KEY);
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch (_) { return null; }
     }
 
     function getQuery(name) {
@@ -145,9 +141,8 @@
         const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
         if (storeEl) storeEl.textContent = storeName;
 
-        const cart = loadCart();
-        const totalPrice = cart.reduce((s, it) => s + (it.qty || 0) * (it.price || 0), 0);
-        if (totalEl) totalEl.textContent = fmtWon(totalPrice);
+        const summary = loadOrderSummary() || { totalAmount: 0 };
+        if (totalEl) totalEl.textContent = fmtWon(summary.totalAmount);
     }
 
     function renderReason(config) {

--- a/src/main/resources/templates_front/flowP/P01-summary.html
+++ b/src/main/resources/templates_front/flowP/P01-summary.html
@@ -93,6 +93,7 @@
     </li>
 </template>
 
+<script src="/js/common/api-client.js"></script>
 <script src="/js/flowP/P01-summary.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P03-vein.html
+++ b/src/main/resources/templates_front/flowP/P03-vein.html
@@ -126,6 +126,7 @@
     </footer>
 </div>
 
+<script src="/js/common/api-client.js"></script>
 <script src="/js/flowP/P03-vein.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
- N02-menu.js 카트를 sessionStorage 에서 서버 Redis(/api/orders/cart) 로 전환
- OrderService.addItem 에 같은 메뉴+옵션 합산 로직 추가 (라인 중복 방지)
- P01: 서버 카트 GET, 수량/삭제 호출, 단순 P02 이동
- P02: 결제수단 선택 후 단순 이동 (백엔드 호출 없음)
- P03/P04: 인증/승인 직전에 confirmOrder + payment.create + markSuccess 묶어 호출, 실패 시 P06
- P05: orderSummary 표시 + sessions.complete + sessionStorage 정리
- P06: orderSummary 표시 + paymentId 있으면 markFail (1회 가드)
- 뒤로/취소/결제수단 변경은 history.back() 으로 통일 (이전 화면으로 자연 복귀)
- mode 키 대문자 통일 (NORMAL/AVATAR) — S01 저장 시점 + S02/N02 읽는 시점 정규화
- api-client.js: ApiResponse code 2xx 전체 success 처리 (created=201 거절되던 문제 수정)

## 📣 Related Issue

- close #76

## 📝 Summary

### 카트 흐름 서버 통합
- N02-menu.js 의 카트 함수(addToCart/changeCartQty/removeFromCart) 를 서버 Cart API(`/api/orders/cart/...`) 호출로 전환
  - sessionStorage 의 `cart` 키 제거, `sessionId` 만 클라가 보관 ("열쇠"만 들고 본체는 서버 Redis)
  - AI(FastAPI) 가 같은 Redis 카트를 직접 변경 가능 → `window.__N02_syncCart` 헬퍼로 동기화 가능
- `OrderService.addItem` — 같은 menuId + 동일 옵션 조합이면 quantity 합산, 다르면 새 라인 (이전엔 매번 새 itemId 추가하던 라인 중복 버그)

### flowP 6개 화면 백엔드 연결
- **P01-summary**: 서버 카트 GET → 표시, 수량/삭제는 Cart API 호출 후 응답으로 재렌더, "주문 확인 완료" → 단순 P02 이동
- **P02-payment**: 결제수단(IC/정맥) 선택 후 P03/P04 로 이동만. 백엔드 호출은 다음 단계로 미룸
- **P03-vein** (정맥) / **P04-processing** (IC): 인증/승인 직전에 한 번에 호출
  - `POST /api/orders/confirm` → orderId
  - `POST /api/payments` → paymentId
  - `PATCH /api/payments/{id}/success`
  - 실패 시 `markFail` 가드 호출 후 P06
- **P05-complete**: orderSummary 표시 + `PATCH /api/sessions/{id}/complete` + 카운트다운 후 sessionStorage 정리
- **P06-fail**: orderSummary 표시 + paymentId 있으면 `markFail` (1회 가드)

### 뒤로가기 흐름 정리
- P03/P04 의 뒤로/취소/결제수단 변경 버튼 → 모두 `history.back()`
- `location.href` 로 새 entry 쌓던 옛 동작 → P02 에서 뒤로가기 시 이전 결제 화면으로 되돌아가는 문제 해결
- confirm 호출을 결제 직전까지 미뤘기에, P03/P04 진행 중 어디서든 뒤로가도 카트가 그대로 살아있음

### 부가 수정
- mode 키(NORMAL/AVATAR) 대문자 통일 — S01 저장 시 toUpperCase(), S02/N02 읽기 시 정규화 + fallback
- `api-client.js` — `ApiResponse.code` 2xx 전체 success 처리. 백엔드 `created()` 의 201 을 에러로 처리하던 버그 수정
- 새 어댑터: `currentStoreName` sessionStorage 저장 (P01/P05/P06 매장명 표시용)

## 🙏 Question & PR point

- **Stack PR**: 이 브랜치는 `#72/n02-menu-connection` 위에 쌓여있습니다. #72 머지 → 이 PR 머지 순서.
- 백엔드 `OrderService.addItem` 에서 옵션 비교는 `Set<Long>` 으로 optionId 집합이 같은지로 판단. 옵션 미지정(빈 배열) 끼리도 합산됩니다.
- `cancelOrder` 가 카트를 복원하지 않아 "결제 진행 중 결제수단 변경" 시 새 결제로 되돌릴 수 없는 케이스가 남아있습니다. 이번 PR 에서는 confirmOrder 호출을 결제 직전으로 미루는 방식으로 우회했습니다 — 결제 진행 직전(P03/P04 success/approved 직전) 까지는 카트가 살아있어 자유 복귀 가능. cancelOrder 카트 복원은 후속 이슈로 분리 예정.
- AI(FastAPI) 가 카트를 변경한 직후 프론트에서 호출할 동기화 훅을 `window.__N02_syncCart` 로 노출했습니다. FastAPI 응답 처리 코드가 추가되면 이 훅을 부르면 됩니다.

## 📬 Postman

<!-- 검증 시 사용한 cURL 흐름:
  POST /api/sessions {mode:NORMAL, language:ko}
  POST /api/orders/cart/items {sessionId, menuId, quantity, optionIds:[]}  ×N
  GET  /api/orders/cart/{sessionId}
  POST /api/orders/confirm {sessionId}
  POST /api/payments {orderId, method:IC_CARD|VEIN_AUTH}
  PATCH /api/payments/{id}/success
  PATCH /api/sessions/{id}/complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 동일한 메뉴와 옵션으로 추가된 장바구니 항목이 더 이상 중복되지 않고 병합됩니다
  * API 응답 처리 범위 확대로 호환성 개선

* **개선사항**
  * 장바구니 데이터 동기화 안정성 강화
  * 결제 프로세스 및 세션 관리 개선으로 사용자 경험 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->