### PR TITLE
[Feat] N02 일반 모드 STT 연결 + 데이터 정리/정렬

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/menu/entity/Menu.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/entity/Menu.java
@@ -118,4 +118,11 @@ public class Menu extends BaseEntity {
     public void markAvailable() {
         this.isSoldOut = false;
     }
+
+    /** 데이터 마이그레이션용 — 매장 라벨(층/식당명/운영시간) 일괄 갱신 */
+    public void relabel(Integer floor, String restaurantName, String operatingHours) {
+        this.floor = floor;
+        this.restaurantName = restaurantName;
+        this.operatingHours = operatingHours;
+    }
 }

--- a/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/menu/repository/MenuRepository.java
@@ -5,11 +5,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long>, JpaSpecificationExecutor<Menu> {
 
     // 카테고리 ID로 메뉴 목록 조회
     List<Menu> findByCategory_CategoryId(Long categoryId);
+
+    // 데이터 마이그레이션용 — 이름으로 단건 조회
+    Optional<Menu> findByName(String name);
 
     // 추천 메뉴 조회
     List<Menu> findByIsRecommendedTrueAndIsSoldOutFalse();

--- a/src/main/java/dgu/capstone/nunchi/global/config/MenuLabelMigration.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/MenuLabelMigration.java
@@ -1,0 +1,90 @@
+package dgu.capstone.nunchi.global.config;
+
+import dgu.capstone.nunchi.domain.menu.repository.MenuRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 메뉴 라벨 / 정리 마이그레이션.
+ *
+ *  - 사진 없는 메뉴 2건 (장조림버터솥밥 / 날치알김치불고기솥밥) 삭제
+ *  - 분식당(1층) 메뉴 5건 라벨링 (스팸도시락 / 계란라면 / 치즈라면 / 해장라면 / 공기밥)
+ *
+ * 멱등성:
+ *  - 매 부팅마다 실행되지만, 이미 라벨이 동일하면 변경 없음.
+ *  - 메뉴가 이미 삭제되어 없으면 skip.
+ *
+ * DataInitializer 다음 순서로 실행되도록 @Order(2) 지정.
+ */
+@Slf4j
+@Component
+@Profile({"local", "dev"})
+@Order(2)
+@RequiredArgsConstructor
+public class MenuLabelMigration implements ApplicationRunner {
+
+    private static final String BUNSIK_HOURS = "10:00-14:00";
+    private static final int    BUNSIK_FLOOR = 1;
+    private static final String BUNSIK_NAME  = "분식당";
+
+    private final MenuRepository menuRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        // 1) 사진 없는 메뉴 삭제
+        deleteIfExists("장조림버터솥밥");
+        deleteIfExists("날치알김치불고기솥밥");
+
+        // 2) 분식당 라벨링 — 이미 같은 라벨이면 no-op
+        relabelToBunsik("스팸도시락");
+        relabelToBunsik("계란라면");
+        relabelToBunsik("치즈라면");
+        relabelToBunsik("해장라면");
+        relabelToBunsik("공기밥");
+    }
+
+    private void deleteIfExists(String name) {
+        menuRepository.findByName(name).ifPresent(menu -> {
+            Long id = menu.getMenuId();
+            // FK 제약 — 옵션·옵션그룹·판매집계·알레르기 먼저 정리 후 menu 삭제
+            em.createNativeQuery(
+                    "DELETE FROM menu_option WHERE option_group_id IN " +
+                    "(SELECT option_group_id FROM menu_option_group WHERE menu_id = :id)")
+                    .setParameter("id", id).executeUpdate();
+            em.createNativeQuery("DELETE FROM menu_option_group WHERE menu_id = :id")
+                    .setParameter("id", id).executeUpdate();
+            em.createNativeQuery("DELETE FROM sales_daily WHERE menu_id = :id")
+                    .setParameter("id", id).executeUpdate();
+            em.createNativeQuery("DELETE FROM menu_allergy WHERE menu_id = :id")
+                    .setParameter("id", id).executeUpdate();
+            em.flush();
+
+            menuRepository.delete(menu);
+            log.info("[MenuLabelMigration] 메뉴 삭제 완료: {} (menuId={})", name, id);
+        });
+    }
+
+    private void relabelToBunsik(String name) {
+        menuRepository.findByName(name).ifPresent(menu -> {
+            boolean alreadyLabeled =
+                    BUNSIK_FLOOR == (menu.getFloor() == null ? -1 : menu.getFloor())
+                            && BUNSIK_NAME.equals(menu.getRestaurantName())
+                            && BUNSIK_HOURS.equals(menu.getOperatingHours());
+            if (alreadyLabeled) return;
+            menu.relabel(BUNSIK_FLOOR, BUNSIK_NAME, BUNSIK_HOURS);
+            log.info("[MenuLabelMigration] 분식당 라벨링: {} (menuId={})", name, menu.getMenuId());
+        });
+    }
+}

