### PR TITLE
[Feat] 음성 원격조작 결제 흐름 연결 + 메뉴 옵션 선택 UI + 결제화면 마이크/대화/뒤로가기

### DIFF
--- a/src/main/resources/static/front/css/components.css
+++ b/src/main/resources/static/front/css/components.css
@@ -797,6 +797,15 @@
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    flex: 1;              /* 제목이 공간을 채워 우측 액션(대화/마이크)을 오른쪽으로 정렬 */
+}
+
+/* 상단바 우측 액션 묶음(대화·마이크)이 여러 개여도 오른쪽에 모이도록 */
+.p-topbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
 }
 
 .p-topbar__eyebrow {

--- a/src/main/resources/static/front/css/flowN/N02-menu.css
+++ b/src/main/resources/static/front/css/flowN/N02-menu.css
@@ -823,6 +823,115 @@
     letter-spacing: -0.2px;
 }
 
+/* ───────── 옵션 선택 ───────── */
+.n02__detail-options {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.n02__detail-optgroup {
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+}
+
+.n02__detail-optgroup-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.n02__detail-optgroup-name {
+    font-size: 13px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    letter-spacing: -0.2px;
+}
+
+.n02__detail-optgroup-req {
+    display: inline-flex;
+    align-items: center;
+    height: 19px;
+    padding: 0 7px;
+    border-radius: 9999px;
+    background: var(--primary-500);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+}
+
+.n02__detail-optgroup-choices {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+/* 옵션 버튼 — 미선택 기본 */
+.n02__detail-opt {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 0 15px;
+    background: var(--color-bg-card, #fff);
+    border: 1.5px solid var(--neutral-200);
+    border-radius: 12px;
+    color: var(--neutral-700);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    cursor: pointer;
+    transition: border-color .15s, background .15s, color .15s;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* 라디오 점 */
+.n02__detail-opt::before {
+    content: "";
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    border: 2px solid var(--neutral-300);
+    box-sizing: border-box;
+    transition: border-color .15s, box-shadow .15s;
+}
+
+.n02__detail-opt-name { white-space: nowrap; }
+
+.n02__detail-opt-price {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-text-secondary, var(--neutral-500));
+}
+
+/* 옵션 버튼 — 선택됨 */
+.n02__detail-opt.is-selected {
+    border-color: var(--primary-500);
+    background: var(--primary-50);
+    color: var(--primary-700);
+}
+
+.n02__detail-opt.is-selected::before {
+    border-color: var(--primary-500);
+    box-shadow: inset 0 0 0 4px var(--primary-500);
+}
+
+.n02__detail-opt.is-selected .n02__detail-opt-price {
+    color: var(--primary-600);
+}
+
+/* 음성으로 방금 선택된 옵션 펄스 */
+.n02__detail-opt.ai-pulse {
+    animation: n02OptPulse 1.2s ease;
+}
+@keyframes n02OptPulse {
+    0%   { box-shadow: 0 0 0 0 var(--primary-200); }
+    100% { box-shadow: 0 0 0 10px transparent; }
+}
+
 /* 원재료 리스트 */
 .n02__detail-ingredients {
     display: flex;

--- a/src/main/resources/static/front/js/common/api.js
+++ b/src/main/resources/static/front/js/common/api.js
@@ -22,16 +22,18 @@
 
     const LOG = '[Api]';
     // 로컬 개발: 페이지가 localhost 면 Spring 은 same-origin(`''`),
-    //           FastAPI(/ai/**) 는 운영 도메인 — nginx 가 매핑.
-    // 운영: 둘 다 same-origin (`''`).
-    const PROD_DOMAIN = 'https://43-201-20-11.sslip.io';
+    //           FastAPI(/ai/**) 는 로컬 FastAPI(localhost:8000).
+    //           ※ 로컬 Spring 과 로컬 FastAPI 가 같은 로컬 DB/세션을 공유해야
+    //             세션 검증이 일치한다. (운영 FastAPI 를 가리키면 세션 불일치로 502)
+    // 운영: 둘 다 same-origin (`''`) — nginx 가 /ai/** 를 FastAPI 로 매핑.
+    const LOCAL_FASTAPI = 'http://localhost:8000';   // 로컬 NUNCHI-AI
     const isLocalHost = (typeof location !== 'undefined') &&
         (location.hostname === 'localhost' || location.hostname === '127.0.0.1');
 
-    /** path 별 base URL 결정. /ai/** 는 항상 FastAPI(운영), 그 외는 Spring. */
+    /** path 별 base URL 결정. /ai/** 는 FastAPI(로컬=8000, 운영=same-origin), 그 외는 Spring. */
     function resolveUrl(path) {
         if (path.startsWith('/ai/')) {
-            return (isLocalHost ? PROD_DOMAIN : '') + path;
+            return (isLocalHost ? LOCAL_FASTAPI : '') + path;
         }
         return path; // Spring 은 same-origin
     }
@@ -268,6 +270,12 @@
         }
     };
 
+    // /ai/order/chat 동시 호출 차단용 락.
+    // 운영 FastAPI 는 chat 1건이 5~16초(LangGraph 다단계 LLM)라 처리 중에
+    // 두 번째 요청이 겹치면 nginx 가 빈 업스트림을 못 얻어 즉시 502 를 낸다.
+    // 음성 루프는 발화/소음/재시도로 요청이 상시 겹치므로, 진행 중이면 새 요청을 버린다(큐잉X).
+    let _chatInFlight = false;
+
     // /ai/order/* — FastAPI AI 서버 (nginx /ai/** 매핑)
     const Ai = {
         /**
@@ -292,13 +300,21 @@
             if (!body || body.session_id == null || !body.text) {
                 throw new Error('Ai.chat: session_id, text 필수');
             }
+            // 이미 처리 중이면 새 발화는 버린다 — 중첩이 운영 서버 502 의 원인.
+            if (_chatInFlight) {
+                const busy = new ApiError(429, '이전 음성 요청을 처리하고 있어요.', 0, '/ai/order/chat');
+                busy._busy = true;
+                return Promise.reject(busy);
+            }
             const payload = {
                 session_id: body.session_id,
                 text: body.text,
                 mode: body.mode || 'AVATAR',
             };
             if (body.nunchi_signal) payload.nunchi_signal = body.nunchi_signal;
-            return requestRaw('POST', '/ai/order/chat', payload);
+            _chatInFlight = true;
+            return requestRaw('POST', '/ai/order/chat', payload)
+                .finally(() => { _chatInFlight = false; });
         },
         /**
          * 추천/옵션 선택 후 메뉴를 장바구니에 직접 담음 (옵션 선택 UI 거친 뒤 사용).
@@ -335,8 +351,10 @@
         session, menu, cart, order, payment, recommend, Ai, Voice,
     };
 
-    window.NunchiApi = Api;
     window.Api = Api; // 짧은 별칭 (페이지 JS 에서 권장)
+    // api-client.js(대문자 NunchiApi.Cart/Sessions/...) 가 이미 로드된 페이지에서는
+    // 그 객체를 덮어쓰지 않는다. (P 화면들은 api-client.js 의 NunchiApi 를 사용)
+    if (!window.NunchiApi) window.NunchiApi = Api;
 
     // 디버그 모드 토글: 콘솔에서 window.__NUNCHI_API_DEBUG__ = true
 })();

--- a/src/main/resources/static/front/js/common/quick-action.js
+++ b/src/main/resources/static/front/js/common/quick-action.js
@@ -16,6 +16,23 @@
 
     const LOG = '[QuickAction]';
 
+    // 진행 의도가 담긴 발화면 결제 CTA 까지 누른다 (부정형이면 진행 안 함).
+    const _PROCEED_RE = /(결제|진행|할게|해줘|해줄래|주문|이걸로|다음)/;
+    const _PROCEED_NEG_RE = /(안|못|말고|그만|취소|싫어|아니|잠깐|아직|나중에)/;
+
+    function _selectMethodMaybeProceed(method, text) {
+        const card = document.querySelector(`[data-method="${method}"]`);
+        if (card) card.click();
+        const t = text || '';
+        if (_PROCEED_RE.test(t) && !_PROCEED_NEG_RE.test(t)) {
+            // 카드 선택으로 CTA 가 활성화될 시간을 한 틱 준 뒤 클릭
+            setTimeout(() => {
+                const next = document.querySelector('[data-action="next"]');
+                if (next && !next.disabled) next.click();
+            }, 60);
+        }
+    }
+
     /**
      * 룰: { match, guard?, allowOn?, run }
      *  - match:   substring 정규식 — 어디에 있어도 잡음
@@ -24,19 +41,26 @@
      *  - run:     실행 콜백 (m: 정규식 match 객체)
      */
     const RULES = [
-        // ───────── 결제하기 (critical — 부정 가드 + 카트 가드) ─────────
+        // ───────── 결제/다음단계 진행 (critical — 부정 가드) ─────────
+        // 터치의 "다음/결제하기" 버튼을 음성으로 누른 것과 동일하게 페이지별로 전진시킨다.
+        //   /menu    → 주문확인(/summary) (N02 가 카트 비었으면 자체 차단)
+        //   /summary → [data-action="next"] 클릭 → /payment
+        //   (/payment 의 "결제 진행" 은 결제수단 룰/ pay_proceed 가 담당)
         {
             name: 'checkout',
-            match: /결제/,
+            match: /(결제|주문\s*확인\s*완료|다음\s*단계|다음으로)/,
             guard: /(안|못|말고|그만|취소|싫어|아니|잠깐|아직|나중에)/,
             allowOn: (p) => p === '/menu' || p === '/summary',
             run: () => {
-                // N02 에서는 카트 비어있으면 발동 안 함 (N02 가 노출한 함수가 알아서 처리)
-                if (typeof window.__N02_gotoCheckout === 'function') {
-                    window.__N02_gotoCheckout();
-                } else {
-                    location.href = '/summary';
+                if (location.pathname === '/menu') {
+                    if (typeof window.__N02_gotoCheckout === 'function') window.__N02_gotoCheckout();
+                    else location.href = '/summary';
+                    return;
                 }
+                // /summary — 화면의 다음(결제하기) CTA 를 누른다 → /payment
+                const next = document.querySelector('[data-action="next"]');
+                if (next && !next.disabled) next.click();
+                else location.href = '/payment';
             },
         },
 
@@ -83,24 +107,39 @@
             run: (m) => document.querySelector(`[data-floor="F${m[1]}"]`)?.click(),
         },
 
-        // ───────── P02 결제수단 (안전 — 카드 선택만, CTA 누르지 않음) ─────────
+        // ───────── P02 결제수단 선택 (+ 진행어 있으면 결제까지 진행) ─────────
+        // 터치처럼: 결제수단 카드 클릭 → ("결제/진행/할게/해줘" 포함 시) 결제 CTA 까지 클릭.
+        //   "카카오페이"        → 카드 선택만
+        //   "카카오페이로 결제" → 카드 선택 + 결제 진행
         {
             name: 'pay_kakao',
             match: /(카카오\s*페이?|카카오\s*바코드|카톡\s*페이?|바코드)/,
             allowOn: (p) => p === '/payment',
-            run: () => document.querySelector('[data-method="barcode"]')?.click(),
+            run: (m) => _selectMethodMaybeProceed('barcode', m.input),
         },
         {
             name: 'pay_ic',
             match: /(IC\s*카드|아이씨\s*카드|신용\s*카드|체크\s*카드|카드(?!오))/i,
             allowOn: (p) => p === '/payment',
-            run: () => document.querySelector('[data-method="ic"]')?.click(),
+            run: (m) => _selectMethodMaybeProceed('ic', m.input),
         },
         {
             name: 'pay_vein',
             match: /(정맥|손바닥\s*정맥|손바닥\s*인증)/,
             allowOn: (p) => p === '/payment',
-            run: () => document.querySelector('[data-method="vein"]')?.click(),
+            run: (m) => _selectMethodMaybeProceed('vein', m.input),
+        },
+
+        // ───────── P02 결제 진행 (결제수단 이미 선택된 상태에서 "결제하기/진행") ─────────
+        {
+            name: 'pay_proceed',
+            match: /(결제하기|결제\s*진행|이걸로\s*(결제|해|할게)|진행해|결제할게|결제해|결제\s*완료|다음으로|다음\s*단계)/,
+            guard: /(안|못|말고|그만|취소|싫어|아니|잠깐|아직|나중에)/,
+            allowOn: (p) => p === '/payment',
+            run: () => {
+                const next = document.querySelector('[data-action="next"]');
+                if (next && !next.disabled) next.click();
+            },
         },
 
         // ───────── 마이크 끄기 (안전) ─────────

--- a/src/main/resources/static/front/js/common/voice-controller.js
+++ b/src/main/resources/static/front/js/common/voice-controller.js
@@ -1,0 +1,267 @@
+// ========================================================
+// voice-controller.js — 공통 마이크/STT 컨트롤러
+//
+// 책임:
+//  - ConvEngine 초기화 + 마이크 토글 (startMic / stopMic)
+//  - 발화(final) 처리 — QuickAction → 매치 안 되면 Api.Ai.chat → AiAction.handle
+//  - 502/504 일시 오류 1회 재시도
+//  - 마이크 버튼 [data-action="toggle-mic"] 클릭 + voice:stop 이벤트 자동 처리
+//
+// 사용:
+//   VoiceController.init({
+//       getSessionId: () => Number(sessionStorage.getItem('sessionId')),
+//       onUserUtterance: (text) => { ... },   // 옵션 — 페이지가 추가로 할 일
+//       onAiReply: (data) => { ... },         // 옵션 — reply 받았을 때
+//       onInterim: (text) => { ... },         // 옵션 — 실시간 자막
+//       mode: 'NORMAL',                       // 옵션 — 기본 NORMAL
+//   });
+//
+// 의존: api.js (Api.Ai), conversation-engine.js (ConvEngine),
+//      quick-action.js (QuickAction, 선택), ai-action.js (AiAction, 선택)
+// ========================================================
+
+(function () {
+    'use strict';
+
+    const LOG = '[Voice]';
+    const MIC_KEY = 'voiceMicOn';   // 페이지 이동 시 마이크 상태 보존용
+    let _inited = false;
+    let _opts = {};
+    const _state = {
+        micActive: false,
+    };
+
+    function _persistMicOn(on) {
+        try { sessionStorage.setItem(MIC_KEY, on ? '1' : '0'); } catch (_) {}
+    }
+    function _isMicPersistedOn() {
+        try { return sessionStorage.getItem(MIC_KEY) === '1'; } catch (_) { return false; }
+    }
+
+    // ── 대화 기록 패널 (결제 화면 등 채팅 UI 없는 화면 공용) ──────────
+    const _transcript = [];   // [{role:'user'|'ai'|'system', text}]
+    let _panelEl = null, _dimEl = null, _stylesInjected = false;
+
+    function _injectChatStyles() {
+        if (_stylesInjected) return;
+        _stylesInjected = true;
+        const css =
+'.vc-chat-dim{position:fixed;inset:0;background:rgba(0,0,0,.35);opacity:0;visibility:hidden;transition:opacity .2s;z-index:900;}' +
+'.vc-chat-dim.is-open{opacity:1;visibility:visible;}' +
+'.vc-chat{position:fixed;top:0;right:0;height:100%;width:380px;max-width:86vw;background:#fff;box-shadow:-8px 0 24px rgba(0,0,0,.12);transform:translateX(100%);transition:transform .25s;z-index:901;display:flex;flex-direction:column;}' +
+'.vc-chat.is-open{transform:translateX(0);}' +
+'.vc-chat__head{display:flex;align-items:center;justify-content:space-between;padding:18px 20px;border-bottom:1px solid #eee;}' +
+'.vc-chat__title{font-size:16px;font-weight:800;color:#222;}' +
+'.vc-chat__close{border:none;background:#f3f3f3;width:34px;height:34px;border-radius:50%;font-size:20px;line-height:1;cursor:pointer;color:#555;}' +
+'.vc-chat__body{flex:1;overflow-y:auto;padding:16px 18px;display:flex;flex-direction:column;gap:10px;}' +
+'.vc-chat__empty{color:#999;font-size:13px;text-align:center;margin-top:30px;line-height:1.6;}' +
+'.vc-msg{max-width:80%;padding:10px 13px;border-radius:14px;font-size:14px;line-height:1.45;word-break:break-word;white-space:pre-wrap;}' +
+'.vc-msg--user{align-self:flex-end;background:var(--primary-500,#3d7eff);color:#fff;border-bottom-right-radius:4px;}' +
+'.vc-msg--ai{align-self:flex-start;background:#f1f1f4;color:#222;border-bottom-left-radius:4px;}' +
+'.vc-msg--system{align-self:center;background:transparent;color:#999;font-size:12px;}';
+        const s = document.createElement('style');
+        s.textContent = css;
+        document.head.appendChild(s);
+    }
+
+    function _ensurePanel() {
+        if (_panelEl) return;
+        _injectChatStyles();
+        _dimEl = document.createElement('div');
+        _dimEl.className = 'vc-chat-dim';
+        _dimEl.addEventListener('click', _closeChat);
+
+        _panelEl = document.createElement('aside');
+        _panelEl.className = 'vc-chat';
+        _panelEl.setAttribute('aria-label', 'AI 대화');
+        _panelEl.innerHTML =
+            '<div class="vc-chat__head"><span class="vc-chat__title">AI 대화</span>' +
+            '<button type="button" class="vc-chat__close" aria-label="닫기">×</button></div>' +
+            '<div class="vc-chat__body"></div>';
+        _panelEl.querySelector('.vc-chat__close').addEventListener('click', _closeChat);
+
+        document.body.appendChild(_dimEl);
+        document.body.appendChild(_panelEl);
+        _renderTranscript();
+    }
+
+    function _renderTranscript() {
+        if (!_panelEl) return;
+        const body = _panelEl.querySelector('.vc-chat__body');
+        if (!_transcript.length) {
+            body.innerHTML = '<p class="vc-chat__empty">아직 대화가 없어요.\n마이크를 켜고 말씀해보세요.</p>';
+            return;
+        }
+        body.innerHTML = '';
+        _transcript.forEach((m) => {
+            const el = document.createElement('div');
+            el.className = 'vc-msg vc-msg--' + m.role;
+            el.textContent = m.text;          // XSS 안전
+            body.appendChild(el);
+        });
+        body.scrollTop = body.scrollHeight;
+    }
+
+    function _logChat(role, text) {
+        if (!text) return;
+        _transcript.push({ role: role, text: String(text) });
+        if (_transcript.length > 100) _transcript.shift();
+        _renderTranscript();
+    }
+
+    function _openChat()  { _ensurePanel(); _dimEl.classList.add('is-open'); _panelEl.classList.add('is-open'); }
+    function _closeChat() { if (_panelEl) { _dimEl.classList.remove('is-open'); _panelEl.classList.remove('is-open'); } }
+    function _toggleChat() { _ensurePanel(); (_panelEl.classList.contains('is-open') ? _closeChat : _openChat)(); }
+
+    function init(opts) {
+        if (_inited) return;
+        _opts = opts || {};
+
+        if (!window.ConvEngine || !window.ConvEngine.isSupported || !window.ConvEngine.isSupported()) {
+            console.warn(LOG, 'Web Speech API 미지원 브라우저');
+            return;
+        }
+
+        window.ConvEngine.init({
+            onInterim: (interim) => {
+                if (_opts.onInterim) {
+                    try { _opts.onInterim(interim); } catch (e) { console.warn(LOG, 'onInterim 실패', e); }
+                }
+            },
+            onUserUtterance: async (text) => {
+                console.log(LOG, '발화:', text);
+                _logChat('user', text);
+                if (_opts.onUserUtterance) {
+                    try { _opts.onUserUtterance(text); } catch (e) { console.warn(LOG, 'onUserUtterance 실패', e); }
+                }
+                await _dispatch(text);
+                // 처리 끝났으면 다시 LISTENING 으로
+                if (_state.micActive && window.ConvEngine) window.ConvEngine.endTurn();
+            },
+            onSilencePrompt: () => null,
+            onBargeIn: () => {},
+            onModeChange: (m) => console.log(LOG, 'mode →', m),
+        });
+
+        // 마이크 버튼 + 뒤로가기 버튼 클릭 위임
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('[data-action="toggle-mic"]')) toggle();
+            // 뒤로가기 — 이전 화면으로. 히스토리 없으면 메뉴로.
+            if (e.target.closest('[data-action="nav-back"]')) {
+                if (window.history.length > 1) window.history.back();
+                else window.location.href = '/menu';
+            }
+            // 대화 보기 패널 토글
+            if (e.target.closest('[data-action="open-chat"]')) _toggleChat();
+        });
+
+        // 음성 명령으로 "마이크 꺼" 일 때 발생하는 이벤트
+        window.addEventListener('voice:stop', () => { if (_state.micActive) stop(); });
+
+        _inited = true;
+        console.log(LOG, '초기화 완료');
+
+        // 직전 화면에서 마이크가 켜져 있었으면 이 화면에서도 자동으로 켠다.
+        // (권한은 same-origin 에서 1회 허용 후 유지되므로 팝업 없이 시작)
+        if (_isMicPersistedOn()) {
+            console.log(LOG, '직전 화면 마이크 ON 상태 → 자동 시작');
+            start();
+        }
+    }
+
+    async function _dispatch(text) {
+        // 1) JS quick-action (있으면)
+        if (window.QuickAction && window.QuickAction.try(text, { page: location.pathname })) {
+            _logChat('system', '✓ 처리했어요');
+            return;
+        }
+
+        // 2) 세션 확보
+        const sid = _opts.getSessionId ? _opts.getSessionId() : null;
+        if (!sid) {
+            console.warn(LOG, 'session_id 없음 — AI 호출 생략');
+            return;
+        }
+
+        // 3) FastAPI/LangGraph 호출 (502/504 1회 재시도)
+        const callAi = () => window.Api.Ai.chat({
+            session_id: sid,
+            text: text,
+            mode: _opts.mode || 'NORMAL',
+        });
+
+        try {
+            let res;
+            try {
+                res = await callAi();
+            } catch (firstErr) {
+                const isGateway = firstErr && (firstErr.status === 502 || firstErr.status === 504);
+                if (!isGateway) throw firstErr;
+                console.warn(LOG, '502/504, 1회 재시도');
+                await new Promise(r => setTimeout(r, 1000));
+                res = await callAi();
+            }
+
+            if (res && res.reply) _logChat('ai', res.reply);
+            if (_opts.onAiReply) {
+                try { _opts.onAiReply(res); } catch (e) { console.warn(LOG, 'onAiReply 실패', e); }
+            }
+
+            // 4) 화면 액션 dispatch
+            if (window.AiAction) {
+                if (res && res.action)          window.AiAction.handle(res.action);
+                if (res && res.recommendations) window.AiAction.handleRecommendations(res.recommendations);
+            }
+        } catch (e) {
+            // 처리 중 중첩으로 버려진 발화 — 에러 아님, 조용히 무시.
+            if (e && e._busy) {
+                console.log(LOG, '처리 중 — 중복 발화 무시:', text);
+                return;
+            }
+            console.error(LOG, 'AI 최종 실패', e);
+            const _errMsg = (e && (e.status === 502 || e.status === 504))
+                ? "AI 서버가 잠시 응답이 느려요. 잠시 후 다시 말씀해주세요."
+                : "응답을 가져오지 못했어요.";
+            _logChat('ai', _errMsg);
+            if (_opts.onAiReply) {
+                try {
+                    _opts.onAiReply({ reply: _errMsg, _error: true });
+                } catch (_) {}
+            }
+        }
+    }
+
+    function start() {
+        if (!window.ConvEngine || !window.ConvEngine.isSupported()) return;
+        if (_state.micActive) return;
+        window.ConvEngine.start();
+        window.ConvEngine.endTurn();   // 인사 발화 없이 즉시 LISTENING
+        _state.micActive = true;
+        _persistMicOn(true);           // 페이지 이동 후에도 유지
+        _toggleMicButton(true);
+        if (_opts.onMicStateChange) _opts.onMicStateChange(true);
+    }
+
+    function stop() {
+        if (!window.ConvEngine) return;
+        window.ConvEngine.stop();
+        _state.micActive = false;
+        _persistMicOn(false);          // 명시적으로 끄면 다음 화면도 OFF
+        _toggleMicButton(false);
+        if (_opts.onMicStateChange) _opts.onMicStateChange(false);
+    }
+
+    function toggle() {
+        if (_state.micActive) stop();
+        else                   start();
+    }
+
+    function _toggleMicButton(active) {
+        const btn = document.querySelector('[data-action="toggle-mic"]');
+        if (btn) btn.classList.toggle('app-topbar__action-icon--mic-active', !!active);
+    }
+
+    function isActive() { return _state.micActive; }
+
+    window.VoiceController = { init, start, stop, toggle, isActive };
+})();

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -520,6 +520,13 @@
 
         await aiSpeakChained(res.reply);
 
+        // AI 화면 원격조작 — navigate 등 (음성=터치). LLM 이 준 화면 명령을 그대로 반영.
+        // navigate 면 페이지를 떠나므로 이후 후처리는 생략.
+        if (window.AiAction && res.action) {
+            window.AiAction.handle(res.action);
+            if (res.action.type === 'navigate' && res.action.page) return;
+        }
+
         // reply 후처리
         const reply = res.reply;
         if (window.ReplyKeywords && window.ReplyKeywords.replyHasCartChange(reply)) {

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -63,6 +63,8 @@
     const $detailNutC     = document.querySelector('[data-detail-nut-carb]');
     const $detailNutF     = document.querySelector('[data-detail-nut-fat]');
     const $detailCtaPrice = document.querySelector('[data-detail-cta-price]');
+    const $detailOptions        = document.querySelector('[data-detail-options]');
+    const $detailOptionsSection = document.querySelector('[data-detail-options-section]');
 
     const $chatPanel      = document.querySelector('[data-chat-panel]');
     const $chatDim        = document.querySelector('[data-chat-dim]');
@@ -345,6 +347,128 @@
         $cartArrowNext.hidden = !showArrows;
     }
 
+    // ---------- 메뉴 상세 옵션 ----------
+    // detailOptionGroups: [{groupId, groupName, options:[{optionId, name, extraPrice}]}]
+    // detailSelected:     { [groupId]: optionId }  (그룹당 1개 — 라디오)
+    let detailOptionGroups = [];
+    const detailSelected = {};
+    let detailBasePrice = 0;
+
+    function renderDetailOptions(groups, basePrice) {
+        detailOptionGroups = Array.isArray(groups) ? groups : [];
+        detailBasePrice = basePrice || 0;
+        Object.keys(detailSelected).forEach((k) => delete detailSelected[k]);
+
+        if (!detailOptionGroups.length) {
+            if ($detailOptionsSection) $detailOptionsSection.hidden = true;
+            if ($detailOptions) $detailOptions.innerHTML = "";
+            recomputeDetailPrice();
+            return;
+        }
+
+        const html = detailOptionGroups.map((g) => {
+            const first = g.options && g.options[0];
+            if (first) detailSelected[g.groupId] = first.optionId;   // 첫 옵션 기본 선택
+            const choices = (g.options || []).map((o) => {
+                const sel = first && o.optionId === first.optionId ? " is-selected" : "";
+                const price = o.extraPrice > 0
+                    ? `<span class="n02__detail-opt-price">+${fmt(o.extraPrice)}</span>` : "";
+                return `<button type="button" class="n02__detail-opt${sel}"
+                                data-group-id="${g.groupId}" data-option-id="${o.optionId}">
+                            <span class="n02__detail-opt-name">${o.name}</span>${price}
+                        </button>`;
+            }).join("");
+            return `<div class="n02__detail-optgroup" data-optgroup="${g.groupId}">
+                        <div class="n02__detail-optgroup-head">
+                            <span class="n02__detail-optgroup-name">${g.groupName}</span>
+                            <span class="n02__detail-optgroup-req">필수</span>
+                        </div>
+                        <div class="n02__detail-optgroup-choices">${choices}</div>
+                    </div>`;
+        }).join("");
+
+        if ($detailOptions) $detailOptions.innerHTML = html;
+        if ($detailOptionsSection) $detailOptionsSection.hidden = false;
+        recomputeDetailPrice();
+    }
+
+    function selectDetailOption(groupId, optionId) {
+        detailSelected[groupId] = optionId;
+        const group = $detailOptions && $detailOptions.querySelector(`[data-optgroup="${groupId}"]`);
+        if (group) {
+            group.querySelectorAll(".n02__detail-opt").forEach((b) => {
+                b.classList.toggle("is-selected", b.getAttribute("data-option-id") === String(optionId));
+            });
+        }
+        recomputeDetailPrice();
+    }
+
+    function recomputeDetailPrice() {
+        let total = detailBasePrice;
+        for (const g of detailOptionGroups) {
+            const opt = (g.options || []).find((o) => o.optionId === detailSelected[g.groupId]);
+            if (opt && opt.extraPrice) total += opt.extraPrice;
+        }
+        if ($detailPrice)    $detailPrice.textContent = fmt(total);
+        if ($detailCtaPrice) $detailCtaPrice.textContent = "· " + fmt(total);
+    }
+
+    function getDetailSelectedOptionIds() {
+        return detailOptionGroups
+            .map((g) => detailSelected[g.groupId])
+            .filter((v) => v != null);
+    }
+
+    // 옵션명과 발화가 매칭되는지 — STT 오인식/축약 고려해 느슨하게.
+    const _OPT_GENERIC = ["추가", "선택", "없음", "기본", "변경", "옵션"];
+    function _optNameMatches(spoken, optName) {
+        const t = (spoken || "").replace(/\s/g, "");
+        const n = (optName || "").replace(/\s/g, "");
+        if (!t || !n) return false;
+        if (t.includes(n) || n.includes(t)) return true;          // 전체 포함
+        // 옵션명에서 일반어 뺀 핵심 토큰(2자+) 중 하나라도 발화에 있으면 매치
+        const tokens = (optName || "").split(/\s+/)
+            .filter((w) => w.length >= 2 && !_OPT_GENERIC.includes(w));
+        return tokens.some((w) => t.includes(w));
+    }
+
+    // 상세 오버레이가 열려 있을 때의 음성 처리 — 옵션 선택 / 담기 / 닫기.
+    // 처리하면 true(LLM 안 넘김), 닫혀 있거나 해당 없으면 false.
+    function tryDetailVoice(text) {
+        if (!$detail || $detail.hidden || openDetailMenuId == null) return false;
+        const t = (text || "").replace(/\s/g, "");
+        if (!t) return false;
+
+        // 1) 옵션명 매칭 → 선택 (느슨)
+        for (const g of detailOptionGroups) {
+            for (const o of (g.options || [])) {
+                if (_optNameMatches(text, o.name)) {
+                    selectDetailOption(g.groupId, o.optionId);
+                    const btn = $detailOptions && $detailOptions.querySelector(`[data-option-id="${o.optionId}"]`);
+                    if (btn) { btn.classList.add("ai-pulse"); setTimeout(() => btn.classList.remove("ai-pulse"), 1200); }
+                    pushChatBubble("system", `${g.groupName}: ${o.name} 선택했어요`);
+                    return true;
+                }
+            }
+        }
+
+        // 2) 담기 / 확정 (선택된 옵션과 함께)
+        if (/(담아|담기|넣어|이걸로|장바구니|주문할|완료)/.test(t) && !/(안|말고|취소|아니|그만)/.test(t)) {
+            addToCart(openDetailMenuId, { optionIds: getDetailSelectedOptionIds() });
+            closeDetail();
+            return true;
+        }
+
+        // 3) 닫기 / 취소
+        if (/(닫아|닫기|취소|그만|뒤로|나가)/.test(t)) {
+            closeDetail();
+            pushChatBubble("system", "상세를 닫았어요");
+            return true;
+        }
+
+        return false;
+    }
+
     // ---------- 메뉴 상세 오버레이 ----------
     function openDetail(menuId) {
         const found = window.MenuData.findMenuById(menuId);
@@ -387,8 +511,15 @@
         $detailNutC.textContent    = meta.nutrition.carb;
         $detailNutF.textContent    = meta.nutrition.fat;
 
-        // CTA 가격
+        // CTA 가격 (옵션 로딩 전 base 가격)
         $detailCtaPrice.textContent = "· " + fmt(m.price);
+
+        // 옵션 — 우선 비우고, 상세 API 로 그룹 fetch 후 렌더 (없으면 섹션 숨김)
+        renderDetailOptions([], m.price);
+        window.Api.menu.detail(menuId).then((d) => {
+            if (openDetailMenuId !== menuId) return;   // 그새 다른 메뉴 열렸으면 무시
+            renderDetailOptions(d && d.optionGroups, m.price);
+        }).catch((e) => console.warn("[N02] 옵션 조회 실패", e));
 
         $detail.hidden = false;
         $detail.setAttribute("aria-hidden", "false");
@@ -412,7 +543,7 @@
                 sessionId: sessionId,
                 menuId: menuId,
                 quantity: 1,
-                optionIds: [],
+                optionIds: Array.isArray(opts.optionIds) ? opts.optionIds : [],
             });
             applyCartResponse(res);
 
