### PR TITLE
[feat] FastAPI 호출 클라이언트 및 시간 로깅 추가

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/global/client/FastApiClient.java
+++ b/src/main/java/dgu/capstone/nunchi/global/client/FastApiClient.java
@@ -1,0 +1,89 @@
+package dgu.capstone.nunchi.global.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+@Component
+public class FastApiClient {
+
+    private final RestClient fastApiRestClient;
+
+    public FastApiClient(@Qualifier("fastApiRestClient") RestClient fastApiRestClient) {
+        this.fastApiRestClient = fastApiRestClient;
+    }
+
+    public <T> T post(String endpoint, Object request, Class<T> responseType) {
+        long startTime = System.currentTimeMillis();
+
+        try {
+            T response = fastApiRestClient.post()
+                    .uri(endpoint)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(responseType);
+
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.info("[AI_CALL] method=POST endpoint={} elapsedMs={} status=SUCCESS",
+                    endpoint, elapsedMs);
+
+            return response;
+
+        } catch (RestClientResponseException e) {
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.warn("[AI_CALL] method=POST endpoint={} elapsedMs={} status=FAILED httpStatus={} error={}",
+                    endpoint, elapsedMs, e.getStatusCode(), e.getClass().getSimpleName());
+
+            throw e;
+
+        } catch (Exception e) {
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.warn("[AI_CALL] method=POST endpoint={} elapsedMs={} status=FAILED error={}",
+                    endpoint, elapsedMs, e.getClass().getSimpleName());
+
+            throw e;
+        }
+    }
+
+    public <T> T get(String endpoint, Class<T> responseType) {
+        long startTime = System.currentTimeMillis();
+
+        try {
+            T response = fastApiRestClient.get()
+                    .uri(endpoint)
+                    .retrieve()
+                    .body(responseType);
+
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.info("[AI_CALL] method=GET endpoint={} elapsedMs={} status=SUCCESS",
+                    endpoint, elapsedMs);
+
+            return response;
+
+        } catch (RestClientResponseException e) {
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.warn("[AI_CALL] method=GET endpoint={} elapsedMs={} status=FAILED httpStatus={} error={}",
+                    endpoint, elapsedMs, e.getStatusCode(), e.getClass().getSimpleName());
+
+            throw e;
+
+        } catch (Exception e) {
+            long elapsedMs = System.currentTimeMillis() - startTime;
+
+            log.warn("[AI_CALL] method=GET endpoint={} elapsedMs={} status=FAILED error={}",
+                    endpoint, elapsedMs, e.getClass().getSimpleName());
+
+            throw e;
+        }
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/global/config/FastApiClientConfig.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/FastApiClientConfig.java
@@ -1,0 +1,19 @@
+package dgu.capstone.nunchi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class FastApiClientConfig {
+
+    @Bean
+    public RestClient fastApiRestClient(
+            @Value("${fastapi.base-url}") String fastApiBaseUrl
+    ) {
+        return RestClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #116

## 📝 Summary

- `fastapi.base-url` 설정값을 사용하는 `RestClient` Bean을 추가했습니다.
- Spring에서 FastAPI를 호출하기 위한 공통 `FastApiClient`를 추가했습니다.
- FastAPI 호출 시 method, endpoint, elapsedMs, status 정보를 `[AI_CALL]` 로그로 기록하도록 구성했습니다.
- 정상 응답뿐 아니라 예외 발생 상황에서도 호출 시간이 기록되도록 처리했습니다.

## 🙏 Question & PR point

- 이번 PR은 FastAPI 호출 및 시간 로깅을 위한 공통 기반 추가 작업입니다.
- 실제 주문 흐름에서 `/ai/order/start`, `/ai/order/chat`을 호출하는 연동은 후속 이슈에서 진행할 예정입니다.
- 현재 FastAPI 주요 endpoint는 `POST /ai/order/start`, `POST /ai/order/chat`, `POST /ai/api/order/cart/add`, `GET /ai/api/order/cart/{session_id}`입니다.