--- a/src/main/resources/static/front/js/flowA/conversation-engine.js
+++ b/src/main/resources/static/front/js/flowA/conversation-engine.js
@@ -31,7 +31,7 @@
         THINKING: 'THINKING'
     };
 
-    const SILENCE_MS = 1200;     // 침묵 N 초 → 되물음 (시끄러운 환경: 0.8~1.2초 권장)
+    const SILENCE_MS = 1000;     // 침묵 1초 → 누적 텍스트 있으면 즉시 final, 없으면 onSilencePrompt 콜백
     const SILENCE_TICK = 200;    // 타이머 폴링 간격
 
     let handlers = {
@@ -197,6 +197,26 @@
             if (state.mode !== MODE.LISTENING) return;
             if (Date.now() - state.lastInterimAt < SILENCE_MS) return;
             _clearSilenceTimer();
+
+            // 1) 1초 침묵 + 누적 interim/final 있으면 즉시 final 로 강제 처리
+            //    (Web Speech API 의 자체 isFinal 기다리지 않음 → 응답 체감 ~1초 단축)
+            const accum = (state.finalAccum + state.interimAccum).trim();
+            if (accum) {
+                state.finalAccum = '';
+                state.interimAccum = '';
+                _stopRecognition();
+                setMode(MODE.THINKING);
+                if (handlers.onInterim) {
+                    try { handlers.onInterim(''); } catch (_) {}
+                }
+                if (handlers.onUserUtterance) {
+                    try { handlers.onUserUtterance(accum); }
+                    catch (e) { console.warn(LOG, '사용자 발화 처리 실패', e); }
+                }
+                return;
+            }
+
+            // 2) 누적 없으면 호스트가 안내 발화 (현재 N02 는 null → 그냥 timer 재시작)
             let prompt = null;
             if (handlers.onSilencePrompt) {
                 try { prompt = handlers.onSilencePrompt(); }

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -256,7 +256,7 @@
                         <span class="n02__menu-card-detail-chip">
                             상세 <i class="xi xi-angle-right-thin"></i>
                         </span>
-                        <span class="n02__menu-card-thumb-text">${m.name}</span>
+                        ${m.imageUrl ? "" : `<span class="n02__menu-card-thumb-text">${m.name}</span>`}
                         ${qty > 0 ? `
                             <span class="n02__menu-card-qty-badge">${qty}</span>` : ""}
                     </div>
@@ -485,69 +485,173 @@
         $chatDim.setAttribute("aria-hidden", "true");
     }
 
+    // ---------- 채팅 패널 ----------
+    // chatLog 메모리 누적은 더 이상 사용 안 함 (JSON export 제거).
+    // 대화 영속은 서버(POST /api/sessions/{id}/messages) 에 LangGraph 가 자동 저장.
     function pushChatBubble(role, text) {
-        const item = { role: role, text: text, ts: nowHHMM() };
-        state.chatLog.push(item);
-        renderChatBubble(item);
-        // 패널 열려 있으면 자동 스크롤
+        // role: "user" | "system" | "tool"
+        const node = document.createElement("div");
+        node.className = "ai-chat-bubble ai-chat-bubble--" + role;
+        const iconHtml = role === "system"
+            ? '<i class="xi xi-message"></i>'
+            : (role === "tool" ? '<i class="xi xi-lightning"></i>' : '');
+        node.innerHTML = `
+            <div class="ai-chat-bubble__body"></div>
+            <div class="ai-chat-bubble__time">${iconHtml}<span>${nowHHMM()}</span></div>
+        `;
+        // textContent 로 안전하게 (XSS 방지)
+        node.querySelector(".ai-chat-bubble__body").textContent = text;
+        $chatMessages.appendChild(node);
+
         if ($chatPanel.classList.contains("ai-chat-panel--open")) {
             $chatMessages.scrollTop = $chatMessages.scrollHeight;
         }
     }
 
-    function renderChatBubble(item) {
-        const cls = "ai-chat-bubble--" + item.role;
-        const iconHtml = item.role === "system"
-            ? '<i class="xi xi-message"></i>'
-            : (item.role === "tool"
-                ? '<i class="xi xi-lightning"></i>'
-                : '');
-        const node = document.createElement("div");
-        node.className = "ai-chat-bubble " + cls;
-        node.innerHTML = `
-            <div class="ai-chat-bubble__body">${item.text}</div>
-            <div class="ai-chat-bubble__time">${iconHtml}<span>${item.ts}</span></div>
-        `;
-        $chatMessages.appendChild(node);
-    }
-
     function renderChatInitial() {
-        $chatSession.textContent = state.sessionId;
+        if ($chatSession) $chatSession.textContent = state.sessionId ?? "—";
         $chatMessages.innerHTML = "";
-        // 디폴트 인사말
         pushChatBubble("system",
-            "안녕하세요! 상록원 AI 주문 도우미입니다. 음성으로 편하게 주문하세요 😊 핀 마이크가 항상 켜져 있어 버튼을 누르지 않아도 돼요.");
+            "안녕하세요! 상록원 AI 주문 도우미입니다. 상단 마이크 버튼을 눌러 음성으로 주문해보세요.");
     }
 