@@ -577,6 +708,9 @@
     }
 
     async function dispatchUserUtterance(text) {
+        // 0) 상세 오버레이가 열려 있으면 옵션 선택/담기/닫기를 우선 처리 (LLM 없이)
+        if (tryDetailVoice(text)) return;
+
         // 1) JS quick-action — 결정론적 명령(결제하기/뒤로/층/결제수단 등)은 LLM 없이 0ms 처리
         if (window.QuickAction && window.QuickAction.try(text, { page: location.pathname })) {
             pushChatBubble("system", "✓ 처리했어요");
@@ -615,12 +749,28 @@
             // AI 가 백엔드 카트를 변경했을 수 있으므로 서버 카트 재동기화
             await syncCartFromServer();
 
-            // 4) AI 응답의 화면 명령(action) + 추천 시각화
-            if (window.AiAction) {
-                if (res && res.action)          window.AiAction.handle(res.action);
-                if (res && res.recommendations) window.AiAction.handleRecommendations(res.recommendations);
+            // 4) 옵션 필요한 메뉴 → 상세(옵션 UI) 자동 오픈 → 사용자가 옵션 고르고 "담아줘"
+            if (res && res.menu_options && res.menu_options.menu_id != null) {
+                openDetail(res.menu_options.menu_id);
+            } else if (window.AiAction && res && res.action) {
+                const a = res.action;
+                // 빈 카트로 결제/주문확인 화면 이동 금지 — 메뉴부터 담게 안내
+                if (a.type === "navigate" && (a.page === "/summary" || a.page === "/payment") && !state.cart.length) {
+                    pushChatBubble("system", "장바구니가 비어 있어요. 메뉴를 먼저 담아주세요.");
+                } else {
+                    window.AiAction.handle(a);
+                }
+            }
+            // 5) 추천 시각화
+            if (window.AiAction && res && res.recommendations) {
+                window.AiAction.handleRecommendations(res.recommendations);
             }
         } catch (e) {
+            // 처리 중 중첩으로 버려진 발화 — 에러 아님, 조용히 무시(직전 요청이 곧 응답).
+            if (e && e._busy) {
+                console.log("[N02] 처리 중 — 중복 발화 무시:", text);
+                return;
+            }
             console.error("[N02] AI 응답 최종 실패", e);
             const friendly = (e && (e.status === 502 || e.status === 504))
                 ? "AI 서버가 잠시 응답이 느려요. 잠시 후 다시 말씀해주세요."
@@ -647,6 +797,7 @@
         window.ConvEngine.start();
         window.ConvEngine.endTurn();   // 인사 발화 없이 즉시 LISTENING
         state.micActive = true;
+        try { sessionStorage.setItem("voiceMicOn", "1"); } catch (_) {}  // 결제 화면까지 ON 유지
         $micBtn.classList.add("app-topbar__action-icon--mic-active");
         setMicStatus("listening");
         pushChatBubble("system", "🎙️ 음성 인식을 시작했어요. 편하게 말씀해주세요.");
@@ -656,6 +807,7 @@
     function stopMic() {
         if (window.ConvEngine) window.ConvEngine.stop();
         state.micActive = false;
+        try { sessionStorage.setItem("voiceMicOn", "0"); } catch (_) {}  // 명시적 OFF
         $micBtn.classList.remove("app-topbar__action-icon--mic-active");
         setMicStatus("off");
         pushChatBubble("system", "🔇 음성 인식을 멈췄어요.");
@@ -758,11 +910,22 @@
             if (btn) closeDetail();
         });
 
+        // 상세 옵션 선택 (그룹당 라디오)
+        if ($detailOptions) {
+            $detailOptions.addEventListener("click", (e) => {
+                const opt = e.target.closest(".n02__detail-opt");
+                if (!opt) return;
+                const groupId  = Number(opt.getAttribute("data-group-id"));
+                const optionId = Number(opt.getAttribute("data-option-id"));
+                selectDetailOption(groupId, optionId);
+            });
+        }
+
         // 상세에서 카트 담기
         document.addEventListener("click", (e) => {
             const btn = e.target.closest('[data-action="add-from-detail"]');
             if (btn && openDetailMenuId != null) {
-                addToCart(openDetailMenuId);
+                addToCart(openDetailMenuId, { optionIds: getDetailSelectedOptionIds() });
                 closeDetail();
             }
         });
@@ -840,6 +1003,13 @@
 
         // 외부에서 마이크 강제 종료 (QuickAction "마이크 꺼" 명령) 수신
         window.addEventListener("voice:stop", () => { if (state.micActive) stopMic(); });
+
+        // 직전 화면(결제 등)에서 마이크가 켜져 있었으면 자동으로 다시 켠다.
+        try {
+            if (sessionStorage.getItem("voiceMicOn") === "1" && !state.micActive) {
+                startMic();
+            }
+        } catch (_) {}
 
         // 운영 상태는 1분마다 갱신
         setInterval(renderStoreList, 60 * 1000);

--- a/src/main/resources/static/front/js/flowP/P01-summary.js
+++ b/src/main/resources/static/front/js/flowP/P01-summary.js
@@ -178,11 +178,22 @@
         }
     });
 
