### PR TITLE
[Fix]/#108/avata session duplication

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/session/service/SessionService.java
@@ -41,17 +41,23 @@ public class SessionService {
         return SessionResponse.from(session);
     }
 
+    /**
+     * 세션 종료 — 멱등 처리.
+     * 아바타 모드에서 FastAPI MCP Tool 이 결제 완료 시 자동으로 종료를 호출하고,
+     * 프론트(P05) 도 결제 완료 페이지 진입 시 동일 API 를 호출하는 흐름이 있어
+     * 같은 세션에 대해 종료가 두 번 들어올 수 있다.
+     * 단말기 연동 후엔 프론트가 결제 승인 후 단독으로 호출하므로 이 경로가 사라지지만,
+     * 안전망으로 멱등 응답을 유지한다.
+     * 이미 COMPLETED/EXPIRED 상태면 상태 변경 없이 현재 스냅샷을 반환한다.
+     */
     @Transactional
     public SessionResponse completeSession(Long sessionId) {
         KioskSession session = kioskSessionRepository.findByIdWithLock(sessionId)
                 .orElseThrow(() -> new SessionException(SessionErrorCode.NOT_FOUND_SESSION));
 
-        // 이미 종료된 세션이면 예외 처리
-        if (session.getSessionStatus() != SessionStatus.ACTIVE) {
-            throw new SessionException(SessionErrorCode.SESSION_ALREADY_ENDED);
+        if (session.getSessionStatus() == SessionStatus.ACTIVE) {
+            session.complete();
         }
-
-        session.complete();
         return SessionResponse.from(session);
     }
 

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -2,7 +2,8 @@
 // A01-avatar.js — 아바타 모드(동대맘) 통합 로직 (FastAPI 연결 + 턴테이킹)
 //
 // 흐름:
-//   1) 진입: Spring 세션 생성(POST /api/sessions, mode=AVATAR) + FastAPI 세션 생성(POST /ai/order/start)
+//   1) 진입: FastAPI 세션 시작(POST /ai/order/start) — FastAPI 가 Spring 에
+//      세션을 생성한 뒤 동일한 sessionId 를 응답. 프론트는 단일 ID 사용.
 //   2) 대기 화면: FastAPI greeting 을 typewriter 로 노출
 //   3) 마이크 클릭: ConvEngine.start() → enterState('opening')
 //   4) 사용자 발화 → POST /ai/order/chat → reply 발화
@@ -18,8 +19,8 @@
 //   - window.ConvEngine   (conversation-engine.js)
 //
 // 세션 키:
-//   sessionId    — Spring Long ID (P-flow 호환, 메시지/카트/주문)
-//   aiSessionId  — FastAPI 세션 ID (대화 흐름)
+//   sessionId    — Spring/FastAPI 공유 단일 sessionId (FastAPI start 응답값)
+//   aiSessionId  — sessionId 와 동일 값. FastAPI API 시그니처 호환 용도로 별도 보관.
 //   cart, currentStep, mode, dineOption, orderId, currentStoreName
 // ========================================================
 
@@ -50,8 +51,8 @@
     // ========================================================
     const state = {
         fsm: 'opening',
-        sessionId: null,            // Spring Long sessionId
-        aiSessionId: null,          // FastAPI session_id
+        sessionId: null,            // Spring/FastAPI 공유 sessionId (FastAPI start 응답값)
+        aiSessionId: null,          // sessionId 와 동일 값 — FastAPI 호출 시그니처 호환용
         bootGreeting: null,         // FastAPI 첫 인사말
         cart: { items: [], totalAmount: 0 },
         chatLog: [],
@@ -128,59 +129,9 @@
     }
 
     // ========================================================
-    // 5. 세션 영속 — Spring 세션
-    // ========================================================
-    /**
-     * sessionStorage 의 sessionId 가 양의 정수인지 엄격 검사.
-     * mock 잔재('a01-...') 또는 소수, 음수, 0 은 폐기.
-     */
-    function readStoredSessionId() {
-        const raw = AppState.get('SESSION_ID');
-        if (!raw) return null;
-        if (!/^[1-9][0-9]*$/.test(raw)) return null;
-        const n = Number(raw);
-        if (!Number.isInteger(n) || n <= 0 || !Number.isSafeInteger(n)) return null;
-        return n;
-    }
-
-    /**
-     * 저장된 세션 ID 가 서버에 실제로 존재하는지 가벼운 ping 으로 검증.
-     * 별도 GET /sessions/{id} 엔드포인트가 없어 tool-logs 조회로 대체.
-     */
-    async function verifyStoredSession(sessionId) {
-        try {
-            await window.Api.session.getToolLogs(sessionId, 1);
-            return true;
-        } catch (e) {
-            return false;
-        }
-    }
-
-    async function loadOrCreateSpringSession() {
-        const stored = readStoredSessionId();
-        if (stored) {
-            const ok = await verifyStoredSession(stored);
-            if (ok) {
-                state.sessionId = stored;
-                return;
-            }
-            AppState.remove('SESSION_ID');
-        }
-        const res = await callApi('Spring 세션 생성', () =>
-            window.Api.session.create({
-                mode: 'AVATAR',
-                language: 'ko',
-                orderType: resolveOrderType()
-            })
-        );
-        if (res && res.sessionId) {
-            state.sessionId = res.sessionId;
-            AppState.set('SESSION_ID', res.sessionId);
-        }
-    }
-
-    // ========================================================
-    // 5b. 세션 영속 — FastAPI 세션
+    // 5. 세션 시작 — FastAPI 가 내부에서 Spring 세션을 생성하고
+    // 동일한 sessionId 를 응답으로 돌려준다. 프론트는 이 단일 ID 를
+    // Spring(미니카트/결제) 및 FastAPI(대화) 양쪽 호출에 그대로 사용.
     // ========================================================
     async function startAiSession() {
         const res = await callApi('AI 세션 시작', () =>
@@ -191,7 +142,10 @@
             })
         );
         if (res && res.session_id != null) {
+            // Spring/FastAPI 가 공유하는 단일 sessionId — 두 변수에 동일 값 저장
+            state.sessionId = res.session_id;
             state.aiSessionId = res.session_id;
+            AppState.set('SESSION_ID', res.session_id);
             AppState.set('AI_SESSION_ID', res.session_id);
             state.bootGreeting = res.greeting || null;
             return true;
@@ -1060,8 +1014,8 @@
         },
         async diagnoseCart() {
             console.log('━━━━━ 카트 진단 ━━━━━');
-            console.log('Spring sessionId:', state.sessionId);
-            console.log('AI sessionId:   ', state.aiSessionId);
+            console.log('sessionId (공유):', state.sessionId);
+            console.log('aiSessionId    :', state.aiSessionId, '(sessionId 와 동일해야 함)');
             try {
                 const springCart = await window.Api.cart.get(state.sessionId);
                 console.log('[Spring cart]', springCart);
@@ -1107,11 +1061,8 @@
 
         onConvModeChange('INACTIVE');
 
-        // Spring + FastAPI 세션 병렬 시작
-        await Promise.all([
-            loadOrCreateSpringSession(),
-            startAiSession()
-        ]);
+        // FastAPI 가 Spring 세션을 함께 생성 — 단일 sessionId 사용
+        await startAiSession();
         if (state.sessionId) await refreshCart();
 
         // 자동 청취 시작 — ConvEngine.start() 가 AI_SPEAKING 으로 진입,

--- a/src/main/resources/static/front/js/flowP/P04-processing.js
+++ b/src/main/resources/static/front/js/flowP/P04-processing.js
@@ -159,7 +159,18 @@
         }
     }
 
