### PR TITLE
[Feat] FastAPI 주문 프록시 API 연동

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/domain/ai/controller/AiOrderProxyController.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/ai/controller/AiOrderProxyController.java
@@ -1,0 +1,32 @@
+package dgu.capstone.nunchi.domain.ai.controller;
+
+import dgu.capstone.nunchi.domain.ai.service.AiOrderProxyService;
+import dgu.capstone.nunchi.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai/order")
+public class AiOrderProxyController {
+
+    private final AiOrderProxyService aiOrderProxyService;
+
+    @PostMapping("/start")
+    public ApiResponse<Map<String, Object>> startOrder(
+            @RequestBody Map<String, Object> request
+    ) {
+        Map<String, Object> response = aiOrderProxyService.startOrder(request);
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/chat")
+    public ApiResponse<Map<String, Object>> chatOrder(
+            @RequestBody Map<String, Object> request
+    ) {
+        Map<String, Object> response = aiOrderProxyService.chatOrder(request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/domain/ai/service/AiOrderProxyService.java
+++ b/src/main/java/dgu/capstone/nunchi/domain/ai/service/AiOrderProxyService.java
@@ -1,0 +1,30 @@
+package dgu.capstone.nunchi.domain.ai.service;
+
+import dgu.capstone.nunchi.global.client.FastApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AiOrderProxyService {
+
+    private final FastApiClient fastApiClient;
+
+    public Map<String, Object> startOrder(Map<String, Object> request) {
+        return fastApiClient.post(
+                "/ai/order/start",
+                request,
+                Map.class
+        );
+    }
+
+    public Map<String, Object> chatOrder(Map<String, Object> request) {
+        return fastApiClient.post(
+                "/ai/order/chat",
+                request,
+                Map.class
+        );
+    }
+}

--- a/src/main/java/dgu/capstone/nunchi/global/config/FastApiClientConfig.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/FastApiClientConfig.java
@@ -1,10 +1,15 @@
 package dgu.capstone.nunchi.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
+import java.time.Duration;
+
+@Slf4j
 @Configuration
 public class FastApiClientConfig {
 
@@ -12,8 +17,15 @@ public class FastApiClientConfig {
     public RestClient fastApiRestClient(
             @Value("${fastapi.base-url}") String fastApiBaseUrl
     ) {
+        log.info("[FASTAPI_CONFIG] baseUrl={}", fastApiBaseUrl);
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(3));
+        requestFactory.setReadTimeout(Duration.ofSeconds(30));
+
         return RestClient.builder()
                 .baseUrl(fastApiBaseUrl)
+                .requestFactory(requestFactory)
                 .build();
     }
 }

--- a/src/main/java/dgu/capstone/nunchi/global/security/SecurityConfig.java
+++ b/src/main/java/dgu/capstone/nunchi/global/security/SecurityConfig.java
@@ -64,7 +64,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
                                 "/api/admin/auth/unlock",
-                                "/actuator/**"
+                                "/actuator/**",
+                                "/api/ai/order/**"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()


### PR DESCRIPTION
## 📣 Related Issue

- close #117

## 📝 Summary

- Spring에서 FastAPI 주문 API를 호출하는 프록시 API를 추가했습니다.
- `POST /api/ai/order/start` 요청 시 FastAPI의 `POST /ai/order/start`를 호출하도록 연동했습니다.
- FastAPI 호출 시 `[AI_CALL]` 로그를 통해 method, endpoint, elapsedMs, status를 기록하도록 확인했습니다.
- 로컬 환경에서 MCP 서버, FastAPI 서버, Spring 서버를 실행한 뒤 주문 세션 시작 요청이 정상 처리되는 것을 확인했습니다.

## 🙏 Question & PR point

- 이번 PR을 통해 Spring API 전체 응답 시간과 FastAPI 호출 시간을 분리해서 비교할 수 있습니다.
- Actuator의 `http.server.requests`는 Spring API 전체 시간을 보여주고, `[AI_CALL]` 로그는 FastAPI 호출 구간 시간을 보여줍니다.
- FastAPI 내부의 LLM, LangGraph, MCP 단계별 처리 시간은 후속 이슈에서 별도로 계측할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 주문 기능 엔드포인트 추가 - 사용자가 AI를 통해 주문을 시작하고 상호작용할 수 있는 새로운 API 엔드포인트 제공

* **Chores**
  * 보안 설정 업데이트 - AI 주문 기능에 대한 접근 권한 구성
  * 네트워크 통신 안정성 개선 - 연결 및 응답 타임아웃 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->