-    backEl.addEventListener('click', () => confirmGoHome());
+    if (backEl) backEl.addEventListener('click', () => confirmGoHome());
 
     ctaEl.addEventListener('click', goNext);
 
     /* ---------- Init ---------- */
     renderAll();
     fetchCart();
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: getSessionId,
+            mode: 'NORMAL',
+            onAiReply: (data) => {
+                console.log('[P01] AI reply:', data && data.reply);
+            },
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P02-payment.js
+++ b/src/main/resources/static/front/js/flowP/P02-payment.js
@@ -159,4 +159,15 @@
     /* ---------- Init ---------- */
     renderAll();
     fetchCart();
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: getSessionId,
+            mode: 'NORMAL',
+            onAiReply: (data) => {
+                console.log('[P02] AI reply:', data && data.reply);
+            },
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P03-vein.js
+++ b/src/main/resources/static/front/js/flowP/P03-vein.js
@@ -226,4 +226,17 @@
         try { sessionStorage.setItem(METHOD_KEY, 'vein'); } catch (_) {}
         setState('prepare');
     }
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: () => {
+                const raw = sessionStorage.getItem('sessionId');
+                const n = raw ? Number(raw) : NaN;
+                return Number.isFinite(n) ? n : null;
+            },
+            mode: 'NORMAL',
+            onAiReply: (data) => console.log('[P03] AI reply:', data && data.reply),
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P04-processing.js
+++ b/src/main/resources/static/front/js/flowP/P04-processing.js
@@ -237,4 +237,13 @@
     const initial = getQuery('state');
     if (initial && COPY[initial]) setState(initial, { transition: false });
     else setState('inserting', { transition: false });
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: getSessionId,
+            mode: 'NORMAL',
+            onAiReply: (data) => console.log('[P04] AI reply:', data && data.reply),
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -162,4 +162,13 @@
 
     setTimeout(markReceiptDone, 3000);
     startCountdown();
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: getSessionId,
+            mode: 'NORMAL',
+            onAiReply: (data) => console.log('[P05] AI reply:', data && data.reply),
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P06-fail.js
+++ b/src/main/resources/static/front/js/flowP/P06-fail.js
@@ -240,4 +240,17 @@
     if (switchEl) switchEl.addEventListener('click', goSwitch);
     if (retryEl)  retryEl.addEventListener('click', () => goRetry(config.retry));
     if (homeEl)   homeEl.addEventListener('click', goHome);
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: () => {
+                const raw = sessionStorage.getItem('sessionId');
+                const n = raw ? Number(raw) : NaN;
+                return Number.isFinite(n) ? n : null;
+            },
+            mode: 'NORMAL',
+            onAiReply: (data) => console.log('[P06] AI reply:', data && data.reply),
+        });
+    }
 })();

