### PR TITLE
[Feat] 카카오페이 바코드 결제 화면(P07) + N02 orderType 회귀 수정

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/global/config/WebConfig.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/WebConfig.java
@@ -35,6 +35,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addViewController("/payment").setViewName("forward:/flowP/P02-payment.html");
         registry.addViewController("/vein").setViewName("forward:/flowP/P03-vein.html");
         registry.addViewController("/processing").setViewName("forward:/flowP/P04-processing.html");
+        registry.addViewController("/barcode").setViewName("forward:/flowP/P07-barcode.html");
         registry.addViewController("/complete").setViewName("forward:/flowP/P05-complete.html");
         registry.addViewController("/fail").setViewName("forward:/flowP/P06-fail.html");
     }

--- a/src/main/resources/static/front/css/flowP/P07-barcode.css
+++ b/src/main/resources/static/front/css/flowP/P07-barcode.css
@@ -1,0 +1,267 @@
+/* ========================================================
+   P07-barcode.css — 카카오페이 결제 (Step 3/3)
+   states: waiting / success
+   - P03-vein.css 와 동일한 원형 280 프레임 패턴 사용
+   - 카카오 옐로우(#FAE100) 톤
+   ======================================================== */
+
+.p07 {
+    position: relative;
+    padding: 24px var(--pad-side) 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+}
+
+/* ===========================
+   1) 원형 비주얼
+   =========================== */
+.p07__scanner {
+    position: relative;
+    width: 320px;
+    height: 320px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* ---- 원형 프레임 ---- */
+.p07__frame {
+    position: relative;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 50%,
+        #FFF8C5 0%,
+        var(--neutral-0) 70%);
+    border: 3px solid #FAE100;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 12px 40px rgba(250, 225, 0, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color var(--duration-base) var(--ease-out),
+                box-shadow var(--duration-base) var(--ease-out);
+}
+
+/* ---- 카카오페이 카드 (원형 안에 둠) ---- */
+.p07__card {
+    width: 200px;
+    height: 130px;
+    border-radius: 12px;
+    background: #FAE100;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 10px 14px 12px;
+    gap: 8px;
+    transition: opacity var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-out);
+}
+
+.p07__card-head {
+    display: flex;
+    align-items: center;
+}
+.p07__card-brand {
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    color: #3C1E1E;     /* 카카오 진갈색 */
+    text-transform: lowercase;
+}
+
+/* ---- 바코드 일러스트 ---- */
+.p07__barcode {
+    flex: 1;
+    display: flex;
+    align-items: stretch;
+    gap: 2px;
+    background: #FFFFFF;
+    border-radius: 4px;
+    padding: 6px 10px;
+}
+.p07__barcode span {
+    display: block;
+    background: #2B2B2B;
+    border-radius: 1px;
+    height: 100%;
+}
+.p07__barcode span:nth-child(odd)  { width: 3px; }
+.p07__barcode span:nth-child(even) { width: 1px; }
+.p07__barcode span:nth-child(3n)   { width: 4px; }
+.p07__barcode span:nth-child(5n)   { width: 2px; }
+.p07__barcode span:nth-child(7n)   { width: 3px; }
+
+/* ---- 스캔 라인 (waiting 시 위→아래 반복) ---- */
+.p07__scanline {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 220px;
+    height: 3px;
+    border-radius: 2px;
+    background: linear-gradient(90deg,
+        transparent 0%,
+        #E8600A 30%,
+        #FF8A3D 50%,
+        #E8600A 70%,
+        transparent 100%);
+    box-shadow: 0 0 12px rgba(232, 96, 10, 0.65);
+    top: 80px;
+    opacity: 0;
+    pointer-events: none;
+}
+.p07[data-state="waiting"] .p07__scanline {
+    opacity: 1;
+    animation: p07-scan 2.2s ease-in-out infinite;
+}
+@keyframes p07-scan {
+    0%   { top: 80px;  opacity: 0.85; }
+    50%  { top: 200px; opacity: 1; }
+    100% { top: 80px;  opacity: 0.85; }
+}
+
+/* ---- 펄스 링 (waiting 에서만) ---- */
+.p07__pulse {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    border: 2px solid rgba(250, 225, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+}
+.p07[data-state="waiting"] .p07__pulse {
+    animation: p07-pulse 2.4s ease-out infinite;
+}
+.p07[data-state="waiting"] .p07__pulse--2 { animation-delay: 0.8s; }
+.p07[data-state="waiting"] .p07__pulse--3 { animation-delay: 1.6s; }
+
+@keyframes p07-pulse {
+    0%   { transform: scale(0.85); opacity: 0.0; }
+    20%  { opacity: 0.7; }
+    100% { transform: scale(1.35); opacity: 0; }
+}
+
+/* ---- 성공 오버레이 ---- */
+.p07__status-icon {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.95);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 56px;
+    color: var(--success-600, #16a34a);
+    opacity: 0;
+    transform: scale(0.6);
+    pointer-events: none;
+    transition: opacity var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-out);
+}
+
+.p07[data-state="success"] .p07__status-icon--success {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.p07[data-state="success"] .p07__frame {
+    border-color: var(--success-600, #16a34a);
+    box-shadow: 0 12px 40px rgba(22, 163, 74, 0.25);
+    background: radial-gradient(circle at 50% 50%,
+        rgba(22, 163, 74, 0.08) 0%,
+        var(--neutral-0) 70%);
+}
+
+.p07[data-state="success"] .p07__card {
+    opacity: 0.4;
+    transform: scale(0.92);
+}
+.p07[data-state="success"] .p07__scanline {
+    opacity: 0;
+    animation: none;
+}
+
+/* ===========================
+   2) 텍스트 영역
+   =========================== */
+.p07__text {
+    width: 100%;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.p07__title {
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1.35;
+    color: var(--neutral-900);
+    margin: 0;
+}
+
+.p07__desc {
+    font-size: 16px;
+    color: var(--neutral-700);
+    margin: 0;
+    line-height: 1.55;
+    max-width: 480px;
+}
+
+/* 진행 바 (waiting 에서만 보임) */
+.p07__progress {
+    width: 280px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--neutral-200);
+    overflow: hidden;
+    margin-top: 8px;
+}
+.p07__progress-bar {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, #FAE100 0%, #FFB800 100%);
+    border-radius: 3px;
+    transition: width 0.1s linear;
+}
+.p07[data-state="success"] .p07__progress {
+    display: none;
+}
+
+/* ===========================
+   3) 하단 CTA
+   =========================== */
+.p07__cta-wrap {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 16px var(--pad-side) 24px;
+    background: linear-gradient(180deg, transparent 0%, var(--neutral-0) 30%);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+}
+
+.p07__cta--cancel { display: block; }
+.p07__cta--success-hint {
+    display: none;
+    font-size: 15px;
+    color: var(--neutral-600);
+    margin: 0;
+}
+.p07[data-state="success"] ~ .p07__cta-wrap .p07__cta--cancel { display: none; }
+.p07[data-state="success"] ~ .p07__cta-wrap .p07__cta--success-hint { display: block; }

--- a/src/main/resources/static/front/js/common/api-client.js
+++ b/src/main/resources/static/front/js/common/api-client.js
@@ -184,6 +184,11 @@
         create(orderId, method) {
             return request('POST', '/api/payments', { orderId, method });
         },
+        // POST /api/payments/barcode — 백엔드는 confirmOrder 완료된 orderId 가 필요하고
+        // barcodeValue 검증 없이 즉시 SUCCESS 결제 레코드를 만든다.
+        payByBarcode(orderId, barcodeValue) {
+            return request('POST', '/api/payments/barcode', { orderId, barcodeValue });
+        },
         markSuccess(paymentId) {
             return request('PATCH', `/api/payments/${encodeURIComponent(paymentId)}/success`);
         },

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -108,9 +108,15 @@
         const rawMode = (state.mode || "NORMAL").toUpperCase();
         const safeMode = (rawMode === "AVATAR") ? "AVATAR" : "NORMAL";
 
+        // S02-dine 의 dineOption (`dine_in` / `take_out`) → 백엔드 OrderType (`DINE_IN` / `TAKEOUT`)
+        // SessionCreateRequest 가 @NotNull 로 orderType 요구하므로 누락 시 400.
+        const rawDine = sessionStorage.getItem("dineOption") || "";
+        const orderType = (rawDine === "take_out") ? "TAKEOUT" : "DINE_IN";
+
         const created = await window.Api.session.create({
             mode: safeMode,
             language: "ko",
+            orderType: orderType,
         });
         state.sessionId = created.sessionId;
         sessionStorage.setItem("sessionId", String(state.sessionId));

--- a/src/main/resources/static/front/js/flowP/P02-payment.js
+++ b/src/main/resources/static/front/js/flowP/P02-payment.js
@@ -85,6 +85,12 @@
                 hintEl.classList.add('p02__hint--selected');
                 hintTxtEl.textContent = '등록된 손바닥 정맥으로 간편하게 인증해요';
             }
+        } else if (selectedMethod === 'barcode') {
+            ctaEl.textContent = '카카오페이로 결제하기 →';
+            if (hintEl && hintTxtEl) {
+                hintEl.classList.add('p02__hint--selected');
+                hintTxtEl.textContent = '카카오톡 결제 바코드 화면을 미리 켜두세요';
+            }
         } else {
             ctaEl.textContent = '결제 수단 선택 →';
             if (hintEl && hintTxtEl) {
@@ -144,6 +150,8 @@
                 location.href = '/processing';
             } else if (selectedMethod === 'vein') {
                 location.href = '/vein';
+            } else if (selectedMethod === 'barcode') {
+                location.href = '/barcode';
             }
         });
     }

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -71,8 +71,9 @@
 
     function getMethodLabel() {
         const m = sessionStorage.getItem(METHOD_KEY);
-        if (m === 'vein') return '정맥 인증';
-        if (m === 'ic')   return 'IC 카드';
+        if (m === 'vein')    return '정맥 인증';
+        if (m === 'ic')      return 'IC 카드';
+        if (m === 'barcode') return '카카오 바코드';
         return 'IC 카드';
     }
 