-    function exportChatJson() {
-        const blob = new Blob(
-            [JSON.stringify({ sessionId: state.sessionId, log: state.chatLog }, null, 2)],
-            { type: "application/json" }
-        );
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `nunchi-session-${state.sessionId}.json`;
-        a.click();
-        URL.revokeObjectURL(url);
+    // 패널 헤더의 마이크 상태 표시 (off / listening / thinking)
+    const $micStatusEl       = document.querySelector('[data-mic-status]');
+    const $micStatusTitle    = document.querySelector('[data-mic-status-title]');
+    const $micStatusDesc     = document.querySelector('[data-mic-status-desc]');
+    const $micStatusBadge    = document.querySelector('[data-mic-status-badge]');
+    function setMicStatus(kind) {
+        if (!$micStatusEl) return;
+        $micStatusEl.dataset.mic = kind;
+        const COPY = {
+            off:       { title: "마이크 꺼짐",        desc: "상단 마이크 버튼을 눌러 음성 주문을 시작하세요", badge: "OFF" },
+            listening: { title: "듣고 있어요",        desc: "편하게 말씀해 주세요",                            badge: "LIVE" },
+            thinking:  { title: "응답을 준비 중…",    desc: "잠시만 기다려주세요",                              badge: "…"   },
+        };
+        const c = COPY[kind] || COPY.off;
+        if ($micStatusTitle) $micStatusTitle.textContent = c.title;
+        if ($micStatusDesc)  $micStatusDesc.textContent  = c.desc;
+        if ($micStatusBadge) $micStatusBadge.textContent = c.badge;
     }
 
     function resetChat() {
-        state.chatLog = [];
-        state.sessionId = generateSessionId();
-        sessionStorage.setItem("aiSessionId", state.sessionId);
+        // 서버 세션은 유지 — UI 만 초기 인사말로 되돌림
         renderChatInitial();
     }
 
-    // ---------- 마이크 토글 ----------
-    function toggleMic() {
-        state.micActive = !state.micActive;
-        $micBtn.classList.toggle("app-topbar__action-icon--mic-active", state.micActive);
-        if (state.micActive) {
-            pushChatBubble("system", "🎙️ 청취 시작 — 편하게 말씀해 주세요");
-        } else {
-            pushChatBubble("system", "🔇 청취 일시 정지");
+    // ---------- 마이크 / ConvEngine ----------
+    // ConvEngine 은 사용자 발화 → onUserUtterance(text) 콜백으로 final 텍스트 전달.
+    // 우리는 그 텍스트를 FastAPI /ai/order/chat 으로 보내고 응답을 채팅 패널에 표시한다.
+    // TTS 는 일반 모드에서는 사용하지 않으므로 speak 핸들러 없음.
+    let _convEngineInited = false;
+    function initConvEngineOnce() {
+        if (_convEngineInited) return;
+        if (!window.ConvEngine || !window.ConvEngine.isSupported || !window.ConvEngine.isSupported()) {
+            console.warn("[N02] Web Speech API 미지원");
+            pushChatBubble("system", "이 브라우저는 음성 인식을 지원하지 않아 채팅으로만 안내드려요.");
+            return;
         }
+        window.ConvEngine.init({
+            onInterim: (interim) => {
+                // 실시간 자막 — 상태 패널 desc 자리에 짧게 노출
+                if ($micStatusDesc && interim) $micStatusDesc.textContent = "…" + interim;
+            },
+            onUserUtterance: async (text) => {
+                pushChatBubble("user", text);
+                setMicStatus("thinking");
+                await dispatchUserUtterance(text);
+                // 처리 끝났으면 다시 LISTENING 으로
+                if (state.micActive && window.ConvEngine) {
+                    window.ConvEngine.endTurn();
+                    setMicStatus("listening");
+                }
+            },
+            onSilencePrompt: () => null,  // 침묵 시 자동 재촉발화 안 함
+            onBargeIn: () => {},
+            onModeChange: (m) => { /* 디버깅 시 사용 */ },
+        });
+        _convEngineInited = true;
+    }
+
+    async function dispatchUserUtterance(text) {
+        if (!state.sessionId) {
+            try { await ensureServerSession(); } catch (e) {
+                logApiError("세션 발급", e);
+                return;
+            }
+        }
+
+        // 일시적 nginx/FastAPI 502 대응: 1회 재시도 (1초 대기)
+        const callAi = () => window.Api.Ai.chat({
+            session_id: state.sessionId,
+            text: text,
+            mode: "NORMAL",
+        });
+
+        try {
+            let res;
+            try {
+                res = await callAi();
+            } catch (firstErr) {
+                const isGateway = firstErr && (firstErr.status === 502 || firstErr.status === 504);
+                if (!isGateway) throw firstErr;
+                console.warn("[N02] AI 응답 502/504, 1회 재시도");
+                await new Promise(r => setTimeout(r, 1000));
+                res = await callAi();
+            }
+
+            if (res && res.reply) {
+                pushChatBubble("system", res.reply);
+            }
+            // AI 가 백엔드 카트를 변경했을 수 있으므로 서버 카트 재동기화
+            await syncCartFromServer();
+
+            // 향후 응답 스키마의 action 필드 처리 (현재 백엔드 미구현)
+            if (res && res.action) handleAiAction(res.action);
+        } catch (e) {
+            console.error("[N02] AI 응답 최종 실패", e);
+            const friendly = (e && (e.status === 502 || e.status === 504))
+                ? "AI 서버가 잠시 응답이 느려요. 잠시 후 다시 말씀해주세요."
+                : "응답을 가져오지 못했어요. 다시 시도해 주세요.";
+            pushChatBubble("system", friendly);
+        }
+    }
+
+    // 향후 백엔드가 action 필드 채워 보내면 화면 컨트롤. 지금은 navigate 만 지원.
+    function handleAiAction(action) {
+        if (!action || !action.type) return;
+        switch (action.type) {
+            case "navigate":
+                if (action.page) location.href = action.page;
+                break;
+            default:
+                console.log("[N02] 미지원 action:", action);
+        }
+    }
+
+    function startMic() {
+        initConvEngineOnce();
+        if (!window.ConvEngine || !window.ConvEngine.isSupported()) return;
+        window.ConvEngine.start();
+        window.ConvEngine.endTurn();   // 인사 발화 없이 즉시 LISTENING
+        state.micActive = true;
+        $micBtn.classList.add("app-topbar__action-icon--mic-active");
+        setMicStatus("listening");
+        pushChatBubble("system", "🎙️ 음성 인식을 시작했어요. 편하게 말씀해주세요.");
+        if (!$chatPanel.classList.contains("ai-chat-panel--open")) openChat();
+    }
+
+    function stopMic() {
+        if (window.ConvEngine) window.ConvEngine.stop();
+        state.micActive = false;
+        $micBtn.classList.remove("app-topbar__action-icon--mic-active");
+        setMicStatus("off");
+        pushChatBubble("system", "🔇 음성 인식을 멈췄어요.");
+    }
+
+    function toggleMic() {
+        if (state.micActive) stopMic();
+        else                  startMic();
     }
 
     // ---------- 결제 ----------
@@ -655,7 +759,6 @@
         document.addEventListener("click", (e) => {
             if (e.target.closest('[data-action="open-chat"]'))   openChat();
             if (e.target.closest('[data-action="close-chat"]'))  closeChat();
-            if (e.target.closest('[data-action="export-chat"]')) exportChatJson();
             if (e.target.closest('[data-action="reset-chat"]'))  resetChat();
         });
         $chatDim.addEventListener("click", closeChat);

--- a/src/main/resources/static/front/js/flowN/menu-data.js
+++ b/src/main/resources/static/front/js/flowN/menu-data.js
@@ -106,14 +106,33 @@
             });
         }
 