--- a/src/main/resources/static/front/js/flowP/P07-barcode.js
+++ b/src/main/resources/static/front/js/flowP/P07-barcode.js
@@ -199,4 +199,13 @@
     } else {
         setState('waiting');
     }
+
+    // ---------- 음성 컨트롤 ----------
+    if (window.VoiceController) {
+        window.VoiceController.init({
+            getSessionId: getSessionId,
+            mode: 'NORMAL',
+            onAiReply: (data) => console.log('[P07] AI reply:', data && data.reply),
+        });
+    }
 })();

--- a/src/main/resources/templates_front/flowA/A01-avatar.html
+++ b/src/main/resources/templates_front/flowA/A01-avatar.html
@@ -186,6 +186,7 @@
 <script src="/js/common/confirm-modal.js"></script>
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api.js"></script>
+<script src="/js/common/ai-action.js"></script>
 <script src="/js/flowA/reply-keywords.js"></script>
 <script src="/js/flowA/recommend-sheet.js"></script>
 <script src="/js/flowA/option-sheet.js"></script>

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -161,6 +161,16 @@
             <div class="n02__detail-body" data-detail-body>
                 <p class="n02__detail-desc" data-detail-desc></p>
 
+                <!-- 옵션 선택 (옵션 있는 메뉴에서만 노출 — JS 가 채움) -->
+                <section class="n02__detail-section n02__detail-section--options"
+                         data-detail-options-section hidden>
+                    <h3 class="n02__detail-section-title">
+                        <i class="xi xi-check-circle-o" aria-hidden="true"></i>
+                        옵션 선택
+                    </h3>
+                    <div class="n02__detail-options" data-detail-options></div>
+                </section>
+
                 <section class="n02__detail-section">
                     <h3 class="n02__detail-section-title">
                         <i class="xi xi-restaurant" aria-hidden="true"></i>

