### PR TITLE
[Feat] N02 음성 원격조작 1차 — JS quick-action + AI action dispatcher

### DIFF
--- a/src/main/resources/static/front/css/components.css
+++ b/src/main/resources/static/front/css/components.css
@@ -1047,3 +1047,20 @@
     margin-top: 12px;
 }
 
+
+/* ========================================================
+   AI 추천/액션 강조 효과
+   AiAction.highlightMenu / handleRecommendations 가 사용
+   ======================================================== */
+@keyframes ai-pulse-kf {
+    0%   { box-shadow: 0 0 0 0   rgba(232, 96, 10, 0.55); }
+    60%  { box-shadow: 0 0 0 14px rgba(232, 96, 10, 0);    }
+    100% { box-shadow: 0 0 0 0   rgba(232, 96, 10, 0);    }
+}
+.ai-pulse {
+    animation: ai-pulse-kf 1.6s ease-out 1;
+    outline: 2px solid var(--primary-500, #e8600a);
+    outline-offset: 2px;
+    border-radius: inherit;
+    transition: outline-color 240ms ease;
+}

--- a/src/main/resources/static/front/js/common/ai-action.js
+++ b/src/main/resources/static/front/js/common/ai-action.js
@@ -1,0 +1,107 @@
+// ========================================================
+// ai-action.js — AI 응답의 화면 명령 dispatcher
+//
+// MCP/LangGraph 응답 스키마(향후):
+//   { reply, current_step, recommendations, menu_options, suggestions,
+//     action: { type, ...payload } }       ← 우리가 처리할 부분
+//
+// 지원 액션 (현재 / 향후 백엔드 도구):
+//   navigate                 page → location.href
+//   select_floor             floor → 층 탭 click
+//   select_restaurant        name  → 식당 사이드바 click
+//   highlight_menu           menu_id → 카드 펄스 + 자동 스크롤
+//   open_menu_detail         menu_id → 상세 오버레이 오픈 (페이지가 hook 노출 시)
+//   close_overlay            현재 열린 오버레이/패널 닫기
+//   select_payment_method    method: ic|vein|barcode → P02 카드 click
+//
+// 추천 시각화:
+//   handleRecommendations(list) — 메뉴 카드 펄스 + 첫 메뉴 스크롤
+//
+// CSS:
+//   .ai-pulse  — 1.6s 펄스 효과 (common.css 또는 페이지 CSS 에 정의 필요)
+// ========================================================
+
+(function () {
+    'use strict';
+
+    const LOG = '[AiAction]';
+
+    function handleAiAction(action) {
+        if (!action || !action.type) return;
+        console.log(LOG, 'dispatch', action);
+
+        switch (action.type) {
+            case 'navigate':
+                if (action.page) location.href = action.page;
+                break;
+
+            case 'select_floor': {
+                const tab = document.querySelector(`[data-floor="F${action.floor}"]`);
+                tab?.click();
+                break;
+            }
+
+            case 'select_restaurant': {
+                const stores = document.querySelectorAll('[data-store]');
+                for (const el of stores) {
+                    const name = el.querySelector('.n02__store-name')?.textContent?.trim();
+                    if (name === action.name) { el.click(); break; }
+                }
+                break;
+            }
+
+            case 'highlight_menu':
+                highlightMenu(action.menu_id);
+                break;
+
+            case 'open_menu_detail':
+                if (typeof window.__N02_openDetail === 'function') {
+                    window.__N02_openDetail(action.menu_id);
+                }
+                break;
+
+            case 'close_overlay':
+                document.querySelector('[data-action="close-detail"]')?.click();
+                document.querySelector('[data-action="close-chat"]')?.click();
+                break;
+
+            case 'select_payment_method':
+                document.querySelector(`[data-method="${action.method}"]`)?.click();
+                break;
+
+            default:
+                console.warn(LOG, '미지원 action:', action.type);
+        }
+    }
+
+    function highlightMenu(menuId) {
+        const card = document.querySelector(`[data-menu="${menuId}"]`);
+        if (!card) return;
+        card.classList.add('ai-pulse');
+        card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setTimeout(() => card.classList.remove('ai-pulse'), 2400);
+    }
+
+    /**
+     * AI 응답의 recommendations 배열을 받아 카드 강조 + 자동 스크롤.
+     * 첫 메뉴만 스크롤 / 나머지는 200ms 간격 펄스.
+     */
+    function handleRecommendations(list) {
+        if (!Array.isArray(list) || !list.length) return;
+        list.forEach((m, idx) => {
+            setTimeout(() => {
+                const card = document.querySelector(`[data-menu="${m.menu_id}"]`);
+                if (!card) return;
+                card.classList.add('ai-pulse');
+                if (idx === 0) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => card.classList.remove('ai-pulse'), 2400);
+            }, idx * 220);
+        });
+    }
+
+    window.AiAction = {
+        handle: handleAiAction,
+        handleRecommendations: handleRecommendations,
+        highlightMenu: highlightMenu,
+    };
+})();