-        // Map → 정렬된 배열 (층 번호 오름차순)
+        // 식당 우선순위: 솥앤누들 → 분식당 → (그 외 가나다)
+        const RESTAURANT_PRIORITY = { "솥앤누들": 0, "분식당": 1 };
+        function storeSortKey(store) {
+            const p = RESTAURANT_PRIORITY[store.name];
+            return p == null ? [99, store.name] : [p, ""];
+        }
+
+        // Map → 정렬된 배열
+        //   floors : 층 번호 오름차순
+        //   stores : 우선순위 → 가나다
+        //   menus  : menuId 오름차순 (분식당의 공기밥 같은 추가메뉴가 자연스럽게 마지막)
         const floors = Array.from(floorMap.values())
             .sort((a, b) => (a.num ?? 99) - (b.num ?? 99))
-            .map((f) => ({
-                id:     f.id,
-                label:  f.label,
-                stores: Array.from(f.stores.values()),
-            }));
+            .map((f) => {
+                const stores = Array.from(f.stores.values())
+                    .map((s) => ({
+                        ...s,
+                        menus: [...s.menus].sort((m1, m2) => Number(m1.id) - Number(m2.id)),
+                    }))
+                    .sort((a, b) => {
+                        const [pa, na] = storeSortKey(a);
+                        const [pb, nb] = storeSortKey(b);
+                        if (pa !== pb) return pa - pb;
+                        return na.localeCompare(nb);
+                    });
+                return { id: f.id, label: f.label, stores };
+            });
 
         return floors;
     }

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -243,34 +243,22 @@
             </button>
         </div>
 