--- a/src/main/resources/templates_front/flowP/P01-summary.html
+++ b/src/main/resources/templates_front/flowP/P01-summary.html
@@ -15,12 +15,24 @@
 
     <!-- 상단바 -->
     <header class="p-topbar">
-        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
-            <i class="xi-home" aria-hidden="true"></i>
+        <button type="button" class="p-topbar__back" data-action="nav-back" aria-label="뒤로">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
         </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">결제</h1>
+        </div>
+        <div class="p-topbar__actions">
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="open-chat"
+                    aria-label="대화 보기">
+                <i class="xi xi-comment" aria-hidden="true"></i>
+            </button>
+            <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -95,7 +107,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P01-summary.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -15,12 +15,24 @@
 
     <!-- 상단바 -->
     <header class="p-topbar">
-        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
-            <i class="xi-home" aria-hidden="true"></i>
+        <button type="button" class="p-topbar__back" data-action="nav-back" aria-label="뒤로">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
         </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">결제 수단 선택</h1>
+        </div>
+        <div class="p-topbar__actions">
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="open-chat"
+                    aria-label="대화 보기">
+                <i class="xi xi-comment" aria-hidden="true"></i>
+            </button>
+            <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -151,7 +163,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P02-payment.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P03-vein.html
+++ b/src/main/resources/templates_front/flowP/P03-vein.html
@@ -15,12 +15,24 @@
 
     <!-- 상단바 -->
     <header class="p-topbar">