--- a/src/main/resources/static/front/js/common/quick-action.js
+++ b/src/main/resources/static/front/js/common/quick-action.js
@@ -1,0 +1,150 @@
+// ========================================================
+// quick-action.js — JS 측 음성 단축 명령 (LLM 호출 없이 즉시 처리)
+//
+// 정책 (느슨 매치 + critical 부정 가드):
+//  - 화면 컨트롤만 처리. 메뉴 추천/카트 조작/자연어는 LLM.
+//  - substring 매치 — 종결어미/조사 자동 흡수 ("결제할게요", "1층 메뉴 보여줘" 도 잡음).
+//  - critical 액션(결제/홈)만 부정형 가드 — 잘못 트리거 시 피해 큰 것만 안전 처리.
+//  - 그 외 액션(뒤로/층/결제수단/마이크)은 잘못 잡혀도 무해(쉽게 복구 가능) → 가드 없음.
+//
+// 사용:
+//   if (window.QuickAction.try(text, { page: location.pathname })) return;
+// ========================================================
+
+(function () {
+    'use strict';
+
+    const LOG = '[QuickAction]';
+
+    /**
+     * 룰: { match, guard?, allowOn?, run }
+     *  - match:   substring 정규식 — 어디에 있어도 잡음
+     *  - guard:   매치되면 즉시 미발동 (부정 표현 등) — critical 액션만 사용
+     *  - allowOn: 페이지 가드 — location.pathname 받아 boolean
+     *  - run:     실행 콜백 (m: 정규식 match 객체)
+     */
+    const RULES = [
+        // ───────── 결제하기 (critical — 부정 가드 + 카트 가드) ─────────
+        {
+            name: 'checkout',
+            match: /결제/,
+            guard: /(안|못|말고|그만|취소|싫어|아니|잠깐|아직|나중에)/,
+            allowOn: (p) => p === '/menu' || p === '/summary',
+            run: () => {
+                // N02 에서는 카트 비어있으면 발동 안 함 (N02 가 노출한 함수가 알아서 처리)
+                if (typeof window.__N02_gotoCheckout === 'function') {
+                    window.__N02_gotoCheckout();
+                } else {
+                    location.href = '/summary';
+                }
+            },
+        },
+
+        // ───────── 처음으로 (critical — 세션 초기화 위험) ─────────
+        {
+            name: 'home',
+            match: /(처음으로?|홈으로?|메인\s*화면|초기\s*화면)/,
+            guard: /(안|못|말고|아니|잠깐|그만)/,
+            run: () => location.href = '/start',
+        },
+
+        // ───────── 뒤로 (안전 — 가드 없음) ─────────
+        {
+            name: 'back',
+            match: /(뒤로|이전\s*화면|이전으로|뒤로\s*가)/,
+            run: () => {
+                if (history.length > 1) history.back();
+                else location.href = '/start';
+            },
+        },
+
+        // ───────── 메뉴 화면 이동 (안전) ─────────
+        {
+            name: 'menu',
+            match: /(메뉴(\s*화면)?(\s*보여)?|메뉴로\s*가|메뉴\s*보여|메뉴\s*가)/,
+            // N02 에 이미 있으면 noop. 다른 페이지에서만 의미
+            allowOn: (p) => p !== '/menu',
+            run: () => location.href = '/menu',
+        },
+
+        // ───────── 주문 확인 (P01 단축 진입) ─────────
+        {
+            name: 'summary',
+            match: /(주문\s*확인|확인\s*화면|장바구니\s*화면)/,
+            allowOn: (p) => p !== '/summary',
+            run: () => location.href = '/summary',
+        },
+
+        // ───────── N02 층 선택 (안전) ─────────
+        {
+            name: 'floor',
+            match: /([1-3])\s*층/,
+            allowOn: (p) => p === '/menu',
+            run: (m) => document.querySelector(`[data-floor="F${m[1]}"]`)?.click(),
+        },
+
+        // ───────── P02 결제수단 (안전 — 카드 선택만, CTA 누르지 않음) ─────────
+        {
+            name: 'pay_kakao',
+            match: /(카카오\s*페이?|카카오\s*바코드|카톡\s*페이?|바코드)/,
+            allowOn: (p) => p === '/payment',
+            run: () => document.querySelector('[data-method="barcode"]')?.click(),
+        },
+        {
+            name: 'pay_ic',
+            match: /(IC\s*카드|아이씨\s*카드|신용\s*카드|체크\s*카드|카드(?!오))/i,
+            allowOn: (p) => p === '/payment',
+            run: () => document.querySelector('[data-method="ic"]')?.click(),
+        },
+        {
+            name: 'pay_vein',
+            match: /(정맥|손바닥\s*정맥|손바닥\s*인증)/,
+            allowOn: (p) => p === '/payment',
+            run: () => document.querySelector('[data-method="vein"]')?.click(),
+        },
+
+        // ───────── 마이크 끄기 (안전) ─────────
+        {
+            name: 'mic_off',
+            match: /마이크.{0,3}(꺼|종료|중지|오프|stop)/i,
+            run: () => window.dispatchEvent(new CustomEvent('voice:stop')),
+        },
+    ];
+
+    /**
+     * 발화 텍스트를 검사. 매치되면 run 실행 + true 반환.
+     */
+    function tryAction(text, ctx) {
+        const t = (text || '').trim();
+        if (!t) return false;
+        const page = (ctx && ctx.page) || (typeof location !== 'undefined' ? location.pathname : '');
+
+        for (const rule of RULES) {
+            // 1) page 가드
+            if (rule.allowOn && !rule.allowOn(page)) continue;
+
+            // 2) 매치 확인
+            const m = t.match(rule.match);
+            if (!m) continue;
+
+            // 3) 부정 가드 — 매치되면 즉시 미발동 (LLM 으로 넘어감)
+            if (rule.guard && rule.guard.test(t)) {
+                console.log(LOG, '가드:', t, '→', rule.name);
+                continue;
+            }
+
+            // 4) 실행
+            try {
+                console.log(LOG, '매치:', t, '→', rule.name);
+                rule.run(m);
+                return true;
+            } catch (e) {
+                console.warn(LOG, '실행 실패', rule.name, e);
+                return false;
+            }
+        }
+        return false;
+    }
+
+    window.QuickAction = { try: tryAction, RULES: RULES };
+})();

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -557,10 +557,13 @@
                 if ($micStatusDesc && interim) $micStatusDesc.textContent = "…" + interim;
             },
             onUserUtterance: async (text) => {
+                console.log("[N02 mic] user 발화 final:", text, "micActive=" + state.micActive);
                 pushChatBubble("user", text);
                 setMicStatus("thinking");
                 await dispatchUserUtterance(text);
-                // 처리 끝났으면 다시 LISTENING 으로
+                // 처리 끝났으면 다시 LISTENING 으로 — 단 페이지 이동 중이면 무의미
+                console.log("[N02 mic] dispatch 종료, endTurn 시도. micActive=" + state.micActive
+                    + ", convMode=" + (window.ConvEngine && window.ConvEngine.getMode && window.ConvEngine.getMode()));
                 if (state.micActive && window.ConvEngine) {
                     window.ConvEngine.endTurn();
                     setMicStatus("listening");
@@ -568,12 +571,19 @@
             },
             onSilencePrompt: () => null,  // 침묵 시 자동 재촉발화 안 함
             onBargeIn: () => {},
-            onModeChange: (m) => { /* 디버깅 시 사용 */ },
+            onModeChange: (m) => console.log("[N02 mic] ConvEngine mode →", m),
         });
         _convEngineInited = true;
     }
 
     async function dispatchUserUtterance(text) {
+        // 1) JS quick-action — 결정론적 명령(결제하기/뒤로/층/결제수단 등)은 LLM 없이 0ms 처리
+        if (window.QuickAction && window.QuickAction.try(text, { page: location.pathname })) {
+            pushChatBubble("system", "✓ 처리했어요");
+            return;
+        }
+
+        // 2) 세션 보장
         if (!state.sessionId) {
             try { await ensureServerSession(); } catch (e) {
                 logApiError("세션 발급", e);
@@ -581,7 +591,7 @@
             }
         }
 
-        // 일시적 nginx/FastAPI 502 대응: 1회 재시도 (1초 대기)
+        // 3) FastAPI/LangGraph 호출 — 502/504 1회 재시도
         const callAi = () => window.Api.Ai.chat({
             session_id: state.sessionId,
             text: text,
@@ -600,14 +610,16 @@
                 res = await callAi();
             }
 
-            if (res && res.reply) {
-                pushChatBubble("system", res.reply);
-            }
+            if (res && res.reply) pushChatBubble("system", res.reply);
+
             // AI 가 백엔드 카트를 변경했을 수 있으므로 서버 카트 재동기화
             await syncCartFromServer();
 
-            // 향후 응답 스키마의 action 필드 처리 (현재 백엔드 미구현)
-            if (res && res.action) handleAiAction(res.action);
+            // 4) AI 응답의 화면 명령(action) + 추천 시각화
+            if (window.AiAction) {
+                if (res && res.action)          window.AiAction.handle(res.action);
+                if (res && res.recommendations) window.AiAction.handleRecommendations(res.recommendations);
+            }
         } catch (e) {
             console.error("[N02] AI 응답 최종 실패", e);
             const friendly = (e && (e.status === 502 || e.status === 504))
@@ -617,7 +629,7 @@
         }
     }
 