-        <!--
-            ⚠️ 이 영역의 카피("청취/마이크/LIVE")는 현재 데모용 시뮬레이션 표기입니다.
-            실제 마이크 캡처 / STT 연동 시 다음을 별도 이슈로 함께 처리해야 합니다:
-              · 녹음 시작/종료 토글 가시화 (data-action="toggle-mic" 의 실제 권한·상태 표기)
-              · 음성 데이터 보관 정책(세션 단위 폐기, 서버 전송 여부) 안내 문구
-              · 일시중지 / 마이크 OFF 옵션 노출
-        -->
-        <div class="ai-chat-panel__status">
+        <!-- 음성 인식 상태 — JS 가 data-mic 속성으로 갱신 (off/listening/thinking) -->
+        <div class="ai-chat-panel__status" data-mic-status data-mic="off">
             <div class="ai-chat-panel__status-text">
-                <strong>📝 데모: AI 음성 시뮬레이션</strong>
-                <span>실 마이크 미연동 · 화면 시연용 표기입니다</span>
+                <strong data-mic-status-title>마이크 꺼짐</strong>
+                <span data-mic-status-desc>상단 마이크 버튼을 눌러 음성 주문을 시작하세요</span>
             </div>
-            <span class="ai-chat-panel__live">DEMO</span>
+            <span class="ai-chat-panel__live" data-mic-status-badge>OFF</span>
         </div>
 