-        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
-            <i class="xi-home" aria-hidden="true"></i>
+        <button type="button" class="p-topbar__back" data-action="nav-back" aria-label="뒤로">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
         </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">정맥 인증</h1>
+        </div>
+        <div class="p-topbar__actions">
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="open-chat"
+                    aria-label="대화 보기">
+                <i class="xi xi-comment" aria-hidden="true"></i>
+            </button>
+            <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -128,7 +140,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P03-vein.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P04-processing.html
+++ b/src/main/resources/templates_front/flowP/P04-processing.html
@@ -15,12 +15,24 @@
 
     <!-- 상단바 -->
     <header class="p-topbar">
-        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
-            <i class="xi-home" aria-hidden="true"></i>
+        <button type="button" class="p-topbar__back" data-action="nav-back" aria-label="뒤로">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
         </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">카드 결제</h1>
+        </div>
+        <div class="p-topbar__actions">
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="open-chat"
+                    aria-label="대화 보기">
+                <i class="xi xi-comment" aria-hidden="true"></i>
+            </button>
+            <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -123,7 +135,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P04-processing.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P05-complete.html
+++ b/src/main/resources/templates_front/flowP/P05-complete.html
@@ -15,7 +15,11 @@
 
     <!-- 상단바 (뒤로가기 없음 · 완료 단계이므로 홈 닫기만) -->
     <header class="p-topbar p05__topbar">
