### PR TITLE
[Feat] 장바구니/결제 요약 리스트에 메뉴 썸네일 표시

### DIFF
--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -295,9 +295,15 @@
                 ? item.options.map((o) => o.optionName).join(" · ")
                 : "";
 
+            // 썸네일 — imageUrl 있으면 background-image (cover), 없으면 메뉴명 텍스트 fallback
+            const thumbStyle = item.imageUrl
+                ? ` style="background-image:url('${item.imageUrl}');background-size:cover;background-position:center;"`
+                : "";
+            const thumbInner = item.imageUrl ? "" : item.menuName;
+
             return `
                 <li class="n02__cart-item" data-cart-item="${item.itemId}">
-                    <div class="n02__cart-item-thumb">${item.menuName}</div>
+                    <div class="n02__cart-item-thumb"${thumbStyle}>${thumbInner}</div>
                     <div class="n02__cart-item-name-row">
                         <span class="n02__cart-item-name">${item.menuName}${optionText ? ` <small>(${optionText})</small>` : ""}</span>
                         <button class="n02__cart-item-remove"

--- a/src/main/resources/static/front/js/flowP/P01-summary.js
+++ b/src/main/resources/static/front/js/flowP/P01-summary.js
@@ -62,6 +62,21 @@
             $('[data-price]', node).textContent = fmtWon(it.itemTotal);
             $('[data-qty-value]', node).textContent = String(it.quantity || 1);
 
+            // 썸네일 — imageUrl 있으면 <img> 채우고, 없으면 메뉴명 첫 글자 fallback
+            const thumb = $('[data-thumb]', node);
+            if (thumb) {
+                thumb.innerHTML = '';
+                if (it.imageUrl) {
+                    const img = document.createElement('img');
+                    img.src = it.imageUrl;
+                    img.alt = it.menuName || '';
+                    img.loading = 'lazy';
+                    thumb.appendChild(img);
+                } else {
+                    thumb.textContent = (it.menuName || '').slice(0, 1);
+                }
+            }
+
             const decBtn = $('[data-qty-dec]', node);
             if ((it.quantity || 1) <= 1) decBtn.disabled = true;
 


### PR DESCRIPTION
- N02 카트바 아이템 썸네일: imageUrl 있으면 background-image(cover) 로 표시, 없으면 메뉴명 텍스트 fallback
- P01 결제 요약 리스트 썸네일: imageUrl 있으면 <img object-fit:cover> 채우고, 없으면 메뉴명 첫 글자 fallback
- 백엔드 변경 없음 — CartItemInfo 가 이미 imageUrl 필드 노출하므로 프론트만 적용

본문


## 📣 Related Issue


## 📝 Summary

- **N02 카트바 아이템 썸네일**
  - `item.imageUrl` 있으면 `background-image: url('...'); background-size: cover; background-position: center;` 인라인 스타일로 적용
  - 없으면 기존 메뉴명 텍스트(`item.menuName`) fallback 유지
- **P01 결제 요약 리스트 썸네일** (`[data-thumb]` 영역)
  - `<img src=imageUrl alt=menuName loading=lazy>` 동적 생성 → 기존 `.p01__thumb img { object-fit: cover }` CSS 그대로 활용
  - `imageUrl` 없으면 메뉴명 첫 글자(`menuName.slice(0, 1)`) fallback
- 백엔드 변경 없음 — `CartItemInfo` 가 이미 `imageUrl` 필드 노출

## 🙏 Question & PR point

- 별도 thumbnail 이미지 파일을 만들지 않고, 메뉴 카드와 같은 원본 URL 을 CSS 로 축소 표시했습니다. 트래픽 규모에서 별도 파일 만들 이득이 작아 단순화. 추후 이미지 크기 최적화 필요하면 Spring 측 thumbnail 변환 또는 `picture srcset` 후속 이슈로.
- DB 의 `image_url` 이 비어있거나 (`NULL`) 경로가 잘못된 메뉴는 fallback 으로 텍스트 표시되어 화면이 깨지지 않음. 단 카드와 동일한 fallback 톤이라 시각적 일관성 유지.

## 📬 Postman

<!-- N02 → 메뉴 담기 → 카트바 아이템에 메뉴 사진 작게 표시 / "결제하기" → P01 요약 리스트 좌측