-        <p class="ai-chat-panel__memory-note">대화 기록 · 세션 단위 메모리 (브라우저 세션 종료 시 폐기)</p>
+        <p class="ai-chat-panel__memory-note">대화는 서버에 자동 저장됩니다 (세션 종료 시 메뉴/주문/결제 기록만 보존)</p>
 
         <div class="ai-chat-panel__messages" data-chat-messages>
             <!-- JS 동적 -->
         </div>
 
         <div class="ai-chat-panel__footer">
-            <button class="ai-chat-panel__footer-btn ai-chat-panel__footer-btn--save"
-                    type="button"
-                    data-action="export-chat">
-                <i class="xi xi-download" aria-hidden="true"></i>
-                <span>JSON 저장</span>
-            </button>
             <button class="ai-chat-panel__footer-btn ai-chat-panel__footer-btn--reset"
                     type="button"
                     data-action="reset-chat">
@@ -286,6 +274,7 @@
 <script src="/js/common/confirm-modal.js"></script>
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
 <script src="/js/flowN/menu-data.js"></script>
 <script src="/js/flowN/N02-menu.js"></script>
 </body>


### PR DESCRIPTION
프론트
- N02-menu.html: JSON 저장 버튼 제거, 마이크 상태 UI 동적화(OFF/LIVE/…), conversation-engine.js 스크립트 추가
- N02-menu.js: 마이크 클릭 → Web Speech API STT → /ai/order/chat 호출 → reply 채팅 표시 + 카트 동기화 · exportChatJson 함수/이벤트 제거 (대화 영속은 서버가 담당) · 카드 썸네일 텍스트 — imageUrl 있으면 숨김(사진만), 없으면 fallback · AI 응답 502/504 1회 재시도 + 친절 한국어 fallback
- menu-data.js: 식당 정렬(솥앤누들→분식당→가나다) + 메뉴 menuId 오름차순 (공기밥 자동 마지막)
- conversation-engine.js: SILENCE_MS 1.2s→1.0s, 누적 interim 있으면 1초 침묵 즉시 final 강제 처리

백엔드 마이그레이션
- Menu.relabel(floor, restaurantName, operatingHours) 도메인 메서드
- MenuRepository.findByName(String)
- MenuLabelMigration (신규, @Profile local/dev) — 부팅 시 자동 실행 · 사진 없는 메뉴 2건 삭제 (장조림버터솥밥, 날치알김치불고기솥밥) — 종속 FK(menu_option/option_group/sales_daily/menu_allergy) 정리 후 삭제 · 분식당(1층, 10:00-14:00) 라벨링 5건 (스팸도시락/계란·치즈·해장라면/공기밥) · 멱등성 보장 (이미 적용된 환경에선 no-op)

## 📣 Related Issue

- close #101 

## 📝 Summary