-        <div class="p05__topbar-spacer" aria-hidden="true"></div>
+        <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                data-action="toggle-mic"
+                aria-label="마이크 토글">
+            <i class="xi xi-microphone" aria-hidden="true"></i>
+        </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow">결제 완료</span>
             <h1 class="p-topbar__title">주문이 접수되었어요</h1>
@@ -116,6 +120,11 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P05-complete.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P06-fail.html
+++ b/src/main/resources/templates_front/flowP/P06-fail.html
@@ -22,6 +22,11 @@
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">결제 실패</h1>
         </div>
+        <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                data-action="toggle-mic"
+                aria-label="마이크 토글">
+            <i class="xi xi-microphone" aria-hidden="true"></i>
+        </button>
     </header>
 
     <!-- 3-step : 3단계 error -->
@@ -105,7 +110,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P06-fail.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates_front/flowP/P07-barcode.html
+++ b/src/main/resources/templates_front/flowP/P07-barcode.html
@@ -15,12 +15,24 @@
 
     <!-- 상단바 -->
     <header class="p-topbar">
-        <button type="button" class="p-topbar__back" data-action="back" aria-label="처음으로">
-            <i class="xi-home" aria-hidden="true"></i>
+        <button type="button" class="p-topbar__back" data-action="nav-back" aria-label="뒤로">
+            <i class="xi-angle-left-thin" aria-hidden="true"></i>
         </button>
         <div class="p-topbar__titles">
             <span class="p-topbar__eyebrow" data-bind="storeName">상록원</span>
             <h1 class="p-topbar__title">카카오페이 바코드 결제</h1>
