### PR TITLE
[Feat] 관리자 판매 리포트 엑셀 다운로드 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	implementation 'org.apache.poi:poi-ooxml:5.2.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	implementation 'org.apache.poi:poi-ooxml:5.2.5'
+	implementation 'org.apache.poi:poi-ooxml:5.4.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminReportController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/controller/AdminReportController.java
@@ -1,0 +1,47 @@
+package dgu.capstone.nunchi.domain.admin.controller;
+
+import dgu.capstone.nunchi.domain.admin.service.AdminSalesReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+
+@SecurityRequirement(name = "Bearer Authentication")
+@Tag(name = "관리자 리포트 API", description = "관리자페이지에서 판매 리포트 파일을 다운로드하는 API입니다.")
+@RestController
+@RequestMapping("/api/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminSalesReportService adminSalesReportService;
+
+    @Operation(
+            summary = "월간 판매 리포트 엑셀 다운로드",
+            description = "선택한 월의 주문/매출/메뉴별 판매 데이터를 엑셀 파일로 다운로드합니다. month 값이 없으면 현재 월 기준으로 생성합니다."
+    )
+    @GetMapping("/sales/excel")
+    public ResponseEntity<byte[]> downloadMonthlySalesExcel(
+            @Parameter(description = "조회 월 yyyy-MM 형식", example = "2026-05")
+            @RequestParam(required = false) String month
+    ) {
+        byte[] excelFile = adminSalesReportService.createMonthlySalesExcel(month);
+        String fileName = adminSalesReportService.createMonthlyFileName(month);
+
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(fileName, StandardCharsets.UTF_8)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(excelFile);
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminSalesReportService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminSalesReportService.java
@@ -16,7 +16,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
-import java.util.*;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,11 +33,8 @@ public class AdminSalesReportService {
     public byte[] createMonthlySalesExcel(String month) {
         YearMonth targetMonth = parseMonth(month);
 
-        LocalDate startDate = targetMonth.atDay(1);
-        LocalDate endDate = targetMonth.atEndOfMonth();
-
-        LocalDateTime start = startDate.atStartOfDay();
-        LocalDateTime end = endDate.atTime(23, 59, 59);
+        LocalDateTime start = targetMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = targetMonth.plusMonths(1).atDay(1).atStartOfDay().minusNanos(1);
 
         List<Order> completedOrders = orderRepository.findAllByCreatedAtBetweenAndOrderStatus(
                 start,
@@ -77,7 +77,11 @@ public class AdminSalesReportService {
             return YearMonth.now(ZoneId.of("Asia/Seoul"));
         }
 
-        return YearMonth.parse(month);
+        try {
+            return YearMonth.parse(month);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("조회 월은 yyyy-MM 형식이어야 합니다.");
+        }
     }
 
     private void createSummarySheet(
@@ -91,11 +95,11 @@ public class AdminSalesReportService {
         Sheet sheet = workbook.createSheet("요약");
 
         int totalOrderCount = completedOrders.size();
-        int totalSalesAmount = completedOrders.stream()
-                .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+        long totalSalesAmount = completedOrders.stream()
+                .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                 .sum();
 
-        int averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
+        long averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
 
         AdminTopMenuSalesResponse topMenu = menuSales.isEmpty() ? null : menuSales.get(0);
 
@@ -133,11 +137,11 @@ public class AdminSalesReportService {
         Sheet sheet = workbook.createSheet("대시보드");
 
         int totalOrderCount = completedOrders.size();
-        int totalSalesAmount = completedOrders.stream()
-                .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+        long totalSalesAmount = completedOrders.stream()
+                .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                 .sum();
 
-        int averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
+        long averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
         AdminTopMenuSalesResponse topMenu = menuSales.isEmpty() ? null : menuSales.get(0);
 
         int rowIndex = 0;
@@ -198,27 +202,27 @@ public class AdminSalesReportService {
         Map<LocalDate, List<Order>> ordersByDate = completedOrders.stream()
                 .collect(Collectors.groupingBy(order -> order.getCreatedAt().toLocalDate()));
 
-        Map<LocalDate, Integer> salesByDate = new LinkedHashMap<>();
+        Map<LocalDate, Long> salesByDate = new LinkedHashMap<>();
 
         for (int day = 1; day <= targetMonth.lengthOfMonth(); day++) {
             LocalDate date = targetMonth.atDay(day);
             List<Order> orders = ordersByDate.getOrDefault(date, List.of());
 
-            int salesAmount = orders.stream()
-                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+            long salesAmount = orders.stream()
+                    .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                     .sum();
 
             salesByDate.put(date, salesAmount);
         }
 
-        int maxSales = salesByDate.values().stream()
-                .mapToInt(Integer::intValue)
+        long maxSales = salesByDate.values().stream()
+                .mapToLong(Long::longValue)
                 .max()
-                .orElse(0);
+                .orElse(0L);
 
-        for (Map.Entry<LocalDate, Integer> entry : salesByDate.entrySet()) {
+        for (Map.Entry<LocalDate, Long> entry : salesByDate.entrySet()) {
             LocalDate date = entry.getKey();
-            int salesAmount = entry.getValue();
+            long salesAmount = entry.getValue();
             int orderCount = ordersByDate.getOrDefault(date, List.of()).size();
 
             Row row = sheet.createRow(rowIndex++);
@@ -267,8 +271,8 @@ public class AdminSalesReportService {
             List<Order> orders = ordersByHour.getOrDefault(hour, List.of());
 
             int orderCount = orders.size();
-            int salesAmount = orders.stream()
-                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+            long salesAmount = orders.stream()
+                    .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                     .sum();
 
             Row row = sheet.createRow(rowIndex++);
@@ -383,8 +387,8 @@ public class AdminSalesReportService {
             List<Order> orders = ordersByDate.getOrDefault(date, List.of());
 
             int orderCount = orders.size();
-            int salesAmount = orders.stream()
-                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+            long salesAmount = orders.stream()
+                    .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                     .sum();
 
             Row row = sheet.createRow(rowIndex++);
@@ -423,8 +427,8 @@ public class AdminSalesReportService {
             List<Order> orders = ordersByHour.getOrDefault(hour, List.of());
 
             int orderCount = orders.size();
-            int salesAmount = orders.stream()
-                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+            long salesAmount = orders.stream()
+                    .mapToLong(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0L)
                     .sum();
 
             Row row = sheet.createRow(rowIndex++);

--- a/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminSalesReportService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/admin/service/AdminSalesReportService.java
@@ -1,0 +1,526 @@
+package dgu.capstone.nunchi.domain.admin.service;
+
+import dgu.capstone.nunchi.domain.admin.dto.response.AdminTopMenuSalesResponse;
+import dgu.capstone.nunchi.domain.order.entity.Order;
+import dgu.capstone.nunchi.domain.order.entity.OrderStatus;
+import dgu.capstone.nunchi.domain.order.repository.OrderItemRepository;
+import dgu.capstone.nunchi.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSalesReportService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    public byte[] createMonthlySalesExcel(String month) {
+        YearMonth targetMonth = parseMonth(month);
+
+        LocalDate startDate = targetMonth.atDay(1);
+        LocalDate endDate = targetMonth.atEndOfMonth();
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.atTime(23, 59, 59);
+
+        List<Order> completedOrders = orderRepository.findAllByCreatedAtBetweenAndOrderStatus(
+                start,
+                end,
+                OrderStatus.COMPLETED
+        );
+
+        List<AdminTopMenuSalesResponse> menuSales = orderItemRepository.findMenuSalesByPeriod(
+                start,
+                end,
+                OrderStatus.COMPLETED
+        );
+
+        try (Workbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            CellStyle moneyStyle = createMoneyStyle(workbook);
+
+            createSummarySheet(workbook, headerStyle, moneyStyle, targetMonth, completedOrders, menuSales);
+            createDashboardSheet(workbook, headerStyle, moneyStyle, targetMonth, completedOrders, menuSales);
+            createDailySalesSheet(workbook, headerStyle, moneyStyle, targetMonth, completedOrders);
+            createHourlySalesSheet(workbook, headerStyle, moneyStyle, completedOrders);
+            createMenuSalesSheet(workbook, headerStyle, moneyStyle, menuSales);
+
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("엑셀 리포트 생성에 실패했습니다.", e);
+        }
+    }
+
+    public String createMonthlyFileName(String month) {
+        YearMonth targetMonth = parseMonth(month);
+        return "monthly-sales-report-" + targetMonth + ".xlsx";
+    }
+
+    private YearMonth parseMonth(String month) {
+        if (month == null || month.isBlank()) {
+            return YearMonth.now(ZoneId.of("Asia/Seoul"));
+        }
+
+        return YearMonth.parse(month);
+    }
+
+    private void createSummarySheet(
+            Workbook workbook,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            YearMonth targetMonth,
+            List<Order> completedOrders,
+            List<AdminTopMenuSalesResponse> menuSales
+    ) {
+        Sheet sheet = workbook.createSheet("요약");
+
+        int totalOrderCount = completedOrders.size();
+        int totalSalesAmount = completedOrders.stream()
+                .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                .sum();
+
+        int averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
+
+        AdminTopMenuSalesResponse topMenu = menuSales.isEmpty() ? null : menuSales.get(0);
+
+        int rowIndex = 0;
+
+        Row titleRow = sheet.createRow(rowIndex++);
+        titleRow.createCell(0).setCellValue("NUNCHI 월간 판매 리포트");
+
+        rowIndex++;
+
+        rowIndex = createSummaryRow(sheet, rowIndex, "기준 월", targetMonth.toString(), headerStyle, null);
+        rowIndex = createSummaryRow(sheet, rowIndex, "총 주문 수", totalOrderCount + "건", headerStyle, null);
+        rowIndex = createSummaryRow(sheet, rowIndex, "총 매출", totalSalesAmount, headerStyle, moneyStyle);
+        rowIndex = createSummaryRow(sheet, rowIndex, "평균 주문 금액", averageOrderAmount, headerStyle, moneyStyle);
+        rowIndex = createSummaryRow(
+                sheet,
+                rowIndex,
+                "TOP 판매 메뉴",
+                topMenu == null ? "-" : topMenu.menuName() + " (" + topMenu.quantitySold() + "개)",
+                headerStyle,
+                null
+        );
+
+        autoSizeColumns(sheet, 2);
+    }
+
+    private void createDashboardSheet(
+            Workbook workbook,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            YearMonth targetMonth,
+            List<Order> completedOrders,
+            List<AdminTopMenuSalesResponse> menuSales
+    ) {
+        Sheet sheet = workbook.createSheet("대시보드");
+
+        int totalOrderCount = completedOrders.size();
+        int totalSalesAmount = completedOrders.stream()
+                .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                .sum();
+
+        int averageOrderAmount = totalOrderCount == 0 ? 0 : totalSalesAmount / totalOrderCount;
+        AdminTopMenuSalesResponse topMenu = menuSales.isEmpty() ? null : menuSales.get(0);
+
+        int rowIndex = 0;
+
+        Row titleRow = sheet.createRow(rowIndex++);
+        Cell titleCell = titleRow.createCell(0);
+        titleCell.setCellValue("NUNCHI 월간 판매 대시보드");
+        titleCell.setCellStyle(headerStyle);
+
+        rowIndex++;
+
+        rowIndex = createSummaryRow(sheet, rowIndex, "기준 월", targetMonth.toString(), headerStyle, null);
+        rowIndex = createSummaryRow(sheet, rowIndex, "총 주문 수", totalOrderCount + "건", headerStyle, null);
+        rowIndex = createSummaryRow(sheet, rowIndex, "총 매출", totalSalesAmount, headerStyle, moneyStyle);
+        rowIndex = createSummaryRow(sheet, rowIndex, "평균 주문 금액", averageOrderAmount, headerStyle, moneyStyle);
+        rowIndex = createSummaryRow(
+                sheet,
+                rowIndex,
+                "TOP 판매 메뉴",
+                topMenu == null ? "-" : topMenu.menuName() + " (" + topMenu.quantitySold() + "개)",
+                headerStyle,
+                null
+        );
+
+        rowIndex += 2;
+
+        rowIndex = createDailySalesChartSection(sheet, rowIndex, headerStyle, moneyStyle, targetMonth, completedOrders);
+        rowIndex += 2;
+
+        rowIndex = createHourlySalesChartSection(sheet, rowIndex, headerStyle, moneyStyle, completedOrders);
+        rowIndex += 2;
+
+        createMenuSalesChartSection(sheet, rowIndex, headerStyle, moneyStyle, menuSales);
+
+        autoSizeColumns(sheet, 5);
+        setColumnWidths(sheet, 5000, 3000, 5000, 9000, 9000);
+    }
+
+    private int createDailySalesChartSection(
+            Sheet sheet,
+            int rowIndex,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            YearMonth targetMonth,
+            List<Order> completedOrders
+    ) {
+        Row sectionTitle = sheet.createRow(rowIndex++);
+        Cell titleCell = sectionTitle.createCell(0);
+        titleCell.setCellValue("최근 일별 매출 추이");
+        titleCell.setCellStyle(headerStyle);
+
+        Row header = sheet.createRow(rowIndex++);
+        createHeaderCell(header, 0, "날짜", headerStyle);
+        createHeaderCell(header, 1, "주문 수", headerStyle);
+        createHeaderCell(header, 2, "매출", headerStyle);
+        createHeaderCell(header, 3, "추이", headerStyle);
+
+        Map<LocalDate, List<Order>> ordersByDate = completedOrders.stream()
+                .collect(Collectors.groupingBy(order -> order.getCreatedAt().toLocalDate()));
+
+        Map<LocalDate, Integer> salesByDate = new LinkedHashMap<>();
+
+        for (int day = 1; day <= targetMonth.lengthOfMonth(); day++) {
+            LocalDate date = targetMonth.atDay(day);
+            List<Order> orders = ordersByDate.getOrDefault(date, List.of());
+
+            int salesAmount = orders.stream()
+                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                    .sum();
+
+            salesByDate.put(date, salesAmount);
+        }
+
+        int maxSales = salesByDate.values().stream()
+                .mapToInt(Integer::intValue)
+                .max()
+                .orElse(0);
+
+        for (Map.Entry<LocalDate, Integer> entry : salesByDate.entrySet()) {
+            LocalDate date = entry.getKey();
+            int salesAmount = entry.getValue();
+            int orderCount = ordersByDate.getOrDefault(date, List.of()).size();
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(date.toString());
+            row.createCell(1).setCellValue(orderCount);
+
+            Cell salesCell = row.createCell(2);
+            salesCell.setCellValue(salesAmount);
+            salesCell.setCellStyle(moneyStyle);
+
+            row.createCell(3).setCellValue(createBar(salesAmount, maxSales));
+        }
+
+        return rowIndex;
+    }
+
+    private int createHourlySalesChartSection(
+            Sheet sheet,
+            int rowIndex,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            List<Order> completedOrders
+    ) {
+        Row sectionTitle = sheet.createRow(rowIndex++);
+        Cell titleCell = sectionTitle.createCell(0);
+        titleCell.setCellValue("시간대별 주문 현황");
+        titleCell.setCellStyle(headerStyle);
+
+        Row header = sheet.createRow(rowIndex++);
+        createHeaderCell(header, 0, "시간대", headerStyle);
+        createHeaderCell(header, 1, "주문 수", headerStyle);
+        createHeaderCell(header, 2, "매출", headerStyle);
+        createHeaderCell(header, 3, "주문량", headerStyle);
+
+        Map<Integer, List<Order>> ordersByHour = completedOrders.stream()
+                .collect(Collectors.groupingBy(order -> order.getCreatedAt().getHour()));
+
+        int maxOrderCount = 0;
+
+        for (int hour = 0; hour < 24; hour++) {
+            int orderCount = ordersByHour.getOrDefault(hour, List.of()).size();
+            maxOrderCount = Math.max(maxOrderCount, orderCount);
+        }
+
+        for (int hour = 0; hour < 24; hour++) {
+            List<Order> orders = ordersByHour.getOrDefault(hour, List.of());
+
+            int orderCount = orders.size();
+            int salesAmount = orders.stream()
+                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                    .sum();
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(hour + "시");
+            row.createCell(1).setCellValue(orderCount);
+
+            Cell salesCell = row.createCell(2);
+            salesCell.setCellValue(salesAmount);
+            salesCell.setCellStyle(moneyStyle);
+
+            row.createCell(3).setCellValue(createBar(orderCount, maxOrderCount));
+        }
+
+        return rowIndex;
+    }
+
+    private int createMenuSalesChartSection(
+            Sheet sheet,
+            int rowIndex,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            List<AdminTopMenuSalesResponse> menuSales
+    ) {
+        Row sectionTitle = sheet.createRow(rowIndex++);
+        Cell titleCell = sectionTitle.createCell(0);
+        titleCell.setCellValue("TOP 판매 메뉴");
+        titleCell.setCellStyle(headerStyle);
+
+        Row header = sheet.createRow(rowIndex++);
+        createHeaderCell(header, 0, "순위", headerStyle);
+        createHeaderCell(header, 1, "메뉴명", headerStyle);
+        createHeaderCell(header, 2, "판매 수량", headerStyle);
+        createHeaderCell(header, 3, "매출", headerStyle);
+        createHeaderCell(header, 4, "판매량", headerStyle);
+
+        long maxQuantity = menuSales.stream()
+                .mapToLong(menu -> menu.quantitySold() != null ? menu.quantitySold() : 0)
+                .max()
+                .orElse(0);
+
+        for (int i = 0; i < menuSales.size(); i++) {
+            AdminTopMenuSalesResponse menu = menuSales.get(i);
+
+            long quantity = menu.quantitySold() != null ? menu.quantitySold() : 0;
+            long salesAmount = menu.salesAmount() != null ? menu.salesAmount() : 0;
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(i + 1);
+            row.createCell(1).setCellValue(menu.menuName());
+            row.createCell(2).setCellValue(quantity);
+
+            Cell salesCell = row.createCell(3);
+            salesCell.setCellValue(salesAmount);
+            salesCell.setCellStyle(moneyStyle);
+
+            row.createCell(4).setCellValue(createBar(quantity, maxQuantity));
+        }
+
+        return rowIndex;
+    }
+
+    private int createSummaryRow(
+            Sheet sheet,
+            int rowIndex,
+            String label,
+            Object value,
+            CellStyle headerStyle,
+            CellStyle valueStyle
+    ) {
+        Row row = sheet.createRow(rowIndex);
+
+        Cell labelCell = row.createCell(0);
+        labelCell.setCellValue(label);
+        labelCell.setCellStyle(headerStyle);
+
+        Cell valueCell = row.createCell(1);
+
+        if (value instanceof Number number) {
+            valueCell.setCellValue(number.doubleValue());
+        } else {
+            valueCell.setCellValue(String.valueOf(value));
+        }
+
+        if (valueStyle != null) {
+            valueCell.setCellStyle(valueStyle);
+        }
+
+        return rowIndex + 1;
+    }
+
+    private void createDailySalesSheet(
+            Workbook workbook,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            YearMonth targetMonth,
+            List<Order> completedOrders
+    ) {
+        Sheet sheet = workbook.createSheet("일별 매출");
+
+        Row header = sheet.createRow(0);
+        createHeaderCell(header, 0, "날짜", headerStyle);
+        createHeaderCell(header, 1, "주문 수", headerStyle);
+        createHeaderCell(header, 2, "매출", headerStyle);
+
+        Map<LocalDate, List<Order>> ordersByDate = completedOrders.stream()
+                .collect(Collectors.groupingBy(order -> order.getCreatedAt().toLocalDate()));
+
+        int rowIndex = 1;
+
+        for (int day = 1; day <= targetMonth.lengthOfMonth(); day++) {
+            LocalDate date = targetMonth.atDay(day);
+            List<Order> orders = ordersByDate.getOrDefault(date, List.of());
+
+            int orderCount = orders.size();
+            int salesAmount = orders.stream()
+                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                    .sum();
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(date.toString());
+            row.createCell(1).setCellValue(orderCount);
+
+            Cell salesCell = row.createCell(2);
+            salesCell.setCellValue(salesAmount);
+            salesCell.setCellStyle(moneyStyle);
+        }
+
+        autoSizeColumns(sheet, 3);
+        setColumnWidths(sheet, 4000, 3000, 5000);
+
+    }
+
+    private void createHourlySalesSheet(
+            Workbook workbook,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            List<Order> completedOrders
+    ) {
+        Sheet sheet = workbook.createSheet("시간대별 판매");
+
+        Row header = sheet.createRow(0);
+        createHeaderCell(header, 0, "시간대", headerStyle);
+        createHeaderCell(header, 1, "주문 수", headerStyle);
+        createHeaderCell(header, 2, "매출", headerStyle);
+
+        Map<Integer, List<Order>> ordersByHour = completedOrders.stream()
+                .collect(Collectors.groupingBy(order -> order.getCreatedAt().getHour()));
+
+        int rowIndex = 1;
+
+        for (int hour = 0; hour < 24; hour++) {
+            List<Order> orders = ordersByHour.getOrDefault(hour, List.of());
+
+            int orderCount = orders.size();
+            int salesAmount = orders.stream()
+                    .mapToInt(order -> order.getTotalAmount() != null ? order.getTotalAmount() : 0)
+                    .sum();
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(hour + "시");
+            row.createCell(1).setCellValue(orderCount);
+
+            Cell salesCell = row.createCell(2);
+            salesCell.setCellValue(salesAmount);
+            salesCell.setCellStyle(moneyStyle);
+        }
+
+        autoSizeColumns(sheet, 3);
+        setColumnWidths(sheet, 3000, 3000, 5000);
+    }
+
+    private void createMenuSalesSheet(
+            Workbook workbook,
+            CellStyle headerStyle,
+            CellStyle moneyStyle,
+            List<AdminTopMenuSalesResponse> menuSales
+    ) {
+        Sheet sheet = workbook.createSheet("메뉴별 판매");
+
+        Row header = sheet.createRow(0);
+        createHeaderCell(header, 0, "순위", headerStyle);
+        createHeaderCell(header, 1, "메뉴 ID", headerStyle);
+        createHeaderCell(header, 2, "메뉴명", headerStyle);
+        createHeaderCell(header, 3, "판매 수량", headerStyle);
+        createHeaderCell(header, 4, "매출", headerStyle);
+
+        int rowIndex = 1;
+
+        for (int i = 0; i < menuSales.size(); i++) {
+            AdminTopMenuSalesResponse menu = menuSales.get(i);
+
+            Row row = sheet.createRow(rowIndex++);
+            row.createCell(0).setCellValue(i + 1);
+            row.createCell(1).setCellValue(menu.menuId());
+            row.createCell(2).setCellValue(menu.menuName());
+            row.createCell(3).setCellValue(menu.quantitySold() != null ? menu.quantitySold() : 0);
+
+            Cell salesCell = row.createCell(4);
+            salesCell.setCellValue(menu.salesAmount() != null ? menu.salesAmount() : 0);
+            salesCell.setCellStyle(moneyStyle);
+        }
+
+        autoSizeColumns(sheet, 5);
+        setColumnWidths(sheet, 2500, 3000, 6000, 3000, 5000);
+    }
+
+    private CellStyle createHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+
+        Font font = workbook.createFont();
+        font.setBold(true);
+
+        style.setFont(font);
+        style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
+        return style;
+    }
+
+    private CellStyle createMoneyStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        DataFormat format = workbook.createDataFormat();
+        style.setDataFormat(format.getFormat("#,##0원"));
+        return style;
+    }
+
+    private void createHeaderCell(Row row, int columnIndex, String value, CellStyle headerStyle) {
+        Cell cell = row.createCell(columnIndex);
+        cell.setCellValue(value);
+        cell.setCellStyle(headerStyle);
+    }
+
+    private void autoSizeColumns(Sheet sheet, int columnCount) {
+        for (int i = 0; i < columnCount; i++) {
+            sheet.autoSizeColumn(i);
+        }
+    }
+
+    private void setColumnWidths(Sheet sheet, int... widths) {
+        for (int i = 0; i < widths.length; i++) {
+            sheet.setColumnWidth(i, widths[i]);
+        }
+    }
+
+    private String createBar(long value, long maxValue) {
+        if (maxValue <= 0 || value <= 0) {
+            return "";
+        }
+
+        int maxBarLength = 20;
+        int barLength = (int) Math.ceil((double) value / maxValue * maxBarLength);
+
+        return "█".repeat(Math.max(barLength, 1));
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderItemRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
@@ -42,5 +43,25 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     List<AdminTopMenuSalesResponse> findTopMenuSales(
             @Param("orderStatus") OrderStatus orderStatus,
             Pageable pageable
+    );
+
+    @Query("""
+    SELECT new dgu.capstone.nunchi.domain.admin.dto.response.AdminTopMenuSalesResponse(
+        oi.menuId,
+        MAX(oi.menuName),
+        SUM(oi.quantity),
+        SUM(oi.quantity * oi.unitPrice)
+    )
+    FROM OrderItem oi
+    JOIN oi.order o
+    WHERE o.orderStatus = :orderStatus
+      AND o.createdAt BETWEEN :start AND :end
+    GROUP BY oi.menuId
+    ORDER BY SUM(oi.quantity) DESC
+""")
+    List<AdminTopMenuSalesResponse> findMenuSalesByPeriod(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("orderStatus") OrderStatus orderStatus
     );
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/order/repository/OrderRepository.java
@@ -38,4 +38,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("end") LocalDateTime end,
             @Param("orderStatus") OrderStatus orderStatus
     );
+
+    List<Order> findAllByCreatedAtBetweenAndOrderStatus(
+            LocalDateTime start,
+            LocalDateTime end,
+            OrderStatus orderStatus
+    );
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,10 +13,13 @@ spring:
         - classpath:/templates_front/
 
   datasource:
-    url: ${LOCAL_DB_URL}
-    username: ${LOCAL_DB_USERNAME}
-    password: ${LOCAL_DB_PASSWORD}
+    url: jdbc:postgresql://127.0.0.1:5433/nunchi
+    username: nunchi
+    password: nunchi1234
     driver-class-name: org.postgresql.Driver
+    hikari:
+      data-source-properties:
+        sslmode: disable
 
   jpa:
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,9 +13,9 @@ spring:
         - classpath:/templates_front/
 
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5433/nunchi
-    username: nunchi
-    password: nunchi1234
+    url: ${LOCAL_DB_URL:jdbc:postgresql://127.0.0.1:5433/nunchi}
+    username: ${LOCAL_DB_USERNAME:nunchi}
+    password: ${LOCAL_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
       data-source-properties:
@@ -36,12 +36,12 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+  admin:
+    password: ${ADMIN_PASSWORD:1234}
+
+  jwt:
+    secret: ${JWT_SECRET:your-very-long-secret-key-your-very-long-secret-key}
+    expiration-ms: ${JWT_EXPIRATION_MS:3600000}
+
 fastapi:
-  base-url: http://localhost:8000
-
-admin:
-  password: ${ADMIN_PASSWORD:3316}
-
-jwt:
-  secret: ${JWT_SECRET:your-very-long-secret-key-your-very-long-secret-key}
-  expiration-ms: 3600000
+  base-url: ${LOCAL_FASTAPI_URL:http://localhost:8000}

--- a/src/main/resources/static/front/css/admin/admin.css
+++ b/src/main/resources/static/front/css/admin/admin.css
@@ -541,3 +541,44 @@ input {
         align-items: flex-start;
     }
 }
+
+.report-download-box {
+    display: flex;
+    align-items: end;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 18px;
+    border-radius: 16px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+}
+
+.report-download-box label {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #374151;
+}
+
+.admin-input {
+    min-width: 180px;
+    height: 44px;
+    padding: 0 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 12px;
+    font-size: 15px;
+    color: #111827;
+    background: #ffffff;
+}
+
+.admin-input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.primary-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}

--- a/src/main/resources/static/front/css/admin/admin.css
+++ b/src/main/resources/static/front/css/admin/admin.css
@@ -577,8 +577,3 @@ input {
     outline: 2px solid #2563eb;
     outline-offset: 2px;
 }
-
-.primary-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-}

--- a/src/main/resources/static/front/js/admin/admin-dashboard.js
+++ b/src/main/resources/static/front/js/admin/admin-dashboard.js
@@ -17,6 +17,10 @@ const analyticsLoading = document.getElementById("analyticsLoading");
 const analyticsError = document.getElementById("analyticsError");
 const analyticsContent = document.getElementById("analyticsContent");
 
+const salesReportMonth = document.getElementById("salesReportMonth");
+const downloadSalesExcelButton = document.getElementById("downloadSalesExcelButton");
+const salesReportError = document.getElementById("salesReportError");
+
 const dailySalesChart = document.getElementById("dailySalesChart");
 const hourlySalesChart = document.getElementById("hourlySalesChart");
 const topMenuChart = document.getElementById("topMenuChart");
@@ -28,6 +32,8 @@ document.addEventListener("DOMContentLoaded", () => {
         redirectToAdminLogin();
         return;
     }
+
+    setDefaultSalesReportMonth();
 
     loadDashboard();
     loadAnalytics();
@@ -45,6 +51,12 @@ refreshDashboardButton.addEventListener("click", () => {
 if (refreshAnalyticsButton) {
     refreshAnalyticsButton.addEventListener("click", () => {
         loadAnalytics();
+    });
+}
+
+if (downloadSalesExcelButton) {
+    downloadSalesExcelButton.addEventListener("click", () => {
+        downloadSalesExcelReport();
     });
 }
 
@@ -199,4 +211,74 @@ function escapeHtml(value) {
         .replaceAll(">", "&gt;")
         .replaceAll('"', "&quot;")
         .replaceAll("'", "&#039;");
+}
+
+function setDefaultSalesReportMonth() {
+    if (!salesReportMonth) return;
+
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+
+    salesReportMonth.value = `${year}-${month}`;
+}
+
+async function downloadSalesExcelReport() {
+    if (!salesReportMonth || !downloadSalesExcelButton) return;
+
+    const month = salesReportMonth.value;
+
+    if (!month) {
+        salesReportError.textContent = "조회 월을 선택해주세요.";
+        return;
+    }
+
+    salesReportError.textContent = "";
+    downloadSalesExcelButton.disabled = true;
+    downloadSalesExcelButton.textContent = "다운로드 중...";
+
+    try {
+        const token = getAdminToken();
+
+        if (!token) {
+            redirectToAdminLogin();
+            return;
+        }
+
+        const response = await fetch(`/api/admin/reports/sales/excel?month=${encodeURIComponent(month)}`, {
+            method: "GET",
+            headers: {
+                "Authorization": `Bearer ${token}`
+            }
+        });
+
+        if (response.status === 401 || response.status === 403) {
+            clearAdminToken();
+            alert("관리자 인증이 만료되었거나 유효하지 않습니다. 다시 인증해주세요.");
+            redirectToAdminLogin();
+            return;
+        }
+
+        if (!response.ok) {
+            throw new Error("엑셀 리포트 다운로드에 실패했습니다.");
+        }
+
+        const blob = await response.blob();
+        const downloadUrl = window.URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = downloadUrl;
+        link.download = `monthly-sales-report-${month}.xlsx`;
+
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+
+        window.URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+        salesReportError.textContent = error.message;
+    } finally {
+        downloadSalesExcelButton.disabled = false;
+        downloadSalesExcelButton.textContent = "엑셀 다운로드";
+    }
 }

--- a/src/main/resources/static/front/js/admin/admin-dashboard.js
+++ b/src/main/resources/static/front/js/admin/admin-dashboard.js
@@ -224,7 +224,7 @@ function setDefaultSalesReportMonth() {
 }
 
 async function downloadSalesExcelReport() {
-    if (!salesReportMonth || !downloadSalesExcelButton) return;
+    if (!salesReportMonth || !downloadSalesExcelButton || !salesReportError) return;
 
     const month = salesReportMonth.value;
 

--- a/src/main/resources/templates_front/admin/dashboard.html
+++ b/src/main/resources/templates_front/admin/dashboard.html
@@ -56,6 +56,25 @@
     <section class="admin-section">
         <div class="section-title-row">
             <div>
+                <h2>판매 리포트</h2>
+                <p class="hint-text">월간 판매 데이터를 엑셀 파일로 다운로드합니다.</p>
+            </div>
+        </div>
+
+        <div class="report-download-box">
+            <label for="salesReportMonth">조회 월</label>
+            <input id="salesReportMonth" type="month" class="admin-input" />
+            <button id="downloadSalesExcelButton" class="primary-button">
+                엑셀 다운로드
+            </button>
+        </div>
+
+        <div id="salesReportError" class="error-message"></div>
+    </section>
+
+    <section class="admin-section">
+        <div class="section-title-row">
+            <div>
                 <h2>운영 분석</h2>
                 <p class="hint-text">최근 7일 매출, 오늘 시간대별 주문, TOP 판매 메뉴를 확인합니다.</p>
             </div>


### PR DESCRIPTION
## 📣 Related Issue

- close #70

## 📝 Summary

관리자가 월간 판매 데이터를 엑셀 파일로 다운로드할 수 있도록 판매 리포트 기능을 구현했습니다.

월별 주문/매출 데이터를 기반으로 요약, 대시보드, 일별 매출, 시간대별 판매, 메뉴별 판매 시트를 생성하며, 엑셀 내부에서 막대형 시각화를 제공하여 판매 추이를 한눈에 확인할 수 있도록 개선했습니다.

주요 작업 내용은 다음과 같습니다.

- 월간 판매 리포트 엑셀 다운로드 API 구현
  - `GET /api/admin/reports/sales/excel?month=yyyy-MM`
  - month 파라미터가 없을 경우 현재 월 기준으로 생성
  - 관리자 JWT 인증 적용

- 엑셀 리포트 생성 로직 구현
  - Apache POI 기반 `.xlsx` 파일 생성
  - 요약 시트 생성
  - 대시보드 시트 생성
  - 일별 매출 시트 생성
  - 시간대별 판매 시트 생성
  - 메뉴별 판매 시트 생성

- 엑셀 내 시각화 개선
  - 대시보드 시트에 막대형 판매 추이 표시
  - 일별 매출 추이 표시
  - 시간대별 주문량 표시
  - TOP 판매 메뉴 판매량 표시
  - 금액 컬럼 표시 폭 조정

- 관리자 프론트 다운로드 기능 연결
  - 대시보드에 판매 리포트 다운로드 영역 추가
  - 월 선택 input 추가
  - 엑셀 다운로드 버튼 추가
  - JWT Authorization 헤더 포함하여 파일 다운로드 처리

## 🙏 Question & PR point

- 판매 리포트는 `COMPLETED` 주문만 기준으로 집계합니다.
- 월간 리포트는 선택한 `yyyy-MM` 기준으로 생성됩니다.
- 엑셀 파일에는 개인정보 없이 판매 통계 데이터만 포함됩니다.
- 실제 엑셀 차트 객체 대신 셀 기반 막대형 시각화를 적용했습니다.
- 현재 로컬 테스트 DB는 5433 포트의 PostgreSQL 컨테이너를 사용했습니다.

## 📬 Postman

- 관리자 로그인 후 JWT 발급 확인
- `GET /api/admin/reports/sales/excel?month=2026-05` 호출 확인
- `.xlsx` 파일 다운로드 확인
- 요약/대시보드/일별 매출/시간대별 판매/메뉴별 판매 시트 확인
- 관리자 대시보드에서 월 선택 후 엑셀 다운로드 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Admin 월간 판매 리포트 Excel 파일 다운로드 기능 추가
  * Admin 대시보드에 월별 판매 리포트 섹션 추가
  * 월별 판매 데이터 및 메뉴별 판매 통계 조회 기능

* **Chores**
  * Apache POI 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->