-    // 향후 백엔드가 action 필드 채워 보내면 화면 컨트롤. 지금은 navigate 만 지원.
+    // 미사용 (AiAction 모듈로 이관). 페이지 전용 액션 필요 시만 활용.
     function handleAiAction(action) {
         if (!action || !action.type) return;
         switch (action.type) {
@@ -821,6 +833,13 @@
         renderStoreList();
         renderMenuGrid();
         renderCartBar();
+
+        // QuickAction / AiAction 모듈이 호출할 수 있는 핸들러 노출
+        window.__N02_gotoCheckout = gotoCheckout;
+        window.__N02_openDetail   = openDetail;
+
+        // 외부에서 마이크 강제 종료 (QuickAction "마이크 꺼" 명령) 수신
+        window.addEventListener("voice:stop", () => { if (state.micActive) stopMic(); });
 
         // 운영 상태는 1분마다 갱신
         setInterval(renderStoreList, 60 * 1000);

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -274,6 +274,8 @@
 <script src="/js/common/confirm-modal.js"></script>
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
 <script src="/js/flowA/conversation-engine.js"></script>
 <script src="/js/flowN/menu-data.js"></script>
 <script src="/js/flowN/N02-menu.js"></script>


### PR DESCRIPTION
JS 단축 명령 (LLM 호출 없이 0ms 처리)
- common/quick-action.js (신규) · 화면 컨트롤 명령 10개 — checkout/home/back/menu/summary/floor/pay_kakao/pay_ic/pay_vein/mic_off · 느슨한 substring 매치 — "결제할게요" "1층 메뉴 보여줘" 같은 자연 변형도 잡음 · critical 액션(결제/홈) 만 부정형 가드 — "결제 안 할래" 같은 부정 표현은 LLM 으로 흘려보냄 · 페이지별 가드(allowOn) — 결제수단 매치는 /payment 에서만 등

AI 응답 화면 dispatcher (LangGraph 가 채워 보낼 action 처리)
- common/ai-action.js (신규) · navigate / select_floor / select_restaurant / highlight_menu / open_menu_detail / close_overlay / select_payment_method 액션 dispatch · recommendations 배열 받으면 메뉴 카드 펄스 + 첫 메뉴 자동 스크롤
- components.css: .ai-pulse 키프레임 (1.6s primary 컬러 펄스)

N02-menu.js 통합
- dispatchUserUtterance 맨 앞에 QuickAction.try 가드 추가
- AiAction.handle(res.action) + AiAction.handleRecommendations(res.recommendations) 호출
- gotoCheckout / openDetail 을 window.__N02_* 로 노출 (QuickAction/AiAction 이 호출)
- voice:stop 커스텀 이벤트 수신 — 음성으로 마이크 끄기 지원
- onUserUtterance 진단 로깅 강화

흐름:
  발화 → QuickAction 매치 (0ms) ? 즉시 처리 : LLM 호출 LLM 응답 → reply 채팅 + 카트 동기화 + action dispatch + recommendations 시각화

후속: NUNCHI-AI 측에서 ChatOrderResponse.action 필드 + UI 메타 도구 + intent_classifier OOD 분류 보강 필요

## 📣 Related Issue

- close #103 

## 📝 Summary

### JS 단축 명령 (LLM 호출 없이 0ms 처리)
- `common/quick-action.js` 신규 — 화면 컨트롤 10개 룰
  - 결제 / 홈 / 뒤로 / 메뉴 / 주문확인 / 1·2·3층 / IC카드 / 정맥 / 카카오페이 / 마이크 끄기
  - 느슨 substring 매치 — "결제할게요" "1층 메뉴 보여줘" 같은 자연 변형도 잡음
  - critical 액션(결제/홈)만 부정형 가드: "결제 안 할래" 같은 표현은 LLM 으로 흘려보냄
  - 페이지별 가드 — 결제수단 매치는 /payment 에서만, 층 매치는 /menu 에서만

### AI 응답 화면 dispatcher
- `common/ai-action.js` 신규 — LangGraph 가 미래에 채워 보낼 `action` 필드 처리
  - navigate / select_floor / select_restaurant / highlight_menu / open_menu_detail / close_overlay / select_payment_method
- 추천 시각화 — `recommendations` 배열 받으면 메뉴 카드 펄스 + 첫 메뉴 자동 스크롤
- `components.css` `.ai-pulse` 키프레임 (1.6s primary 컬러 outline + box-shadow 펄스)

### N02 통합
- `dispatchUserUtterance` 맨 앞에 `QuickAction.try()` 가드 추가
- 응답 받으면 `AiAction.handle(res.action)` + `AiAction.handleRecommendations(res.recommendations)` 호출
- `gotoCheckout` / `openDetail` 을 `window.__N02_*` 로 노출 — QuickAction/AiAction 이 호출 가능
- `voice:stop` 커스텀 이벤트 수신 — 음성으로 "마이크 꺼" 발화 시 마이크 종료
- onUserUtterance 진단 로깅 강화 ([N02 mic] prefix)

## 🙏 Question & PR point

- 현재 LangGraph 응답에 `action` 필드 없어 화면 자동 전환 부분은 inactive 상태. NUNCHI-AI 측 PR(별도) 머지 후 활성화됨
- JS 가 잡는 화면 컨트롤 키워드: 향후 시연 시나리오에 맞춰 정규식 추가 용이 (RULES 배열에 한 줄)
- 부정 가드는 결제/홈에만 — 다른 명령은 잘못 잡혀도 "뒤로" 음성으로 즉시 복구 가능해서 의도적

## 📬 Postman

<!-- N02 진입 → 마이크 클릭 → 다음 발화 테스트:
  "결제할게요"       → 즉시 /summary 이동 (콘솔: [QuickAction] 매치: ... → checkout)
  "결제 안 할래"     → 가드 발동, LLM 으로 흘려보냄
  "1층 메뉴 보여줘"  → 1층 탭 자동 click
  "단백질 많은 거 추천" → LLM 호출 (느림이지만 정상)