### N02 일반 모드 STT 연결
- N02-menu.html: 채팅 패널의 "JSON 저장" 버튼 제거. 마이크 상태 UI 동적화(OFF / LIVE / `…`). `conversation-engine.js` 스크립트 포함
- N02-menu.js: 마이크 클릭 → Web Speech API STT → final 텍스트 → `Api.Ai.chat({session_id, text, mode:"NORMAL"})` 호출 → reply 채팅 표시 + `syncCartFromServer()` 호출
  - `exportChatJson` 제거. 대화 영속은 서버 `conversation_message` 가 담당 (LangGraph 가 `tool_save_message` 자동 호출, 동작 검증됨)
  - 카드 썸네일 사진 위 메뉴명 텍스트 제거 — `imageUrl` 있을 때만 텍스트 숨김, 없으면 fallback
  - AI 응답 502/504 1회 재시도(1초 후), 그래도 실패하면 "AI 서버가 잠시 응답이 느려요…" 친절 메시지

### conversation-engine.js 침묵 정책 강화
- `SILENCE_MS` 1.2s → 1.0s
- 1초 침묵 시 누적 interim/final 있으면 Web Speech API 의 `isFinal` 기다리지 않고 즉시 final 로 강제 처리 → 응답 체감 ~1초 단축

### 식당·메뉴 정렬 (menu-data.js)
- 식당: 솥앤누들 → 분식당 → 그 외 가나다 (RESTAURANT_PRIORITY 명시)
- 메뉴: menuId 오름차순 — 분식당 안에서 공기밥(31) 자동 마지막

### DB 마이그레이션 (부팅 시 자동 실행, 멱등)
- `Menu.relabel(floor, restaurantName, operatingHours)` 도메인 메서드 추가
- `MenuRepository.findByName(String)`
- `MenuLabelMigration` 신규 (`@Profile({"local","dev"})`, `@Order(2)`)
  - 사진 없는 메뉴 2건 삭제 — 종속 FK (menu_option / menu_option_group / sales_daily / menu_allergy) native query 로 먼저 정리 후 menu 삭제
  - 분식당 5건 라벨링 — 이미 적용된 환경에선 no-op
- 머지 시 dev 배포 자동 갱신에 의해 운영 DB 도 자동 적용

## 🙏 Question & PR point

- **마이그레이션 클래스 위치**: 운영 DB 갱신이 필요해 백엔드 코드에 포함. Flyway 같은 정식 마이그레이션 도구는 별도 이슈로 분리 (현 ddl-auto: update 기조 유지)
- **502 재시도**: 운영 nginx ↔ FastAPI 일시 끊김 케이스에 대한 클라이언트 측 완화. 근본 원인(nginx `proxy_read_timeout`)은 인프라 측 조치 권장
- **마이크 침묵 1초**: 단어 사이 자연 침묵보다는 충분히 김. 시연 환경에서 끊김이 느껴지면 1.2s 정도로 재조정 가능
- **AI 응답 화면 액션 처리** (recommendations 시각 강조, action.navigate 자동 전환 등) 는 본 PR 범위 외 — 후속 이슈로 분리

## 📬 Postman

<!-- 검증 cURL 흐름:
  POST /ai/order/start { mode:NORMAL, language:ko, order_type:DINE_IN }
  POST /ai/order/chat { session_id, text:"안녕", mode:"NORMAL" }
  POST /ai/order/chat { session_id, text:"치즈라면 두 개 담아줘", mode:"NORMAL" }
  GET  /api/orders/cart/{session_id}
  GET  /api/sessions/{session_id}/messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 음성 채팅 중 마이크 상태(OFF/수신 중/생각 중) 실시간 표시 추가

* **Improvements**
  * 음성 인식 침묵 감지 시간 단축으로 더 빠른 응답
  * 메뉴 목록을 층별, 식당명, 가나다순으로 자동 정렬
  * AI 채팅 기록이 서버에 자동 저장되도록 변경

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->