+        </div>
+        <div class="p-topbar__actions">
+            <button class="app-topbar__action-icon" type="button"
+                    data-action="open-chat"
+                    aria-label="대화 보기">
+                <i class="xi xi-comment" aria-hidden="true"></i>
+            </button>
+            <button class="p-topbar__mic app-topbar__action-icon" type="button"
+                    data-action="toggle-mic"
+                    aria-label="마이크 토글">
+                <i class="xi xi-microphone" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -107,7 +119,12 @@
 
 <script src="/js/common/app-state.js"></script>
 <script src="/js/common/api-client.js"></script>
+<script src="/js/common/api.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
+<script src="/js/common/quick-action.js"></script>
+<script src="/js/common/ai-action.js"></script>
+<script src="/js/flowA/conversation-engine.js"></script>
+<script src="/js/common/voice-controller.js"></script>
 <script src="/js/flowP/P07-barcode.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## 📣 Related Issue

- close #

## 📝 Summary

음성으로 메뉴 담기부터 결제까지 화면이 실제로 넘어가도록 연결했고, 결제 화면에 빠져있던 뒤로가기/대화보기 버튼을 채웠습니다. 옵션 있는 메뉴는 상세에서 옵션을 골라 담게 했습니다.

공통
- voice-controller.js (신규): 마이크 토글 + STT 발화 처리. quick-action 먼저 확인하고 안 걸리면 AI 호출, 응답의 action으로 화면 조작. 페이지 이동해도 마이크 상태 유지. 결제 화면용 대화 패널과 뒤로가기 버튼 핸들러도 여기 둠.
- quick-action.js (신규): LLM 안 거치고 바로 처리하는 단축 명령(결제/뒤로/메뉴/층/결제수단). 결제 흐름은 페이지마다 다음 버튼을 누르도록.
- ai-action.js (신규): AI가 준 action(navigate, highlight_menu, open_menu_detail, select_payment_method 등)을 받아 화면 조작.
- api.js: 로컬에서 /ai 호출을 로컬 FastAPI(localhost:8000)로 보내도록 라우팅, chat 중복 호출 막는 잠금 추가.
- app-state.js: 안 쓰는 avatarMuted 키 제거.

메뉴(flowN)
- N02-menu.js: 상세에 옵션 선택 추가(고르면 가격 갱신), 음성으로 옵션 고르고 "담아줘"로 담기, 옵션 메뉴는 상세 자동 오픈, 빈 장바구니면 결제로 못 넘어가게.
- N02-menu.css: 옵션 그룹/버튼 스타일 추가.
- N02-menu.html: 상세에 옵션 선택 영역 추가.

아바타(flowA)
- A01-avatar.js: AI action navigate를 받아 실제로 화면 전환되게 연결, 세션 id 검사 정리.
- A01-avatar.html: ai-action.js 로드 추가.

결제(flowP)
- P02~P07.js: VoiceController 연결해서 결제 화면에서도 마이크/대화/뒤로가기 동작.
- P01-summary.js: 뒤로가기 버튼 없을 때 addEventListener에서 크래시 나던 것 가드 추가.
- P01~P04, P07 html: 상단 홈 버튼을 뒤로가기로 교체, 대화 보기 버튼 추가.
- components.css: 상단바 우측 버튼(대화/마이크)을 묶어서 오른쪽 정렬.

설정/백엔드 (1차 커밋에 포함)
- application-local.yml: 구글 클라우드 api-key 키 이름 정리, actuator(management) 설정과 DB url/username 기본값 제거.
- build.gradle: actuator 의존성 제거(구글 STT/TTS는 REST 직접 호출).
- SessionService.java: completeSession을 멱등 처리에서, 이미 종료된 세션이면 예외(SESSION_ALREADY_ENDED) 던지도록 변경.
- admin-dashboard.js, admin.css: 관리자 대시보드 코드 정리.
- avatar-voice-guide.js: 미사용이라 삭제.
- .gitignore: docker-compose 관련 항목 정리.

## 🙏 Question & PR point

- 로컬에서 음성 테스트하려면 NUNCHI-AI(FastAPI)랑 MCP 서버를 같이 띄워야 합니다. api.js가 로컬일 때 /ai를 localhost:8000으로 보내게 돼 있어서요.
- 설정/admin 쪽 변경은 1차 커밋(2f8ef65)에 같이 들어간 거라 이번 음성 작업과는 별개입니다.

## 📬 Postman

- 프론트 작업이라 별도 API 변경 없음