-    /* ---------- 백엔드 결제 확정 (승인 분기) ---------- */
+    /* ---------- 백엔드 결제 확정 (승인 분기) ----------
+     * 정책 (이슈 #109):
+     *   [현재 — 단말기 미연동, 결제 더미]
+     *     confirm → payment.create → markSuccess 를 여기서 일괄 호출.
+     *     아바타 모드는 별도 경로로 FastAPI MCP Tool 이 백엔드를 자동 처리하지만,
+     *     N02·A01 공통으로 결제 흐름이 P04 를 거치므로 여기 호출도 유지된다
+     *     (session.complete 멱등 처리로 중복 안전).
+     *   [단말기 연동 후]
+     *     아래 markSuccess 호출은 단말기 승인 결과 콜백 시점으로 이동해야 한다.
+     *     즉 confirm + payment.create 까지만 P04 진입 시 호출하고,
+     *     단말기 → 프론트 승인 이벤트 수신 후 markSuccess + (P05 의) session.complete.
+     */
     let finalizing = false;
     async function finalizePaymentThenGoComplete() {
         if (finalizing) return;
@@ -192,6 +203,7 @@
             paymentId = payment.paymentId;
             sessionStorage.setItem('paymentId', String(paymentId));
 
+            // TODO(단말기 연동): 아래 markSuccess 호출은 단말기 승인 콜백 시점으로 이동.
             await window.NunchiApi.Payments.markSuccess(paymentId);
 
             approvedTimer = setTimeout(() => {

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -151,8 +151,19 @@
     renderAll();
     try { sessionStorage.setItem(STATUS_KEY, 'approved'); } catch (_) {}
 
-    // 세션 종료 — 정리 전에 sessionId 캡처해서 PATCH /api/sessions/{id}/complete 호출.
-    // 아바타 모드면 FastAPI 세션도 함께 정리 (별도 종료 엔드포인트가 없어 sessionStorage 제거만).
+    // 세션 종료 정책 (이슈 #109)
+    //
+    //   [현재 — 단말기 미연동, 결제 더미]
+    //   - 일반(N02) 모드: P04 markSuccess 후 P05 진입 → 여기서 session.complete 호출.
+    //   - 아바타(A01) 모드: 사용자 "결제해줘" 발화 시 FastAPI MCP Tool 이
+    //     주문 확인 → 결제 요청(더미) → 세션 종료까지 자동 수행. 이후 프론트가
+    //     동일 흐름으로 P05 에 도달하면서 여기서 또 한 번 호출하지만,
+    //     서버 측 complete 가 멱등이라 안전 (이미 COMPLETED 면 상태 변경 없이 응답).
+    //
+    //   [단말기 연동 후]
+    //   - FastAPI MCP Tool 은 주문 확인 + 결제 요청까지만 수행.
+    //   - 단말기 승인 결과를 프론트가 받으면 결제 성공 처리(POST /api/payments/{id}/success)
+    //     후 여기서 세션 종료. 즉 단일 호출 경로로 정리되며 본 호출이 정식 종료 지점이 된다.
     (function completeBackendSession() {
         const sessionId = sessionStorage.getItem(SESSION_ID_KEY);
         if (sessionId && window.NunchiApi) {


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #108 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 1. 아바타 모드 세션 두 개 생기던 문제 해결

  아바타 모드로 진입하면 Spring 세션이 두 개
  만들어지고 있었습니다.

  - 프론트가 한 번: Spring에 POST /api/sessions로
  직접 세션 생성
  - FastAPI가 한 번: /ai/order/start 처리 중
  내부에서 Spring에 세션 생성

  이 때문에 장바구니/결제가 쓰는 세션 ID와 AI
  대화가 쓰는 세션 ID가 서로 달라지면서, 같은
  사용자인데 카트가 비어 보이거나 결제 흐름이 꼬일
  수 있는 상태였습니다.

  FastAPI가 만든 세션 ID를 프론트가 그대로
  받아서 양쪽(미니카트/결제, AI 대화) 호출에 똑같이
   쓰도록 정리했습니다. 이제 한 사용자당 세션은
  항상 1개입니다.

  2. 결제 완료 시 "이미 종료된 세션" 에러 방지

  아바타 모드에서 "결제해줘"라고 말하면 FastAPI가
  백엔드에서 자동으로 주문확인 → 결제(더미) → 세션
  종료까지 처리해두는데, 이후 프론트가 결제 완료
  페이지(P05)에 도달했을 때 세션 종료 API를 한 번
  더 호출하면서 SESSION_ALREADY_ENDED 에러가 발생할
   수 있었습니다.

  서버 측 세션 종료 API를 멱등 처리해서, 이미
  종료된 세션에 다시 종료 요청이 와도 에러 없이
  현재 상태를 그대로 응답합니다. 어떤 경로로
  들어와도 안전합니다.

  3. 단말기 연동 대비 — 결제·세션 종료 정책 명문화

  지금은 단말기가 없어서 결제가 더미로 통과되지만,
  실제 단말기가 붙으면 결제 성공 처리·세션 종료
  호출 지점이 바뀌어야 합니다. 어디서 무엇이
  바뀌어야 하는지 P04/P05에 주석으로
  명시해뒀습니다.

  - 현재: FastAPI가 알아서 종료까지 처리 → 프론트
  호출은 안전망(멱등)
  - 단말기 연동 후: FastAPI는 결제 요청까지만,
  단말기 승인 결과를 받은 프론트가 직접
  /payments/{id}/success + /sessions/{id}/complete
  호출

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
  - FastAPI 응답의 session_id = Spring 세션 ID 라는
   전제로 작업했습니다. FastAPI 쪽에서 정말로
  Spring 세션을 내부에서 만들고 그 ID를 그대로
  응답으로 돌려주는지 한 번만 더 크로스체크
  부탁드립니다.
  - 페이지 새로고침 시 기존 세션 복원
  로직(readStoredSessionId / verifyStoredSession)은
   제거했습니다. FastAPI가 새로고침 시 새 세션을
  만들기 때문에 stored Spring ID로 복원하면 정합이
  깨지기 때문입니다. 결과적으로 새로고침하면 카트가
   새로 시작되는데, 운영상 OK한지 확인 필요.
  - 단말기 연동 시점에 함께 진행되어야 할 변경 두
  가지를 TODO로 남겨뒀습니다:
    a. P04-processing.js의 markSuccess 호출을
  단말기 승인 콜백 시점으로 이동
    b. FastAPI MCP Tool에서 자동 session.complete
  단계 제거 (Spring 측 변경은 이번 PR로 끝)
  - 로컬 부팅 검증 시 기존 orders 테이블에
  order_type IS NULL row가 남아있어서 DDL
  마이그레이션이 실패하는 별개 이슈가 있었습니다.
  이번 PR과는 무관하지만 다른 분도 로컬에서 같은
  증상 만날 수 있어 공유합니다 — DB 초기화 또는
  백필 한 줄로 해결됩니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 중복된 세션 종료 요청에 대한 안정성 개선

* **개선 사항**
  * 세션 초기화 프로세스 단순화 및 최적화

* **문서화**
  * 결제 확정 및 세션 종료 정책 명확화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->