--- a/src/main/resources/static/front/js/flowP/P06-fail.js
+++ b/src/main/resources/static/front/js/flowP/P06-fail.js
@@ -121,6 +121,17 @@
                 '오늘은 다른 결제 수단으로 진행해주세요'
             ],
             retry: null
+        },
+        barcode_error: {
+            pill: 'B-001 · 바코드 인식 실패',
+            title: '바코드를 인식하지 못했어요',
+            desc:  '카카오톡 결제 바코드를 스캐너 위에 평평하게 다시 올려주세요. 화면 밝기를 최대로 두면 인식이 더 잘 됩니다.',
+            help:  [
+                '카카오톡 더보기 → 결제 바코드 화면을 미리 켜두세요',
+                '바코드 화면을 스캐너 정중앙에 올려주세요',
+                '인식이 계속 안 되면 다른 결제 수단을 이용해주세요'
+            ],
+            retry: 'barcode'
         }
     };
 
@@ -178,6 +189,8 @@
             location.href = '/vein';
         } else if (retryTarget === 'ic') {
             location.href = '/processing';
+        } else if (retryTarget === 'barcode') {
+            location.href = '/barcode';
         } else {
             goSwitch();
         }

--- a/src/main/resources/static/front/js/flowP/P07-barcode.js
+++ b/src/main/resources/static/front/js/flowP/P07-barcode.js
@@ -1,0 +1,202 @@
+/* ========================================================
+   P07-barcode.js — 카카오페이 결제 (Step 3/3)
+   states: waiting → success
+   자동 전환:
+     waiting (2.5s + progress 0→100%) →
+       confirmOrder + payByBarcode 묶어 호출 →
+       success (1.2s) → /complete
+     실패 시 → /fail?reason=barcode_error
+
+   디자인 확인용 쿼리스트링:
+     ?state=waiting|success    초기 상태 강제
+     ?result=success|fail      waiting 종료 시 결과 강제
+
+   흐름:
+     사용자 → 카카오톡에 결제 요청 알림 → 휴대폰에서 인증 → 결제 완료
+     (Mock — 백엔드 payByBarcode 는 검증 없이 SUCCESS 처리)
+   ======================================================== */
+
+(function () {
+    'use strict';
+
+    const $ = (sel, root = document) => root.querySelector(sel);
+
+    /* ---------- DOM refs ---------- */
+    const sectionEl     = $('.p07');
+    const titleEl       = $('[data-bind="title"]');
+    const descEl        = $('[data-bind="desc"]');
+    const progressEl    = $('.p07__progress');
+    const progressBarEl = $('[data-bind="progressBar"]');
+    const storeEl       = $('[data-bind="storeName"]');
+
+    const backEl   = $('[data-action="back"]');
+    const cancelEl = $('[data-action="cancel"]');
+
+    /* ---------- Session helpers ---------- */
+    const SESSION_ID_KEY = 'sessionId';
+    const STORE_KEY      = 'currentStoreName';
+    const METHOD_KEY     = 'paymentMethod';
+    const STATUS_KEY     = 'paymentStatus';
+
+    function getSessionId() {
+        const raw = sessionStorage.getItem(SESSION_ID_KEY);
+        const n = raw ? Number(raw) : NaN;
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function getQuery(name) {
+        try { return new URLSearchParams(location.search).get(name); }
+        catch (_) { return null; }
+    }
+
+    /* ---------- Copy per state ---------- */
+    const COPY = {
+        waiting: {
+            title: '카카오페이 결제 바코드를<br>스캐너에 대주세요',
+            desc:  '카카오톡 더보기 → 결제 → 바코드 화면을 스캐너 정중앙에 평평하게 올려주세요',
+        },
+        success: {
+            title: '결제가 완료되었어요',
+            desc:  '카카오페이 바코드 결제가 정상적으로 처리되었습니다',
+        },
+    };
+
+    /* ---------- Timers ---------- */
+    let scanTimer    = null;
+    let progressRaf  = null;
+    let successTimer = null;
+
+    function clearAllTimers() {
+        if (scanTimer)    { clearTimeout(scanTimer);    scanTimer    = null; }
+        if (successTimer) { clearTimeout(successTimer); successTimer = null; }
+        if (progressRaf)  { cancelAnimationFrame(progressRaf); progressRaf = null; }
+    }
+
+    /* ---------- Progress ---------- */
+    function setProgress(pct) {
+        const clamped = Math.max(0, Math.min(100, pct));
+        if (progressBarEl) progressBarEl.style.width = clamped + '%';
+        if (progressEl) progressEl.setAttribute('aria-valuenow', String(Math.round(clamped)));
+    }
+
+    /* ---------- State setter ---------- */
+    function setState(nextState) {
+        clearAllTimers();
+        sectionEl.dataset.state = nextState;
+
+        const copy = COPY[nextState] || COPY.waiting;
+        if (titleEl) titleEl.innerHTML = copy.title;
+        if (descEl)  descEl.textContent = copy.desc;
+
+        if (nextState === 'waiting') {
+            startScanning();
+        } else if (nextState === 'success') {
+            setProgress(100);
+            try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
+            successTimer = setTimeout(() => {
+                location.href = '/complete';
+            }, 1200);
+        }
+    }
+
+    /* ---------- Scanning ---------- */
+    function startScanning() {
+        setProgress(0);
+
+        const DURATION = 2500;
+        const startTs = performance.now();
+
+        const tick = (now) => {
+            const elapsed = now - startTs;
+            setProgress(Math.min(100, (elapsed / DURATION) * 100));
+            if (elapsed < DURATION) {
+                progressRaf = requestAnimationFrame(tick);
+            }
+        };
+        progressRaf = requestAnimationFrame(tick);
+
+        scanTimer = setTimeout(() => {
+            const forced = getQuery('result');
+            if (forced === 'fail') {
+                try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+                location.href = '/fail?reason=barcode_error';
+                return;
+            }
+            finalizeBarcodePayment();
+        }, DURATION);
+    }
+
+    /* ---------- 백엔드 결제 확정 ----------
+       바코드는 백엔드 payByBarcode 가 confirmOrder 완료 후 즉시 SUCCESS 결제 레코드를 만든다.
+       그래서 IC/정맥과 달리 markSuccess 별도 호출 불필요.
+       1) POST /api/orders/confirm   → orderId
+       2) POST /api/payments/barcode → paymentId (이미 SUCCESS 상태)
+       3) orderSummary 저장 → setState('success') → /complete */
+    let finalizing = false;
+    async function finalizeBarcodePayment() {
+        if (finalizing) return;
+        finalizing = true;
+
+        const sid = getSessionId();
+        if (!sid) {
+            location.href = '/menu';
+            return;
+        }
+
+        try {
+            const order = await window.NunchiApi.Orders.confirm(sid);
+            if (!order || !order.orderId) throw new Error('confirm 응답에 orderId 없음');
+            sessionStorage.setItem('orderId', String(order.orderId));
+
+            try {
+                sessionStorage.setItem('orderSummary', JSON.stringify({
+                    totalAmount: order.totalAmount,
+                    itemCount:   (order.items || []).length,
+                    firstName:   (order.items && order.items[0] && order.items[0].menuName) || '',
+                    totalQty:    (order.items || []).reduce((s, it) => s + (it.quantity || 0), 0),
+                }));
+            } catch (_) {}
+
+            // 바코드 값은 mock — 백엔드가 검증하지 않으므로 임의 13자리
+            const barcodeValue = String(Date.now()).slice(-13);
+            const payment = await window.NunchiApi.Payments.payByBarcode(order.orderId, barcodeValue);
+            if (!payment || !payment.paymentId) throw new Error('payByBarcode 응답에 paymentId 없음');
+            sessionStorage.setItem('paymentId', String(payment.paymentId));
+
+            setState('success');
+        } catch (e) {
+            console.warn('[P07] 바코드 결제 실패', e);
+            try { sessionStorage.setItem(STATUS_KEY, 'failed'); } catch (_) {}
+            location.href = '/fail?reason=barcode_error';
+        }
+    }
+
+    /* ---------- Misc ---------- */
+    function renderStoreName() {
+        const storeName = sessionStorage.getItem(STORE_KEY) || '상록원';
+        if (storeEl) storeEl.textContent = storeName;
+    }
+
+    /* ---------- Events ----------
+       성공 단계 이전이면 confirm 도 호출 전이므로 카트가 그대로 살아있음 → 자유 복귀 */
+    function goPrev() {
+        clearAllTimers();
+        if (history.length > 1) history.back();
+        else location.href = '/payment';
+    }
+    if (backEl)   backEl.addEventListener('click',   goPrev);
+    if (cancelEl) cancelEl.addEventListener('click', goPrev);
+
+    window.addEventListener('beforeunload', clearAllTimers);
+
+    /* ---------- Boot ---------- */
+    renderStoreName();
+    try { sessionStorage.setItem(METHOD_KEY, 'barcode'); } catch (_) {}
+
+    const initial = getQuery('state');
+    if (initial && COPY[initial]) {
+        setState(initial);
+    } else {
+        setState('waiting');
+    }
+})();

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -110,6 +110,24 @@
                 </span>
             </button>
 
+            <!-- 카카오페이 바코드 -->
+            <button type="button"
+                    class="method-card p02__method"
+                    role="radio"
+                    aria-pressed="false"
+                    aria-checked="false"
+                    data-method="barcode"
+                    style="--tint: #FAE100;">
+                <span class="method-card__icon" aria-hidden="true">
+                    <i class="xi-barcode"></i>
+                </span>
+                <span class="method-card__title">카카오페이</span>
+                <span class="method-card__desc">카카오톡 결제 바코드를<br>스캐너에 대주세요</span>
+                <span class="method-card__check" aria-hidden="true">
+                    <i class="xi-check-min"></i>
+                </span>
+            </button>
+
         </div>
 
         <!-- 힌트 영역 -->

--- a/src/main/resources/templates_front/flowP/P07-barcode.html
+++ b/src/main/resources/templates_front/flowP/P07-barcode.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=720, initial-scale=1.0, user-scalable=no">
+    <title>카카오페이 바코드 결제 · 눈치 키오스크</title>
+
+    <link rel="stylesheet" href="/lib/fonts/XEIcon-2.2.0/xeicon.min.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/flowP/P07-barcode.css">
+</head>
+<body>
+<div class="page-bg">
+
+    <!-- 상단바 -->
+    <header class="p-topbar">
+        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
+            <i class="xi-home" aria-hidden="true"></i>
+        </button>
+        <div class="p-topbar__titles">
+            <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
+            <h1 class="p-topbar__title">카카오페이 바코드 결제</h1>
+        </div>
+    </header>
+
+    <!-- 3-step 진행 표시 -->
+    <ol class="step-indicator" aria-label="결제 단계" style="--steps: 3;">
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">주문 확인</span>
+        </li>
+        <li class="step-indicator__item" data-state="done">
+            <span class="step-indicator__dot" aria-hidden="true"><i class="xi-check-min"></i></span>
+            <span class="step-indicator__label">결제 수단</span>
+        </li>
+        <li class="step-indicator__item" data-state="active">
+            <span class="step-indicator__dot" aria-hidden="true">3</span>
+            <span class="step-indicator__label">결제</span>
+        </li>
+    </ol>
+
+    <!-- 본문 : data-state 로 상태 전환 -->
+    <section class="p07" data-state="waiting" aria-live="polite">
+
+        <!-- 결제 비주얼 (P03 와 동일한 원형 톤) -->
+        <div class="p07__scanner" aria-hidden="true">
+            <!-- 펄스 링 -->
+            <span class="p07__pulse p07__pulse--1"></span>
+            <span class="p07__pulse p07__pulse--2"></span>
+            <span class="p07__pulse p07__pulse--3"></span>
+
+            <!-- 원형 프레임 -->
+            <div class="p07__frame">
+                <!-- 바코드 일러스트 (카드 안에 카카오 노란 배경으로 끼워넣음) -->
+                <div class="p07__card">
+                    <div class="p07__card-head">
+                        <span class="p07__card-brand">kakaopay</span>
+                    </div>
+                    <div class="p07__barcode" aria-hidden="true">
+                        <span></span><span></span><span></span><span></span>
+                        <span></span><span></span><span></span><span></span>
+                        <span></span><span></span><span></span><span></span>
+                        <span></span><span></span><span></span><span></span>
+                        <span></span><span></span><span></span><span></span>
+                    </div>
+                </div>
+
+                <!-- 스캔 라인 (waiting 일 때만 위→아래 반복) -->
+                <span class="p07__scanline" aria-hidden="true"></span>
+
+                <!-- 상태 오버레이 아이콘 (success) -->
+                <span class="p07__status-icon p07__status-icon--success" aria-hidden="true">
+                    <i class="xi-check"></i>
+                </span>
+            </div>
+        </div>
+
+        <!-- 상태 텍스트 -->
+        <div class="p07__text">
+            <h2 class="p07__title" data-bind="title">카카오페이 결제 바코드를<br>스캐너에 대주세요</h2>
+            <p class="p07__desc" data-bind="desc">카카오톡 더보기 → 결제 → 바코드 화면을 스캐너 정중앙에 평평하게 올려주세요</p>
+
+            <!-- 진행 프로그레스 -->
+            <div class="p07__progress" role="progressbar"
+                 aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="p07__progress-bar" data-bind="progressBar"></span>
+            </div>
+        </div>
+    </section>
+
+    <!-- 하단 액션 영역 -->
+    <footer class="p07__cta-wrap">
+        <!-- waiting : 취소 -->
+        <button type="button"
+                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p07__cta p07__cta--cancel"
+                data-action="cancel">
+            다른 결제 수단으로 변경
+        </button>
+
+        <!-- success : 자동 이동 안내 -->
+        <p class="p07__cta--success-hint" aria-live="polite">
+            잠시 후 주문 완료 화면으로 이동합니다…
+        </p>
+    </footer>
+</div>
+
+<script src="/js/common/app-state.js"></script>
+<script src="/js/common/api-client.js"></script>
+<script src="/js/common/confirm-modal.js"></script>
+<script src="/js/flowP/P07-barcode.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
- POST /api/payments/barcode 호출 흐름 신설 (mock — 어떤 바코드든 SUCCESS)
- P02 결제수단에 "카카오페이" 카드 추가 (data-method=barcode)
- P07-barcode 신규 화면 — P03/P04 톤(원형 280 프레임 + 펄스 + 스캔라인) · 원형 안에 카카오페이 노란 카드 + 바코드 일러스트 · 진입 시 confirmOrder + payByBarcode 묶어 호출 (성공 시 P05, 실패 시 P06) · 뒤로/취소 history.back() — 카트 살아있어 자연 복귀
- WebConfig /barcode → P07-barcode.html 라우트 추가
- api-client.js Payments.payByBarcode(orderId, barcodeValue) 헬퍼 추가
- P05 영수증 method 라벨에 "카카오 바코드" 추가
- P06 실패 사유 barcode_error + retry 분기에 barcode 추가
- N02-menu.js ensureServerSession 에 orderType 추가 (main 회귀 버그 수정 — SessionCreateRequest 가 @NotNull orderType 요구)

## 📣 Related Issue



## 📝 Summary

### P07-barcode (신규 화면)
- P02 에서 "카카오페이" 선택 → `/barcode` 진입
- 원형 280 프레임 안에 카카오페이 노란 카드 + 바코드 일러스트 + 위→아래 스캔라인 (P03/P04 톤 일관)
- 진입 시 한 번에 백엔드 호출: `POST /api/orders/confirm` → `POST /api/payments/barcode` → `setState('success')` → `/complete`
- 실패 시 `/fail?reason=barcode_error`
- 뒤로/취소 버튼은 `history.back()` — confirm 전이라 카트가 살아있어 자연 복귀

### P02 / P05 / P06 정합성
- P02 결제수단 카드 3개 (IC카드 · 정맥인증 · 카카오페이) 그리드 완성
- P05 영수증 라벨 / P06 실패 사유 매핑에 `barcode` 추가

### Backend 연결
- `api-client.js` `Payments.payByBarcode(orderId, barcodeValue)` 추가
- WebConfig `/barcode` → `P07-barcode.html` 라우트
- 백엔드 `/api/payments/barcode` 자체는 main 에 이미 머지된 상태 (mock — 검증 없이 SUCCESS)

### 회귀 수정 (Bonus)
- `N02-menu.js` `ensureServerSession` 에 `orderType` 추가
- main 의 `SessionCreateRequest` 가 `@NotNull` 로 `orderType` 요구하는데 N02 만 빠뜨려서 일반 모드 사용자가 메뉴 화면 진입 시 400 받던 버그. A01-avatar.js 의 `resolveOrderType()` 패턴과 동일하게 처리

## 🙏 Question & PR point

- **카카오페이 결제는 현재 mock**. 백엔드 `payByBarcode` 가 바코드 값 검증 없이 SUCCESS 처리하므로 어떤 13자리든 통과합니다. 실제 카카오비즈 매장결제 PG 연동은 사업자 가맹 계약 필요 → 후속 이슈로 분리.
- **회귀 버그**: N02 의 `orderType` 누락은 main 에 이미 머지된 상태이므로 현재 배포 dev 서버에서도 재현됩니다. 이 PR 머지·배포 시 함께 해결.
- **로컬 환경 메모**: 옛 PostgreSQL DB 가 있다면 `payment_method_check` 체크 제약이 `BARCODE` enum 을 거절합니다. `ALTER TABLE payment DROP CONSTRAINT IF EXISTS payment_method_check;` 한 번 실행 필요. 신규 DB(배포 환경 포함)는 영향 없음.

## 📬 Postman

<!-- cURL 검증 흐름 (스크린샷 첨부 부탁드립니다):
  POST /api/sessions { mode:NORMAL, language:ko, orderType:DINE_IN }
  POST /api/orders/cart/items × N
  POST /api/orders/confirm { sessionId }  → orderId
  POST /api/payments/barcode { orderId, barcodeValue:"1234567890123" }  → paymentId, status:SUCCESS -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카카오페이 바코드 결제 기능을 추가했습니다. 사용자는 이제 결제 수단 선택 화면에서 바코드 옵션을 선택하고, 바코드 스캔 화면에서 결제를 완료할 수 있습니다.
  * 바코드 인식 실패 시 재시도 기능을 지원합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->