### PR TITLE
[Fix] 1차 QA 수정 — 결제 흐름·메뉴 옵션·하단 CTA·첫 진입 가이드

### DIFF
--- a/src/main/java/dgu/capstone/nunchi/global/config/WebConfig.java
+++ b/src/main/java/dgu/capstone/nunchi/global/config/WebConfig.java
@@ -1,12 +1,31 @@
 package dgu.capstone.nunchi.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.concurrent.TimeUnit;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    /**
+     * 잘 바뀌지 않는 정적 리소스(메뉴 이미지·폰트·라이브러리)는 브라우저 캐시를 길게 둔다.
+     * 화면을 전환할 때마다 같은 이미지를 다시 내려받아 "사진이 계속 로드되는" 문제 방지. (QA #14)
+     * JS/CSS 는 개발 중 수정 반영을 위해 캐시 핸들러에서 제외(기본 핸들러가 처리).
+     */
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("classpath:/static/front/images/")
+                .setCacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic());
+        registry.addResourceHandler("/lib/**")
+                .addResourceLocations("classpath:/static/front/lib/")
+                .setCacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic());
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/resources/static/front/css/common.css
+++ b/src/main/resources/static/front/css/common.css
@@ -300,6 +300,9 @@ body {
 
 .page-bg {
     flex-shrink: 0;
+    /* 하단 고정 CTA(.pXX__cta-wrap 등 position:absolute) 가 프레임 기준으로 붙도록
+       positioning context 를 만든다. (없으면 뷰포트 기준이 되어 좌우 마진이 어긋남 — QA) */
+    position: relative;
     box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
     /* 화면이 720×1280 보다 작으면 비율 유지 축소, 크면 그대로(1)
        zoom 사용 이유: transform: scale 은 시각만 축소하고 box 크기는 그대로 → 데스크탑 dev 환경에서

--- a/src/main/resources/static/front/css/components.css
+++ b/src/main/resources/static/front/css/components.css
@@ -156,6 +156,48 @@
 }
 
 /* ========================================================
+   .p-cta — flowP(결제 화면) 하단 CTA 전용 자체 버튼
+   btn-cta 상속/그 큰 패딩(--lg 48px) 없이 깔끔하게. box-sizing 으로 잘림/붙음 방지.
+   ======================================================== */
+.p-cta {
+    box-sizing: border-box;
+    min-width: 0;                /* grid/flex 셀 안에서 줄어들게 → 겹침/넘침 방지 */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 64px;
+    padding: 0 20px;
+    border: none;
+    border-radius: 16px;
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out);
+}
+.p-cta--block { display: flex; width: 100%; }
+.p-cta--primary { background: var(--primary-500); color: #fff; }
+.p-cta--primary:active { background: var(--primary-600); transform: scale(0.99); }
+.p-cta--secondary {
+    background: var(--neutral-0, #fff);
+    color: var(--neutral-700);
+    border: 1.5px solid var(--neutral-200);
+}
+.p-cta--secondary:active { background: var(--neutral-100); transform: scale(0.99); }
+.p-cta:disabled {
+    background: var(--neutral-200);
+    color: var(--neutral-400);
+    border-color: var(--neutral-200);
+    cursor: default;
+}
+
+/* ========================================================
    .btn-home · .btn-back — 좌하단 네비 버튼 (글래스 원형)
    xeicon 사용 (xi-home, xi-angle-left-thin 등)
    ======================================================== */
@@ -685,43 +727,44 @@
     color: var(--primary-500);
 }
 
-/* 시스템 메시지 (AI) — 우측 정렬, 주황 배경 */
-.ai-chat-bubble--system {
+/* 사용자 메시지 — 우측 정렬, 컬러 배경 (카카오톡식 — QA #12) */
+.ai-chat-bubble--user {
     align-self: flex-end;
     align-items: flex-end;
 }
 
-.ai-chat-bubble--system .ai-chat-bubble__body {
+.ai-chat-bubble--user .ai-chat-bubble__body {
     background: var(--primary-500);
     color: var(--color-text-inverse);
     border-bottom-right-radius: 4px;
 }
 
-.ai-chat-bubble--system .ai-chat-bubble__time {
+.ai-chat-bubble--user .ai-chat-bubble__time {
     flex-direction: row-reverse;
 }
 
-/* 사용자 메시지 — 좌측 정렬, 회색 배경 */
-.ai-chat-bubble--user {
+/* AI 응답 — 좌측 정렬, 회색 배경 */
+.ai-chat-bubble--ai {
     align-self: flex-start;
 }
 
-.ai-chat-bubble--user .ai-chat-bubble__body {
+.ai-chat-bubble--ai .ai-chat-bubble__body {
     background: var(--neutral-100);
     color: var(--neutral-800);
     border-bottom-left-radius: 4px;
 }
 
-/* 툴 호출 로그 — 좌측 정렬, primary outline 박스 */
+/* (구) 시스템/툴 안내 — 좌측 muted (현재 거의 미사용) */
+.ai-chat-bubble--system,
 .ai-chat-bubble--tool {
     align-self: flex-start;
 }
 
+.ai-chat-bubble--system .ai-chat-bubble__body,
 .ai-chat-bubble--tool .ai-chat-bubble__body {
-    background: var(--primary-50);
-    border: 1px solid var(--primary-200);
-    color: var(--primary-700);
-    font-weight: 600;
+    background: var(--neutral-100);
+    color: var(--neutral-700);
+    border-bottom-left-radius: 4px;
 }
 
 .ai-chat-panel__footer {

--- a/src/main/resources/static/front/css/flowN/N02-menu.css
+++ b/src/main/resources/static/front/css/flowN/N02-menu.css
@@ -382,7 +382,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    padding: 16px 20px 22px;
+    padding: 16px var(--pad-side) 22px;   /* 결제 화면들과 동일한 좌우 여백(27px) — 우측 붙음 보정 QA R2-4 */
     background: var(--neutral-50);
     border-top: 1px solid var(--neutral-100);
     box-shadow: 0 -8px 24px rgba(30, 25, 21, 0.06);
@@ -580,21 +580,29 @@
     overflow: hidden;
 }
 
+/* 사진 우상단 배치 (QA #8) — 카드(li)가 position:relative 라 absolute 로 띄움 */
 .n02__cart-item-remove {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 2;
     flex-shrink: 0;
-    width: 18px;
-    height: 18px;
+    width: 24px;
+    height: 24px;
     display: flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    background: var(--neutral-100);
-    color: var(--neutral-500);
-    font-size: 11px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid var(--neutral-200, #e5e2dd);
+    color: var(--neutral-800);
+    font-size: 13px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
 }
 
 .n02__cart-item-remove:active {
-    background: var(--neutral-200);
+    background: var(--neutral-100);
+    transform: scale(0.92);
 }
 
 .n02__cart-item-bottom {
@@ -612,26 +620,42 @@
     font-feature-settings: "tnum";
 }
 
-/* 결제 버튼 */
-.n02__cart-pay-btn {
+/* 결제 버튼 — btn-cta 상속 없이 자체 스타일로 새로 작성 (QA, 좌우 잘림/붙음 방지) */
+.n02__pay {
+    box-sizing: border-box;      /* width:100% + padding 가 컨테이너를 넘지 않도록 */
+    width: 100%;
     height: 56px;
-    border-radius: 14px;
-    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;     /* 아이콘 + 결제하기 + 금액 묶음 가운데 */
     gap: 8px;
+    padding: 0 16px;
+    border: none;
+    border-radius: 14px;
+    background: var(--primary-500);
+    color: #fff;
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
 }
 
-.n02__cart-pay-btn[disabled] {
+.n02__pay:active { transform: scale(0.98); background: var(--primary-600); }
+
+.n02__pay:disabled {
     background: var(--neutral-200);
     color: var(--neutral-400);
-    box-shadow: none;
+    cursor: default;
 }
 
-.n02__cart-pay-btn i {
-    font-size: 18px;
-}
+.n02__pay i { font-size: 18px; }
 
 .n02__cart-pay-amount {
     font-feature-settings: "tnum";
+    white-space: nowrap;
 }
 
 /* ========================================================
@@ -699,19 +723,19 @@
 
 .n02__detail-close {
     position: absolute;
-    top: 18px;
-    right: 18px;
-    width: 40px;
-    height: 40px;
+    top: 16px;
+    right: 16px;
+    width: 46px;
+    height: 46px;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    background: #fff;
+    border: 1px solid var(--neutral-200, #e5e2dd);
     border-radius: 50%;
-    color: var(--color-text-inverse);
-    font-size: 20px;
+    color: var(--neutral-900, #1e1915);
+    font-size: 24px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
     z-index: 4;
     transition: background-color var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out);
@@ -719,7 +743,7 @@
 
 .n02__detail-close:active {
     transform: scale(0.94);
-    background: rgba(255, 255, 255, 0.3);
+    background: var(--neutral-100, #f0eeea);
 }
 
 .n02__detail-hero-meta {
@@ -1013,10 +1037,13 @@
 }
 
 .n02__detail-cta {
+    width: 100%;
     height: 60px;
     border-radius: 14px;
     font-size: 18px;
     gap: 8px;
+    padding: 0 18px;        /* btn-cta--lg(48px) 제거 후 적정 여백 — 내용 우측 잘림 방지 */
+    white-space: nowrap;
 }
 
 .n02__detail-cta i {
@@ -1036,3 +1063,235 @@
         animation: none;
     }
 }
+
+/* ========================================================
+   토스트 (매장/포장 변경 등) — QA #3
+   ======================================================== */
+.n02__toast {
+    position: fixed;
+    left: 50%;
+    bottom: 120px;
+    transform: translateX(-50%) translateY(12px);
+    background: rgba(30, 25, 21, 0.92);
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    padding: 13px 22px;
+    border-radius: 9999px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .2s, transform .2s;
+    z-index: 1200;
+    pointer-events: none;
+}
+.n02__toast.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* 매장/포장 토글 pill — refresh 아이콘 강조 */
+/* 매장/포장 토글 — 컴팩트 pill (아이콘 없이 텍스트만, 톤 맞춤) QA R2-2 */
+.n02__dine-toggle {
+    flex-shrink: 0;
+    height: 30px;
+    padding: 0 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid var(--primary-200);
+    background: var(--primary-50);
+    color: var(--primary-700);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    cursor: pointer;
+}
+.n02__dine-toggle:active { transform: scale(0.95); background: var(--primary-100); }
+
+/* ========================================================
+   옵션 선택 모달 (담기 시) — QA #9
+   ======================================================== */
+.n02-opt {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+}
+.n02-opt[hidden] { display: none; }
+
+.n02-opt__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(30, 25, 21, 0.45);
+    animation: n02OptFade 180ms ease-out;
+}
+@keyframes n02OptFade { from { opacity: 0; } to { opacity: 1; } }
+
+.n02-opt__box {
+    position: relative;
+    width: 100%;
+    max-height: 82%;
+    background: #fff;
+    border-radius: 24px 24px 0 0;
+    padding: 28px 24px 24px;
+    box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    animation: n02OptUp 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes n02OptUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+
+.n02-opt__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--neutral-100, #f0eeea);
+    color: var(--neutral-800);
+    font-size: 20px;
+}
+.n02-opt__close:active { transform: scale(0.94); }
+
+.n02-opt__head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding-right: 48px;
+}
+.n02-opt__name {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--neutral-900, #1e1915);
+    letter-spacing: -0.4px;
+}
+.n02-opt__price {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--primary-700);
+    margin-left: auto;
+}
+.n02-opt__hint {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-secondary, var(--neutral-500));
+}
+.n02-opt__groups {
+    margin-top: 18px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+}
+.n02-opt__actions {
+    margin-top: 20px;
+    display: flex;             /* grid 대신 flex — 두 버튼이 겹치지 않게 */
+    gap: 14px;                 /* 두 블록 사이 간격 */
+}
+/* flex 1 1 0 + min-width 0 → 두 버튼이 정확히 반반(약간 가중), 겹침/넘침 없음 */
+.n02-opt__btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    height: 54px;
+    padding: 0 12px;
+    font-size: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.n02-opt__btn[data-opt-action="order"] { flex-grow: 1.3; }  /* 바로 주문만 약간 넓게 */
+
+/* ========================================================
+   첫 진입 가이드 오버레이 — QA #13
+   회색 쉐이드 위 가이드, 터치하면 해제(원래 화면 작동)
+   ======================================================== */
+/* 프레임(page-bg, position:relative) 기준으로 깔아 버튼 좌표와 정렬 */
+.n02-guide {
+    position: absolute;
+    inset: 0;
+    z-index: 1300;
+    background: rgba(20, 17, 14, 0.7);
+    cursor: pointer;
+    animation: n02GuideFade 200ms ease-out;
+}
+.n02-guide[hidden] { display: none; }
+@keyframes n02GuideFade { from { opacity: 0; } to { opacity: 1; } }
+
+/* 점선 + 화살표 — 각 버튼을 가리킴 */
+.n02-guide__svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+.n02-guide__svg path {
+    fill: none;
+    stroke: #ffd54a;             /* 화살표와 같은 앰버색 — 점선이 한 줄로 이어져 보이게 */
+    stroke-width: 3;
+    stroke-dasharray: 2 10;      /* 둥근 점선 */
+    stroke-linecap: round;
+    marker-end: url(#n02GuideArrow);
+}
+
+/* 콜아웃 카드 (가로형, 위치는 인라인 style) */
+.n02-guide__callout {
+    position: absolute;
+    width: 280px;
+    max-width: calc(100% - 28px);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 13px 15px;
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+}
+.n02-guide__callout i {
+    flex: 0 0 auto;
+    width: 38px;
+    height: 38px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--primary-500);
+    color: #fff;
+    font-size: 19px;
+}
+.n02-guide__callout-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.n02-guide__callout-body strong {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--neutral-900, #1e1915);
+}
+.n02-guide__callout-body span {
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--neutral-600, #6b6259);
+    letter-spacing: -0.2px;
+    word-break: keep-all;
+}
+
+.n02-guide__hint {
+    position: absolute;
+    left: 0; right: 0; bottom: 36px;
+    text-align: center;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    animation: n02GuidePulse 1.6s ease-in-out infinite;
+}
+@keyframes n02GuidePulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }

--- a/src/main/resources/static/front/css/flowP/P05-complete.css
+++ b/src/main/resources/static/front/css/flowP/P05-complete.css
@@ -339,3 +339,96 @@
     .p05__confetti { opacity: 0; }
     .p05__receipt-progress-bar { width: 100%; }
 }
+
+/* ========================================================
+   출력 선택 모달 (영수증 / 번호표) — QA #2
+   ======================================================== */
+.p05-output {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(30, 25, 21, 0.45);
+    animation: p05OutputFade 180ms ease-out;
+}
+.p05-output[hidden] { display: none; }
+
+@keyframes p05OutputFade { from { opacity: 0; } to { opacity: 1; } }
+
+.p05-output__box {
+    width: min(620px, 100%);
+    background: var(--neutral-0, #fff);
+    border-radius: 24px;
+    padding: 40px 36px 36px;
+    box-shadow: 0 12px 40px rgba(30, 25, 21, 0.22);
+    text-align: center;
+}
+
+.p05-output__title {
+    font-size: 26px;
+    font-weight: 800;
+    color: var(--neutral-900, #1e1915);
+    letter-spacing: -0.4px;
+}
+
+.p05-output__desc {
+    margin-top: 8px;
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--color-text-secondary, var(--neutral-500));
+}
+
+.p05-output__choices {
+    margin-top: 28px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+}
+
+.p05-output__choice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 28px 16px;
+    background: var(--neutral-50, #f7f6f4);
+    border: 2px solid var(--neutral-200, #e5e2dd);
+    border-radius: 18px;
+    cursor: pointer;
+    transition: border-color .15s, background .15s, transform .08s;
+    -webkit-tap-highlight-color: transparent;
+}
+.p05-output__choice:active { transform: scale(0.97); }
+.p05-output__choice:hover,
+.p05-output__choice:focus-visible {
+    border-color: var(--primary-500);
+    background: var(--primary-50);
+}
+
+.p05-output__choice-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--primary-500);
+    color: #fff;
+    font-size: 26px;
+}
+
+.p05-output__choice-title {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--neutral-900, #1e1915);
+    letter-spacing: -0.3px;
+}
+
+.p05-output__choice-desc {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-secondary, var(--neutral-500));
+}

--- a/src/main/resources/static/front/js/common/confirm-modal.js
+++ b/src/main/resources/static/front/js/common/confirm-modal.js
@@ -173,11 +173,18 @@
      * @param {Function} [beforeNav] 이동 직전 정리 콜백 (e.g. clearAllTimers)
      */
     async function confirmGoHome(beforeNav) {
+        // 머무르기 버튼은 현재 화면에 맞춰 목적어를 넣어 명확히 (QA #10)
+        const p = (typeof location !== 'undefined') ? location.pathname : '';
+        let stayLabel = '계속하기';
+        if (p === '/menu') stayLabel = '메뉴 계속 보기';
+        else if (p === '/summary' || p === '/payment' || p === '/processing'
+                 || p === '/vein' || p === '/barcode') stayLabel = '결제 계속하기';
+
         const ok = await show({
             title: '홈으로 돌아가시겠습니까?',
             message: '진행 중인 주문은 취소됩니다.',
-            confirmLabel: '돌아가기',
-            cancelLabel: '계속하기'
+            confirmLabel: '홈으로 돌아가기',
+            cancelLabel: stayLabel
         });
         if (!ok) return;
         if (typeof beforeNav === 'function') {

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -63,8 +63,8 @@
     const $detailNutC     = document.querySelector('[data-detail-nut-carb]');
     const $detailNutF     = document.querySelector('[data-detail-nut-fat]');
     const $detailCtaPrice = document.querySelector('[data-detail-cta-price]');
-    const $detailOptions        = document.querySelector('[data-detail-options]');
-    const $detailOptionsSection = document.querySelector('[data-detail-options-section]');
+    const $detailAiSection      = document.querySelector('[data-detail-ai-section]');
+    const $detailAiReason       = document.querySelector('[data-detail-ai-reason]');
 
     const $chatPanel      = document.querySelector('[data-chat-panel]');
     const $chatDim        = document.querySelector('[data-chat-dim]');
@@ -165,17 +165,41 @@
         return state.cart.reduce((sum, i) => sum + (i.itemTotal || 0), 0);
     }
 
-    // 서버 응답으로 받은 카트로 state.cart 교체 후 UI 재렌더
+    // 서버 응답으로 받은 카트로 state.cart 교체 후 UI 갱신
+    // 카트만 바뀐 경우 그리드를 통째로 다시 그리지 않고(이미지 재로드 방지 — QA #14)
+    // 카드의 담김 표시/수량 뱃지만 제자리에서 갱신한다.
     function applyCartResponse(cartResponse) {
         state.cart = (cartResponse && cartResponse.items) ? cartResponse.items : [];
-        renderMenuGrid();
+        syncCardCartState();
         renderCartBar();
+    }
+
+    // 메뉴 카드의 in-cart 강조 + 수량 뱃지만 제자리 갱신 (DOM 재생성 X → 이미지 재요청 없음)
+    function syncCardCartState() {
+        if (!$menuGrid) return;
+        $menuGrid.querySelectorAll(".n02__menu-card[data-menu]").forEach((card) => {
+            const id = Number(card.getAttribute("data-menu"));
+            const qty = getCartQty(id);
+            card.classList.toggle("n02__menu-card--in-cart", qty > 0);
+            const thumb = card.querySelector(".n02__menu-card-thumb");
+            let badge = card.querySelector(".n02__menu-card-qty-badge");
+            if (qty > 0) {
+                if (!badge && thumb) {
+                    badge = document.createElement("span");
+                    badge.className = "n02__menu-card-qty-badge";
+                    thumb.appendChild(badge);
+                }
+                if (badge) badge.textContent = String(qty);
+            } else if (badge) {
+                badge.remove();
+            }
+        });
     }
 
     function logApiError(label, e) {
         console.error("[N02] " + label, e);
         const msg = (e && e.message) ? e.message : "요청 실패";
-        pushChatBubble("system", "⚠ " + label + " 실패: " + msg);
+        showN02Toast("⚠ " + label + " 실패: " + msg);
     }
 
     // ---------- 렌더링: 층 탭 ----------
@@ -347,28 +371,26 @@
         $cartArrowNext.hidden = !showArrows;
     }
 
-    // ---------- 메뉴 상세 옵션 ----------
-    // detailOptionGroups: [{groupId, groupName, options:[{optionId, name, extraPrice}]}]
-    // detailSelected:     { [groupId]: optionId }  (그룹당 1개 — 라디오)
-    let detailOptionGroups = [];
-    const detailSelected = {};
-    let detailBasePrice = 0;
+    // ---------- 옵션 선택 모달 (담기 시 — QA #9) ----------
+    // optGroups: [{groupId, groupName, options:[{optionId, name, extraPrice}]}]
+    // optSelected: { [groupId]: optionId } (그룹당 1개 — 라디오)
+    const $optModal    = document.querySelector('[data-opt-modal]');
+    const $optName     = document.querySelector('[data-opt-name]');
+    const $optPrice    = document.querySelector('[data-opt-price]');
+    const $optGroupsEl = document.querySelector('[data-opt-groups]');
 
-    function renderDetailOptions(groups, basePrice) {
-        detailOptionGroups = Array.isArray(groups) ? groups : [];
-        detailBasePrice = basePrice || 0;
-        Object.keys(detailSelected).forEach((k) => delete detailSelected[k]);
+    let optMenuId = null;
+    let optGroups = [];
+    const optSelected = {};
+    let optBasePrice = 0;
 
-        if (!detailOptionGroups.length) {
-            if ($detailOptionsSection) $detailOptionsSection.hidden = true;
-            if ($detailOptions) $detailOptions.innerHTML = "";
-            recomputeDetailPrice();
-            return;
-        }
-
-        const html = detailOptionGroups.map((g) => {
+    function renderOptGroups() {
+        Object.keys(optSelected).forEach((k) => delete optSelected[k]);
+        if (!$optGroupsEl) return;
+        if (!optGroups.length) { $optGroupsEl.innerHTML = ""; recomputeOptPrice(); return; }
+        $optGroupsEl.innerHTML = optGroups.map((g) => {
             const first = g.options && g.options[0];
-            if (first) detailSelected[g.groupId] = first.optionId;   // 첫 옵션 기본 선택
+            if (first) optSelected[g.groupId] = first.optionId;
             const choices = (g.options || []).map((o) => {
                 const sel = first && o.optionId === first.optionId ? " is-selected" : "";
                 const price = o.extraPrice > 0
@@ -381,42 +403,71 @@
             return `<div class="n02__detail-optgroup" data-optgroup="${g.groupId}">
                         <div class="n02__detail-optgroup-head">
                             <span class="n02__detail-optgroup-name">${g.groupName}</span>
-                            <span class="n02__detail-optgroup-req">필수</span>
                         </div>
                         <div class="n02__detail-optgroup-choices">${choices}</div>
                     </div>`;
         }).join("");
-
-        if ($detailOptions) $detailOptions.innerHTML = html;
-        if ($detailOptionsSection) $detailOptionsSection.hidden = false;
-        recomputeDetailPrice();
+        recomputeOptPrice();
     }
 
-    function selectDetailOption(groupId, optionId) {
-        detailSelected[groupId] = optionId;
-        const group = $detailOptions && $detailOptions.querySelector(`[data-optgroup="${groupId}"]`);
+    function selectOpt(groupId, optionId) {
+        optSelected[groupId] = optionId;
+        const group = $optGroupsEl && $optGroupsEl.querySelector(`[data-optgroup="${groupId}"]`);
         if (group) {
             group.querySelectorAll(".n02__detail-opt").forEach((b) => {
                 b.classList.toggle("is-selected", b.getAttribute("data-option-id") === String(optionId));
             });
         }
-        recomputeDetailPrice();
+        recomputeOptPrice();
     }
 
-    function recomputeDetailPrice() {
-        let total = detailBasePrice;
-        for (const g of detailOptionGroups) {
-            const opt = (g.options || []).find((o) => o.optionId === detailSelected[g.groupId]);
+    function recomputeOptPrice() {
+        let total = optBasePrice;
+        for (const g of optGroups) {
+            const opt = (g.options || []).find((o) => o.optionId === optSelected[g.groupId]);
             if (opt && opt.extraPrice) total += opt.extraPrice;
         }
-        if ($detailPrice)    $detailPrice.textContent = fmt(total);
-        if ($detailCtaPrice) $detailCtaPrice.textContent = "· " + fmt(total);
+        if ($optPrice) $optPrice.textContent = fmt(total);
     }
 
-    function getDetailSelectedOptionIds() {
-        return detailOptionGroups
-            .map((g) => detailSelected[g.groupId])
-            .filter((v) => v != null);
+    function getOptSelectedIds() {
+        return optGroups.map((g) => optSelected[g.groupId]).filter((v) => v != null);
+    }
+
+    // 메뉴 담기 진입점 (터치·음성 공통) — 옵션 있으면 모달, 없으면 바로 담기
+    function openOptionModal(menuId) {
+        const found = window.MenuData.findMenuById(menuId);
+        if (!found || found.menu.soldOut) return;
+        const m = found.menu;
+        window.Api.menu.detail(menuId).then((d) => {
+            const groups = (d && d.optionGroups) || [];
+            if (!groups.length) { addToCart(menuId, { optionIds: [] }); return; }
+            optMenuId = menuId;
+            optGroups = groups;
+            optBasePrice = m.price;
+            if ($optName) $optName.textContent = m.name;
+            renderOptGroups();
+            if ($optModal) $optModal.hidden = false;
+        }).catch((e) => {
+            console.warn("[N02] 옵션 조회 실패", e);
+            addToCart(menuId, { optionIds: [] });
+        });
+    }
+
+    function closeOptModal() {
+        optMenuId = null;
+        optGroups = [];
+        if ($optModal) $optModal.hidden = true;
+    }
+
+    // 더 담기(thenCheckout=false): 담고 닫고 계속 / 바로 주문(true): 담고 결제로
+    async function optModalAdd(thenCheckout) {
+        if (optMenuId == null) return;
+        const id = optMenuId;
+        const ids = getOptSelectedIds();
+        closeOptModal();
+        await addToCart(id, { optionIds: ids });
+        if (thenCheckout) gotoCheckout();
     }
 
     // 옵션명과 발화가 매칭되는지 — STT 오인식/축약 고려해 느슨하게.
@@ -425,47 +476,48 @@
         const t = (spoken || "").replace(/\s/g, "");
         const n = (optName || "").replace(/\s/g, "");
         if (!t || !n) return false;
-        if (t.includes(n) || n.includes(t)) return true;          // 전체 포함
-        // 옵션명에서 일반어 뺀 핵심 토큰(2자+) 중 하나라도 발화에 있으면 매치
-        const tokens = (optName || "").split(/\s+/)
-            .filter((w) => w.length >= 2 && !_OPT_GENERIC.includes(w));
+        if (t.includes(n) || n.includes(t)) return true;
+        const tokens = (optName || "").split(/\s+/).filter((w) => w.length >= 2 && !_OPT_GENERIC.includes(w));
         return tokens.some((w) => t.includes(w));
     }
 
-    // 상세 오버레이가 열려 있을 때의 음성 처리 — 옵션 선택 / 담기 / 닫기.
-    // 처리하면 true(LLM 안 넘김), 닫혀 있거나 해당 없으면 false.
-    function tryDetailVoice(text) {
-        if (!$detail || $detail.hidden || openDetailMenuId == null) return false;
+    // 옵션 모달이 열려 있을 때의 음성 처리 (선택 / 바로주문 / 더담기 / 닫기) — MCP 원격조작도 동일
+    function tryOptModalVoice(text) {
+        if (!$optModal || $optModal.hidden || optMenuId == null) return false;
         const t = (text || "").replace(/\s/g, "");
         if (!t) return false;
-
-        // 1) 옵션명 매칭 → 선택 (느슨)
-        for (const g of detailOptionGroups) {
+        for (const g of optGroups) {
             for (const o of (g.options || [])) {
                 if (_optNameMatches(text, o.name)) {
-                    selectDetailOption(g.groupId, o.optionId);
-                    const btn = $detailOptions && $detailOptions.querySelector(`[data-option-id="${o.optionId}"]`);
+                    selectOpt(g.groupId, o.optionId);
+                    const btn = $optGroupsEl && $optGroupsEl.querySelector(`[data-option-id="${o.optionId}"]`);
                     if (btn) { btn.classList.add("ai-pulse"); setTimeout(() => btn.classList.remove("ai-pulse"), 1200); }
-                    pushChatBubble("system", `${g.groupName}: ${o.name} 선택했어요`);
                     return true;
                 }
             }
         }
+        if (/(바로\s*주문|주문할|결제|주문해)/.test(text) && !/(안|말고|취소|아니|그만)/.test(text)) {
+            optModalAdd(true); return true;
+        }
+        if (/(더\s*담|담아|담기|넣어|추가|이걸로)/.test(text) && !/(안|말고|취소|아니|그만)/.test(text)) {
+            optModalAdd(false); return true;
+        }
+        if (/(닫아|닫기|취소|그만|나가)/.test(t)) { closeOptModal(); return true; }
+        return false;
+    }
 
-        // 2) 담기 / 확정 (선택된 옵션과 함께)
-        if (/(담아|담기|넣어|이걸로|장바구니|주문할|완료)/.test(t) && !/(안|말고|취소|아니|그만)/.test(t)) {
-            addToCart(openDetailMenuId, { optionIds: getDetailSelectedOptionIds() });
+    // 상세(정보) 오버레이 음성 — 담기는 옵션 모달로 연결, 닫기.
+    function tryDetailVoice(text) {
+        if (!$detail || $detail.hidden || openDetailMenuId == null) return false;
+        const t = (text || "").replace(/\s/g, "");
+        if (!t) return false;
+        if (/(담아|담기|넣어|이걸로|주문|추가|시킬)/.test(t) && !/(안|말고|취소|아니|그만)/.test(t)) {
+            const id = openDetailMenuId;
             closeDetail();
+            openOptionModal(id);
             return true;
         }
-
-        // 3) 닫기 / 취소
-        if (/(닫아|닫기|취소|그만|뒤로|나가)/.test(t)) {
-            closeDetail();
-            pushChatBubble("system", "상세를 닫았어요");
-            return true;
-        }
-
+        if (/(닫아|닫기|취소|그만|뒤로|나가)/.test(t)) { closeDetail(); return true; }
         return false;
     }
 
@@ -514,12 +566,17 @@
         // CTA 가격 (옵션 로딩 전 base 가격)
         $detailCtaPrice.textContent = "· " + fmt(m.price);
 
-        // 옵션 — 우선 비우고, 상세 API 로 그룹 fetch 후 렌더 (없으면 섹션 숨김)
-        renderDetailOptions([], m.price);
+        // AI 추천 이유 — 우선 숨기고, 상세 API 응답에 aiReason 있으면 노출 (QA #5, 백엔드 제공 전제)
+        // (옵션 선택은 상세가 아니라 담기 시 옵션 모달에서 처리 — QA #9)
+        if ($detailAiSection) $detailAiSection.hidden = true;
         window.Api.menu.detail(menuId).then((d) => {
             if (openDetailMenuId !== menuId) return;   // 그새 다른 메뉴 열렸으면 무시
-            renderDetailOptions(d && d.optionGroups, m.price);
-        }).catch((e) => console.warn("[N02] 옵션 조회 실패", e));
+            const reason = d && (d.aiReason || d.aiRecommendReason);
+            if (reason && $detailAiSection && $detailAiReason) {
+                $detailAiReason.textContent = reason;
+                $detailAiSection.hidden = false;
+            }
+        }).catch((e) => console.warn("[N02] 상세 조회 실패", e));
 
         $detail.hidden = false;
         $detail.setAttribute("aria-hidden", "false");
@@ -547,9 +604,9 @@
             });
             applyCartResponse(res);
 
+            // 담기 피드백은 토스트로 — 대화기록(채팅)에는 실제 대화만 남긴다 (QA #6)
             if (!opts.silent) {
-                pushChatBubble("system", `${found.menu.name}을(를) 장바구니에 담았어요! ${fmt(found.menu.price)}`);
-                pushChatBubble("tool",   `🛒 ${found.menu.name} 담기 실행`);
+                showN02Toast(`${found.menu.name} 담았어요`);
             }
         } catch (e) {
             logApiError("장바구니 추가", e);
@@ -579,7 +636,7 @@
             const res = await window.Api.cart.removeItem(state.sessionId, itemId);
             applyCartResponse(res);
             if (!opts.silent && item) {
-                pushChatBubble("system", `${item.menuName}을(를) 장바구니에서 뺐어요.`);
+                showN02Toast(`${item.menuName} 뺐어요`);
             }
         } catch (e) {
             logApiError("장바구니 삭제", e);
@@ -620,10 +677,11 @@
     // chatLog 메모리 누적은 더 이상 사용 안 함 (JSON export 제거).
     // 대화 영속은 서버(POST /api/sessions/{id}/messages) 에 LangGraph 가 자동 저장.
     function pushChatBubble(role, text) {
-        // role: "user" | "system" | "tool"
+        // 대화기록에는 실제 대화만 남긴다 — role: "user"(내 발화) | "ai"(AI 응답)
+        // 담기/처리 같은 로컬 피드백은 채팅이 아니라 토스트/화면으로 처리한다.
         const node = document.createElement("div");
         node.className = "ai-chat-bubble ai-chat-bubble--" + role;
-        const iconHtml = role === "system"
+        const iconHtml = (role === "ai" || role === "system")
             ? '<i class="xi xi-message"></i>'
             : (role === "tool" ? '<i class="xi xi-lightning"></i>' : '');
         node.innerHTML = `
@@ -642,7 +700,7 @@
     function renderChatInitial() {
         if ($chatSession) $chatSession.textContent = state.sessionId ?? "—";
         $chatMessages.innerHTML = "";
-        pushChatBubble("system",
+        pushChatBubble("ai",
             "안녕하세요! 상록원 AI 주문 도우미입니다. 상단 마이크 버튼을 눌러 음성으로 주문해보세요.");
     }
 
@@ -679,7 +737,7 @@
         if (_convEngineInited) return;
         if (!window.ConvEngine || !window.ConvEngine.isSupported || !window.ConvEngine.isSupported()) {
             console.warn("[N02] Web Speech API 미지원");
-            pushChatBubble("system", "이 브라우저는 음성 인식을 지원하지 않아 채팅으로만 안내드려요.");
+            pushChatBubble("ai", "이 브라우저는 음성 인식을 지원하지 않아 채팅으로만 안내드려요.");
             return;
         }
         window.ConvEngine.init({
@@ -708,12 +766,12 @@
     }
 
     async function dispatchUserUtterance(text) {
-        // 0) 상세 오버레이가 열려 있으면 옵션 선택/담기/닫기를 우선 처리 (LLM 없이)
+        // 0) 옵션 모달/상세가 열려 있으면 그 안에서 우선 처리 (LLM 없이) — QA #9
+        if (tryOptModalVoice(text)) return;
         if (tryDetailVoice(text)) return;
 
         // 1) JS quick-action — 결정론적 명령(결제하기/뒤로/층/결제수단 등)은 LLM 없이 0ms 처리
         if (window.QuickAction && window.QuickAction.try(text, { page: location.pathname })) {
-            pushChatBubble("system", "✓ 처리했어요");
             return;
         }
 
@@ -744,19 +802,19 @@
                 res = await callAi();
             }
 
-            if (res && res.reply) pushChatBubble("system", res.reply);
+            if (res && res.reply) pushChatBubble("ai", res.reply);
 
             // AI 가 백엔드 카트를 변경했을 수 있으므로 서버 카트 재동기화
             await syncCartFromServer();
 
             // 4) 옵션 필요한 메뉴 → 상세(옵션 UI) 자동 오픈 → 사용자가 옵션 고르고 "담아줘"
             if (res && res.menu_options && res.menu_options.menu_id != null) {
-                openDetail(res.menu_options.menu_id);
+                openOptionModal(res.menu_options.menu_id);   // 옵션 모달로 (QA #9, MCP 동일 플로우)
             } else if (window.AiAction && res && res.action) {
                 const a = res.action;
                 // 빈 카트로 결제/주문확인 화면 이동 금지 — 메뉴부터 담게 안내
                 if (a.type === "navigate" && (a.page === "/summary" || a.page === "/payment") && !state.cart.length) {
-                    pushChatBubble("system", "장바구니가 비어 있어요. 메뉴를 먼저 담아주세요.");
+                    pushChatBubble("ai", "장바구니가 비어 있어요. 메뉴를 먼저 담아주세요.");
                 } else {
                     window.AiAction.handle(a);
                 }
@@ -775,7 +833,7 @@
             const friendly = (e && (e.status === 502 || e.status === 504))
                 ? "AI 서버가 잠시 응답이 느려요. 잠시 후 다시 말씀해주세요."
                 : "응답을 가져오지 못했어요. 다시 시도해 주세요.";
-            pushChatBubble("system", friendly);
+            pushChatBubble("ai", friendly);
         }
     }
 
@@ -800,8 +858,7 @@
         try { sessionStorage.setItem("voiceMicOn", "1"); } catch (_) {}  // 결제 화면까지 ON 유지
         $micBtn.classList.add("app-topbar__action-icon--mic-active");
         setMicStatus("listening");
-        pushChatBubble("system", "🎙️ 음성 인식을 시작했어요. 편하게 말씀해주세요.");
-        if (!$chatPanel.classList.contains("ai-chat-panel--open")) openChat();
+        // 마이크만 켠다 — 대화기록 패널은 자동으로 열지 않는다 (QA #7, 패널은 대화기록 버튼으로만)
     }
 
     function stopMic() {
@@ -810,7 +867,6 @@
         try { sessionStorage.setItem("voiceMicOn", "0"); } catch (_) {}  // 명시적 OFF
         $micBtn.classList.remove("app-topbar__action-icon--mic-active");
         setMicStatus("off");
-        pushChatBubble("system", "🔇 음성 인식을 멈췄어요.");
     }
 
     function toggleMic() {
@@ -825,6 +881,106 @@
             sessionStorage.setItem("currentStep", "P01");
         } catch (e) { /* noop */ }
         location.href = PAY_NEXT_URL;
+    }
+
+    // ---------- 매장/포장 토글 (QA #3) ----------
+    const DINE_KEY = 'dineOption';
+    function getDine() {
+        return sessionStorage.getItem(DINE_KEY) === 'take_out' ? 'take_out' : 'dine_in';
+    }
+    function renderDineLabel() {
+        const el = document.querySelector('[data-bind="dineLabel"]');
+        if (el) el.textContent = getDine() === 'take_out' ? '포장' : '매장';
+    }
+    function toggleDine() {
+        const next = getDine() === 'take_out' ? 'dine_in' : 'take_out';
+        try { sessionStorage.setItem(DINE_KEY, next); } catch (_) {}
+        renderDineLabel();
+        showN02Toast(next === 'take_out'
+            ? '포장으로 변경했어요'
+            : '매장 식사로 변경했어요');
+    }
+
+    // ---------- 토스트 ----------
+    function showN02Toast(msg) {
+        let t = document.querySelector('.n02__toast');
+        if (!t) {
+            t = document.createElement('div');
+            t.className = 'n02__toast';
+            document.body.appendChild(t);
+        }
+        t.textContent = msg;
+        t.classList.add('is-visible');
+        clearTimeout(showN02Toast._timer);
+        showN02Toast._timer = setTimeout(() => t.classList.remove('is-visible'), 2000);
+    }
+
+    // ---------- 첫 진입 가이드 오버레이 (QA #13) ----------
+    // 회색 쉐이드 위 가이드, 화면 터치하면 해제. 한 세션(주문)당 1회만.
+    function initGuideOverlay() {
+        const $guide = document.querySelector('[data-guide]');
+        if (!$guide) return;
+        let seen = false;
+        try { seen = sessionStorage.getItem('n02GuideSeen') === '1'; } catch (_) {}
+        if (seen) return;
+        $guide.hidden = false;
+
+        // 실제 버튼 위치를 재서 점선 + 화살표를 그림 (메뉴 카드는 동적이라 좌표를 고정할 수 없음)
+        drawGuideLines($guide);
+
+        $guide.addEventListener('click', () => {
+            $guide.hidden = true;
+            try { sessionStorage.setItem('n02GuideSeen', '1'); } catch (_) {}
+            window.removeEventListener('resize', $guide._redraw);
+        }, { once: true });
+
+        // 창 크기 변동 시 다시 그림
+        $guide._redraw = () => drawGuideLines($guide);
+        window.addEventListener('resize', $guide._redraw);
+    }
+
+    // 콜아웃(data-guide-target)에서 실제 대상 버튼까지 점선 화살표를 그림.
+    // .page-bg 의 zoom 스케일은 svg/콜아웃/대상이 모두 동일하게 받으므로
+    // svg 표시 영역 기준 비율로 환산하면 viewBox(720x1280) 좌표가 정확히 맞는다.
+    function drawGuideLines($guide) {
+        const $svg   = $guide.querySelector('.n02-guide__svg');
+        const $lines = $guide.querySelector('[data-guide-lines]');
+        if (!$svg || !$lines) return;
+
+        const svgRect = $svg.getBoundingClientRect();
+        if (!svgRect.width || !svgRect.height) return;
+        const toVX = (px) => (px - svgRect.left) / svgRect.width  * 720;
+        const toVY = (py) => (py - svgRect.top)  / svgRect.height * 1280;
+
+        $lines.innerHTML = "";
+
+        $guide.querySelectorAll('.n02-guide__callout').forEach((callout) => {
+            const sel = callout.getAttribute('data-guide-target');
+            const target = sel ? document.querySelector(sel) : null;
+            // 대상이 화면에 없으면(예: 추천 메뉴 없음) 콜아웃도 숨김
+            if (!target || target.offsetParent === null) {
+                callout.style.display = "none";
+                return;
+            }
+            callout.style.display = "";
+
+            const tr = target.getBoundingClientRect();
+            const cr = callout.getBoundingClientRect();
+            const tx = toVX(tr.left + tr.width / 2);
+            const ty = toVY(tr.top + tr.height / 2);
+
+            // 콜아웃에서 선이 나가는 지점 (anchor 변의 중앙)
+            const anchor = callout.getAttribute('data-guide-anchor') || 'top';
+            let sx, sy;
+            if (anchor === 'top')         { sx = toVX(cr.left + cr.width / 2); sy = toVY(cr.top); }
+            else if (anchor === 'bottom') { sx = toVX(cr.left + cr.width / 2); sy = toVY(cr.bottom); }
+            else if (anchor === 'left')   { sx = toVX(cr.left);                sy = toVY(cr.top + cr.height / 2); }
+            else                          { sx = toVX(cr.right);               sy = toVY(cr.top + cr.height / 2); }
+
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('d', `M${sx.toFixed(1)},${sy.toFixed(1)} L${tx.toFixed(1)},${ty.toFixed(1)}`);
+            $lines.appendChild(path);
+        });
     }
 
     // ---------- 이벤트 위임 ----------
@@ -859,11 +1015,11 @@
 
         // 메뉴 그리드 위임
         $menuGrid.addEventListener("click", (e) => {
-            // 1) "+ 담기" 버튼
+            // 1) "+ 담기" 버튼 → 옵션 모달 (옵션 없으면 바로 담김) — QA #9
             const addBtn = e.target.closest("[data-add]");
             if (addBtn) {
                 e.stopPropagation();
-                addToCart(parseInt(addBtn.getAttribute("data-add"), 10));
+                openOptionModal(parseInt(addBtn.getAttribute("data-add"), 10));
                 return;
             }
             // 2) 썸네일 → 상세 오버레이
@@ -904,29 +1060,41 @@
             if (btn) gotoCheckout();
         });
 
+        // 매장/포장 토글
+        document.addEventListener("click", (e) => {
+            if (e.target.closest('[data-action="toggle-dine"]')) toggleDine();
+        });
+
         // 상세 닫기
         document.addEventListener("click", (e) => {
             const btn = e.target.closest('[data-action="close-detail"]');
             if (btn) closeDetail();
         });
 
-        // 상세 옵션 선택 (그룹당 라디오)
-        if ($detailOptions) {
-            $detailOptions.addEventListener("click", (e) => {
+        // 옵션 모달 — 옵션 선택(그룹당 라디오) + 더담기/바로주문 + 닫기 (QA #9)
+        if ($optGroupsEl) {
+            $optGroupsEl.addEventListener("click", (e) => {
                 const opt = e.target.closest(".n02__detail-opt");
                 if (!opt) return;
-                const groupId  = Number(opt.getAttribute("data-group-id"));
-                const optionId = Number(opt.getAttribute("data-option-id"));
-                selectDetailOption(groupId, optionId);
+                selectOpt(Number(opt.getAttribute("data-group-id")), Number(opt.getAttribute("data-option-id")));
+            });
+        }
+        if ($optModal) {
+            $optModal.addEventListener("click", (e) => {
+                if (e.target.closest('[data-opt-close]')) { closeOptModal(); return; }
+                const act = e.target.closest('[data-opt-action]');
+                if (!act) return;
+                optModalAdd(act.getAttribute("data-opt-action") === "order");
             });
         }
 
-        // 상세에서 카트 담기
+        // 상세에서 "담기" → 옵션 모달로 연결 (옵션 없으면 바로 담김)
         document.addEventListener("click", (e) => {
             const btn = e.target.closest('[data-action="add-from-detail"]');
             if (btn && openDetailMenuId != null) {
-                addToCart(openDetailMenuId, { optionIds: getDetailSelectedOptionIds() });
+                const id = openDetailMenuId;
                 closeDetail();
+                openOptionModal(id);
             }
         });
 
@@ -961,7 +1129,9 @@
         // 채팅/이벤트는 데이터 로드와 무관하게 먼저 세팅
         renderChatInitial();
         renderCartBar();
+        renderDineLabel();
         bindEvents();
+        initGuideOverlay();
 
         // 백엔드에서 메뉴 트리 로드 + 서버 세션/카트 동기화 (병렬)
         try {
@@ -996,6 +1166,10 @@
         renderStoreList();
         renderMenuGrid();
         renderCartBar();
+
+        // 가이드가 아직 떠 있으면, 이제 렌더된 메뉴 카드(AI추천·상세) 위치까지 점선 다시 그림
+        const $g = document.querySelector('[data-guide]');
+        if ($g && !$g.hidden) drawGuideLines($g);
 
         // QuickAction / AiAction 모듈이 호출할 수 있는 핸들러 노출
         window.__N02_gotoCheckout = gotoCheckout;

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -3,7 +3,7 @@
    - 주문번호(대기번호) 랜덤 생성 후 sessionStorage 유지
    - cart / paymentMethod 로 요약 렌더
    - 영수증 프로그레스 3초 후 \"· 완료\" 표시
-   - 60초 자동 홈 복귀 (/)  — 카운트다운 UI 표시
+   - 15초 자동 홈 복귀 (/)  — 카운트다운 UI 표시
    - CTA/X 클릭 → 즉시 홈 복귀 + flow 세션 초기화
    ======================================================== */
 
@@ -21,6 +21,8 @@
     const totalEl        = $('[data-bind="total"]');
     const autoSecEl      = $('[data-bind="autoSec"]');
     const receiptEl      = $('[data-bind="receipt"]');
+    const receiptTitleEl = $('[data-bind="receiptTitle"]');
+    const outputModalEl  = $('[data-output-modal]');
 
     const homeEls = Array.from(document.querySelectorAll('[data-action="home"]'));
 
@@ -108,8 +110,38 @@
         if (receiptEl) receiptEl.classList.add('p05__receipt--done');
     }
 
+    /* ---------- 출력 선택 모달 (영수증 / 번호표) ---------- */
+    // 완료 화면 진입 시 출력 항목을 고르게 한다. 고른 뒤에야 출력 안내 + 카운트다운 시작.
+    let outputChosen = false;
+    function openOutputModal() {
+        if (!outputModalEl) { afterOutputChosen('receipt'); return; }
+        outputModalEl.hidden = false;
+        const choose = (kind) => {
+            if (outputChosen) return;
+            outputChosen = true;
+            outputModalEl.hidden = true;
+            afterOutputChosen(kind);
+        };
+        outputModalEl.querySelectorAll('[data-output]').forEach((btn) => {
+            btn.addEventListener('click', () => choose(btn.getAttribute('data-output')));
+        });
+        // 안전장치 — 아무도 안 고르면 20초 뒤 영수증으로 진행 (키오스크 멈춤 방지)
+        setTimeout(() => choose('receipt'), 20000);
+    }
+
+    function afterOutputChosen(kind) {
+        if (receiptTitleEl) {
+            receiptTitleEl.textContent = kind === 'ticket'
+                ? '번호표가 출력되고 있어요'
+                : '영수증이 출력되고 있어요';
+        }
+        if (receiptEl) receiptEl.hidden = false;
+        setTimeout(markReceiptDone, 3000);
+        startCountdown();
+    }
+
     /* ---------- Auto-reset countdown ---------- */
-    const AUTO_SEC = 60;
+    const AUTO_SEC = 15;
     let remaining = AUTO_SEC;
     let tickTimer = null;
 
@@ -180,8 +212,8 @@
         window.AvatarGuide.speak('결제가 완료됐어요. 맛있게 드세요.');
     }
 
-    setTimeout(markReceiptDone, 3000);
-    startCountdown();
+    // 출력 항목(영수증/번호표) 선택 후 출력 안내 + 카운트다운 시작
+    openOutputModal();
 
     // ---------- 음성 컨트롤 ----------
     if (window.VoiceController) {

--- a/src/main/resources/templates_front/flowN/N02-menu.html
+++ b/src/main/resources/templates_front/flowN/N02-menu.html
@@ -26,6 +26,10 @@
                 <span class="app-topbar__store-sub" data-bind="brand">상록원</span>
                 <span class="app-topbar__store-name" data-bind="storeName">솥앤누들</span>
             </div>
+            <button class="n02__dine-toggle" type="button"
+                    data-action="toggle-dine" aria-label="매장 또는 포장 변경">
+                <span data-bind="dineLabel">매장</span>
+            </button>
         </div>
         <div class="app-topbar__right">
             <button class="app-topbar__action-pill" type="button"
@@ -87,8 +91,7 @@
                 <span>카트</span>
             </div>
             <p class="n02__cart-empty-msg">메뉴를 담으면 여기에 표시됩니다</p>
-            <button class="btn-cta btn-cta--primary btn-cta--block n02__cart-pay-btn"
-                    type="button" disabled>
+            <button class="n02__pay" type="button" disabled>
                 결제하기
             </button>
         </div>
@@ -127,9 +130,7 @@
                 </button>
             </div>
 
-            <button class="btn-cta btn-cta--primary btn-cta--block n02__cart-pay-btn"
-                    type="button"
-                    data-action="checkout">
+            <button class="n02__pay" type="button" data-action="checkout">
                 <i class="xi xi-cart" aria-hidden="true"></i>
                 <span>결제하기</span>
                 <span class="n02__cart-pay-amount" data-cart-pay-amount>· ₩ 0</span>
@@ -161,14 +162,14 @@
             <div class="n02__detail-body" data-detail-body>
                 <p class="n02__detail-desc" data-detail-desc></p>
 
-                <!-- 옵션 선택 (옵션 있는 메뉴에서만 노출 — JS 가 채움) -->
-                <section class="n02__detail-section n02__detail-section--options"
-                         data-detail-options-section hidden>
+                <!-- AI 추천 이유 (백엔드가 menu detail 에 aiReason 제공 시 노출) — QA #5 -->
+                <section class="n02__detail-section n02__detail-section--ai"
+                         data-detail-ai-section hidden>
                     <h3 class="n02__detail-section-title">
-                        <i class="xi xi-check-circle-o" aria-hidden="true"></i>
-                        옵션 선택
+                        <i class="xi xi-lightning" aria-hidden="true"></i>
+                        AI 추천 이유
                     </h3>
-                    <div class="n02__detail-options" data-detail-options></div>
+                    <p class="n02__detail-ai-reason" data-detail-ai-reason></p>
                 </section>
 
                 <section class="n02__detail-section">
@@ -219,7 +220,7 @@
 
             <!-- 하단 CTA -->
             <div class="n02__detail-cta-wrap">
-                <button class="btn-cta btn-cta--primary btn-cta--block btn-cta--lg n02__detail-cta"
+                <button class="btn-cta btn-cta--primary btn-cta--block n02__detail-cta"
                         type="button"
                         data-action="add-from-detail">
                     <i class="xi xi-cart" aria-hidden="true"></i>
@@ -228,6 +229,30 @@
                 </button>
             </div>
         </article>
+    </div>
+
+    <!-- ========================================================
+         옵션 선택 모달 (담기 시 — QA #9). 옵션 있는 메뉴는 여기서 선택 후 담기.
+         ======================================================== -->
+    <div class="n02-opt" data-opt-modal hidden>
+        <div class="n02-opt__backdrop" data-opt-close></div>
+        <div class="n02-opt__box" role="dialog" aria-modal="true" aria-label="옵션 선택">
+            <button class="n02-opt__close" type="button" data-opt-close aria-label="닫기">
+                <i class="xi xi-close-thin" aria-hidden="true"></i>
+            </button>
+            <div class="n02-opt__head">
+                <span class="n02-opt__name" data-opt-name>메뉴</span>
+                <span class="n02-opt__price" data-opt-price>₩ 0</span>
+            </div>
+            <p class="n02-opt__hint">옵션을 선택하거나 그대로 담을 수 있어요</p>
+            <div class="n02-opt__groups n02__detail-options" data-opt-groups></div>
+            <div class="n02-opt__actions">
+                <button class="btn-cta btn-cta--secondary n02-opt__btn"
+                        type="button" data-opt-action="more">더 담기</button>
+                <button class="btn-cta btn-cta--primary n02-opt__btn"
+                        type="button" data-opt-action="order">바로 주문 →</button>
+            </div>
+        </div>
     </div>
 
     <!-- ========================================================
@@ -277,6 +302,70 @@
             </button>
         </div>
     </aside>
+
+    <!-- ========================================================
+         첫 진입 가이드 오버레이 (회색 쉐이드 · 터치하면 해제) — QA #13
+         ======================================================== -->
+    <div class="n02-guide" data-guide hidden>
+        <!-- 점선 + 화살표 레이어 : 좌표는 JS 가 실제 버튼 위치를 재서 그림 (프레임 720x1280) -->
+        <svg class="n02-guide__svg" viewBox="0 0 720 1280" preserveAspectRatio="none" aria-hidden="true">
+            <defs>
+                <marker id="n02GuideArrow" markerWidth="10" markerHeight="10" refX="6" refY="4" orient="auto">
+                    <path d="M0,0 L8,4 L0,8 Z" fill="#ffd54a"></path>
+                </marker>
+            </defs>
+            <g data-guide-lines></g>
+        </svg>
+
+        <!-- 각 콜아웃은 data-guide-target(가리킬 요소) · data-guide-anchor(콜아웃에서 선이 나가는 변) 로 연결 -->
+        <!-- 매장/포장 (상단 좌측) -->
+        <div class="n02-guide__callout" style="top:150px; left:14px;"
+             data-guide-target=".n02__dine-toggle" data-guide-anchor="top">
+            <i class="xi xi-refresh" aria-hidden="true"></i>
+            <div class="n02-guide__callout-body">
+                <strong>매장 / 포장</strong>
+                <span>터치하면 식사 방식이 바뀌어요</span>
+            </div>
+        </div>
+        <!-- 마이크 (상단 우측) -->
+        <div class="n02-guide__callout" style="top:150px; right:14px;"
+             data-guide-target="[data-action='toggle-mic']" data-guide-anchor="top">
+            <i class="xi xi-microphone" aria-hidden="true"></i>
+            <div class="n02-guide__callout-body">
+                <strong>마이크</strong>
+                <span>켜고 "○○ 담아줘"처럼 음성으로 주문</span>
+            </div>
+        </div>
+        <!-- 대화 기록 (상단 우측) -->
+        <div class="n02-guide__callout" style="top:252px; right:14px;"
+             data-guide-target="[data-action='open-chat']" data-guide-anchor="top">
+            <i class="xi xi-message" aria-hidden="true"></i>
+            <div class="n02-guide__callout-body">
+                <strong>대화 기록</strong>
+                <span>AI와 나눈 대화를 다시 볼 수 있어요</span>
+            </div>
+        </div>
+        <!-- AI 추천 라벨 (메뉴 카드) — 추천 메뉴 없으면 JS 가 숨김 -->
+        <div class="n02-guide__callout" style="bottom:300px; left:14px;"
+             data-guide-target=".n02__menu-card-ai-badge" data-guide-anchor="bottom">
+            <i class="xi xi-lightning" aria-hidden="true"></i>
+            <div class="n02-guide__callout-body">
+                <strong>AI 추천 라벨</strong>
+                <span>AI가 추천하는 메뉴예요</span>
+            </div>
+        </div>
+        <!-- 상세 칩 (메뉴 카드) -->
+        <div class="n02-guide__callout" style="bottom:300px; right:14px;"
+             data-guide-target=".n02__menu-card-detail-chip" data-guide-anchor="bottom">
+            <i class="xi xi-document" aria-hidden="true"></i>
+            <div class="n02-guide__callout-body">
+                <strong>상세</strong>
+                <span>메뉴 정보와 추천 이유를 봐요</span>
+            </div>
+        </div>
+
+        <p class="n02-guide__hint">화면을 터치하면 주문을 시작합니다</p>
+    </div>
 
 </main>
 

--- a/src/main/resources/templates_front/flowP/P01-summary.html
+++ b/src/main/resources/templates_front/flowP/P01-summary.html
@@ -73,7 +73,7 @@
 
     <!-- 하단 CTA -->
     <footer class="p01__cta-wrap">
-        <button type="button" class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p01__cta"
+        <button type="button" class="p-cta p-cta--primary p-cta--block p01__cta"
                 data-action="next">
             주문 확인 완료 →
         </button>

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -153,7 +153,7 @@
     <!-- 하단 CTA -->
     <footer class="p02__cta-wrap">
         <button type="button"
-                class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p02__cta"
+                class="p-cta p-cta--primary p-cta--block p02__cta"
                 data-action="next"
                 disabled>
             결제 수단 선택 →

--- a/src/main/resources/templates_front/flowP/P03-vein.html
+++ b/src/main/resources/templates_front/flowP/P03-vein.html
@@ -112,7 +112,7 @@
 
         <!-- prepare / scanning : 취소 (결제 수단 변경) -->
         <button type="button"
-                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p03__cta p03__cta--cancel"
+                class="p-cta p-cta--secondary p-cta--block p03__cta p03__cta--cancel"
                 data-action="cancel">
             다른 결제 수단으로 변경
         </button>
@@ -120,12 +120,12 @@
         <!-- fail : 다시 시도 / 결제 수단 변경 -->
         <div class="p03__cta-row p03__cta--fail-actions">
             <button type="button"
-                    class="btn-cta btn-cta--secondary btn-cta--lg p03__cta-ghost"
+                    class="p-cta p-cta--secondary p03__cta-ghost"
                     data-action="switch">
                 다른 결제 수단
             </button>
             <button type="button"
-                    class="btn-cta btn-cta--primary btn-cta--lg p03__cta-primary"
+                    class="p-cta p-cta--primary p03__cta-primary"
                     data-action="retry">
                 다시 시도 →
             </button>

--- a/src/main/resources/templates_front/flowP/P04-processing.html
+++ b/src/main/resources/templates_front/flowP/P04-processing.html
@@ -115,7 +115,7 @@
 
         <!-- inserting : 결제 취소 가능 -->
         <button type="button"
-                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p04__cta p04__cta--cancel"
+                class="p-cta p-cta--secondary p-cta--block p04__cta p04__cta--cancel"
                 data-action="cancel">
             결제 취소 (다른 수단 선택)
         </button>

--- a/src/main/resources/templates_front/flowP/P05-complete.html
+++ b/src/main/resources/templates_front/flowP/P05-complete.html
@@ -92,11 +92,11 @@
             </div>
         </div>
 
-        <!-- 영수증 출력 안내 -->
-        <div class="p05__receipt" data-bind="receipt">
+        <!-- 출력 안내 (모달에서 선택한 항목) -->
+        <div class="p05__receipt" data-bind="receipt" hidden>
             <i class="xi-print" aria-hidden="true"></i>
             <div class="p05__receipt-body">
-                <span class="p05__receipt-title">영수증이 출력되고 있어요</span>
+                <span class="p05__receipt-title" data-bind="receiptTitle">영수증이 출력되고 있어요</span>
                 <span class="p05__receipt-progress" aria-hidden="true">
                     <span class="p05__receipt-progress-bar"></span>
                 </span>
@@ -104,13 +104,33 @@
         </div>
     </section>
 
+    <!-- 출력 선택 모달 (영수증 / 번호표) -->
+    <div class="p05-output" data-output-modal hidden>
+        <div class="p05-output__box" role="dialog" aria-modal="true" aria-label="출력 선택">
+            <h2 class="p05-output__title">무엇을 출력할까요?</h2>
+            <p class="p05-output__desc">필요한 것을 선택하시면 출력해 드려요</p>
+            <div class="p05-output__choices">
+                <button type="button" class="p05-output__choice" data-output="receipt">
+                    <span class="p05-output__choice-icon" aria-hidden="true"><i class="xi-print"></i></span>
+                    <span class="p05-output__choice-title">영수증 출력</span>
+                    <span class="p05-output__choice-desc">결제 영수증을 받아요</span>
+                </button>
+                <button type="button" class="p05-output__choice" data-output="ticket">
+                    <span class="p05-output__choice-icon" aria-hidden="true"><i class="xi-document"></i></span>
+                    <span class="p05-output__choice-title">번호표 출력</span>
+                    <span class="p05-output__choice-desc">대기번호표를 받아요</span>
+                </button>
+            </div>
+        </div>
+    </div>
+
     <!-- 하단 CTA -->
     <footer class="p05__cta-wrap">
         <p class="p05__autoreset" aria-live="polite">
-            <span data-bind="autoSec">60</span>초 후 자동으로 처음 화면으로 돌아갑니다
+            <span data-bind="autoSec">15</span>초 후 자동으로 처음 화면으로 돌아갑니다
         </p>
         <button type="button"
-                class="btn-cta btn-cta--primary btn-cta--lg btn-cta--block p05__cta"
+                class="p-cta p-cta--primary p-cta--block p05__cta"
                 data-action="home">
             <i class="xi-redo" aria-hidden="true"></i>
             <span>처음으로</span>

--- a/src/main/resources/templates_front/flowP/P06-fail.html
+++ b/src/main/resources/templates_front/flowP/P06-fail.html
@@ -89,12 +89,12 @@
     <footer class="p06__cta-wrap">
         <div class="p06__cta-row" data-bind="ctaRow">
             <button type="button"
-                    class="btn-cta btn-cta--secondary btn-cta--lg p06__cta-ghost"
+                    class="p-cta p-cta--secondary p06__cta-ghost"
                     data-action="switch">
                 다른 결제 수단
             </button>
             <button type="button"
-                    class="btn-cta btn-cta--primary btn-cta--lg p06__cta-primary"
+                    class="p-cta p-cta--primary p06__cta-primary"
                     data-action="retry">
                 다시 시도 →
             </button>

--- a/src/main/resources/templates_front/flowP/P07-barcode.html
+++ b/src/main/resources/templates_front/flowP/P07-barcode.html
@@ -105,7 +105,7 @@
     <footer class="p07__cta-wrap">
         <!-- waiting : 취소 -->
         <button type="button"
-                class="btn-cta btn-cta--secondary btn-cta--lg btn-cta--block p07__cta p07__cta--cancel"
+                class="p-cta p-cta--secondary p-cta--block p07__cta p07__cta--cancel"
                 data-action="cancel">
             다른 결제 수단으로 변경
         </button>


### PR DESCRIPTION
## 📣 Related Issue

- 1차 QA 라운드 대응 (별도 이슈 없음)

## 📝 Summary

1차 QA에서 나온 결제 흐름·메뉴 옵션·레이아웃 문제를 한 번에 정리했습니다. 프론트(템플릿/CSS/JS) 위주이고, 백엔드는 정적 리소스 캐시 설정 한 건만 추가했습니다.

### 메뉴 / 카트 (flowN)
- `templates_front/flowN/N02-menu.html` : 매장·포장 토글 추가, 옵션 메뉴를 상세/옵션 모달에서 선택하도록 변경, 상세 오버레이에 AI 추천 이유 섹션 추가, 카트 결제 버튼을 self-contained `.n02__pay` 로 재작성, 첫 진입 가이드 오버레이(점선+화살표) 추가
- `static/front/js/flowN/N02-menu.js` : 옵션 메뉴가 카트에 안 담기던(공깃밥만 담기던) 문제 해결 — 옵션 선택 후 담기로 통일. 담을 때 전체 재렌더 대신 해당 카드 상태만 갱신(`syncCardCartState`). 첫 진입 가이드는 실제 버튼 위치를 측정해 점선·화살표를 그리도록 함(`drawGuideLines`) — 메뉴 카드가 동적이라 좌표 고정이 불가능해서이며, 추천 메뉴가 없으면 해당 안내는 자동으로 숨김
- `static/front/css/flowN/N02-menu.css` : 옵션 모달, 카트 항목 X 버튼, 결제 버튼, 가이드 오버레이 스타일

### 결제 흐름 (flowP)
- `templates_front/flowP/P01~P07.html` : 하단 CTA가 오른쪽에 붙던 문제로 전부 `.p-cta` 계열로 교체, 상단바 뒤로가기를 `nav-back` 으로 통일하고 대화/마이크 액션 정리
- `static/front/js/flowP/P05-complete.js` : 자동 이동 시간 15초로 단축, 영수증/번호표 출력 선택 모달 추가(미선택 시 폴백)
- `static/front/css/flowP/P05-complete.css` : 출력 선택 모달 스타일

### 공통
- `static/front/css/common.css` : `.page-bg` 에 `position: relative` 추가 — flowP 하단 푸터가 뷰포트가 아닌 키오스크 프레임 기준으로 정렬되도록(오른쪽 붙던 원인)
- `static/front/css/components.css` : 재사용 가능한 `.p-cta` 버튼 계열 신규(box-sizing 포함, 폭 안정)
- `static/front/js/common/confirm-modal.js` : 홈 이동 모달 문구를 화면별로 분기(메뉴 계속 보기 / 결제 계속하기)

### 백엔드
- `global/config/WebConfig.java` : 정적 리소스(`/images`, `/lib`) 브라우저 캐시 7일 설정 — 화면 전환마다 같은 이미지를 다시 받던 문제 방지. JS/CSS 는 개발 중 반영을 위해 제외

## 🙏 Question & PR point

- QA #5(상세 화면의 AI 추천 이유 노출)은 프론트 자리만 잡아둔 상태입니다. `GET /api/menus/{id}` 응답에 `aiReason` 류 필드가 추가되면 바로 연결됩니다.
- `scripts/seed-cart.sh`(로컬 카트 시드 헬퍼)와 미참조 파일 `css/flowP/P04-fail.css` 는 이번 PR 범위가 아니라 제외했습니다.

## 📬 Postman

- 신규/변경 API 없음(프론트 위주). 백엔드 변경은 정적 리소스 캐시 헤더 설정뿐이라 별도 스크린샷 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 옵션 선택 모달 추가로 메뉴 담기 흐름 개선
  * 매장/포장 전환 토글 버튼 추가
  * 완료 화면에서 영수증/번호표 출력 선택 모달 추가
  * 첫 진입 시 가이드 오버레이로 주요 기능 안내
  * 시스템 메시지 표시용 토스트 알림 추가
  * 메뉴 상세에 AI 추천 이유 표시

* **UI/UX 개선**
  * 주문 완료 후 자동 홈 복귀 시간 60초 → 15초로 단축
  * 결제 화면 CTA 버튼 스타일 통일
  * 이미지/라이브러리 리소스 캐싱 최적화 (7일)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->