### PR TITLE
Feat: 아바타 SSE 스트리밍 적용 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ src/main/resources/static/_figma-raw/
 .env.*
 !.env.example
 
+### SSH/PEM 키 — 절대 커밋 금지 ###
+*.pem
+*.key
+
 .docker-compose.yml
 
 ### Docker (로컬 개발용 - 커밋하지 않음) ###

--- a/src/main/resources/static/front/css/flowA/A01-avatar.css
+++ b/src/main/resources/static/front/css/flowA/A01-avatar.css
@@ -21,8 +21,9 @@
 
 .a01 {
     display: grid;
-    /* 상단바 64 + 아바타 720 + 인디 44 + 로그 196 + 퀵바 140 + 입력바 116 = 1280 */
-    grid-template-rows: 64px 720px 44px 196px 140px 116px;
+    /* 상단바 64 + 아바타 640 + 인디 44 + 로그 196 + 퀵바 220 + 입력바 116 = 1280
+       (퀵바 +80: 카드형 카트로 확장 — 음식사진 + 가격오버레이 + 수량조절) */
+    grid-template-rows: 64px 640px 44px 196px 220px 116px;
     height: 100%;
 }
 
@@ -479,95 +480,80 @@
     gap: 8px;
     padding: 8px var(--pad-side) 0;
     border-top: 1px solid var(--color-border-default);
+    min-height: 0;
 }
 
+/* 미니 카트 컨테이너 — 카드형 (N02 카트 바와 시각 통일) */
 .a01__minicart {
     display: flex;
-    align-items: center;
-    height: 60px;
-    padding: 0 14px;
+    flex-direction: column;
+    padding: 10px 14px;
     border-radius: 14px;
     background: var(--glass-bg-heavy);
     border: 1px solid var(--glass-border);
     box-shadow: var(--shadow-sm);
+    min-height: 0;
+    overflow: hidden;
 }
 
+/* 빈 상태 — 중앙 정렬 */
 .a01__minicart-empty {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 8px;
+    height: 100%;
     color: var(--color-text-secondary);
     font-size: 13px;
     font-weight: 500;
 }
 .a01__minicart-empty i { font-size: 18px; }
 
+/* 채워진 상태 — 헤더 + 카드 트랙 */
 .a01__minicart-filled {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    gap: 8px;
     width: 100%;
-    gap: 12px;
+    height: 100%;
+    min-height: 0;
 }
-.a01__minicart-list {
-    flex: 1;
-    display: flex;
-    gap: 6px;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-}
-.a01__minicart-list::-webkit-scrollbar { display: none; }
 
-.a01__minicart-item {
+.a01__minicart-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     flex-shrink: 0;
-    display: inline-flex;
+}
+.a01__minicart-head-left {
+    display: flex;
     align-items: center;
     gap: 6px;
-    height: 36px;
-    padding: 4px 10px 4px 4px;
-    border-radius: 18px;
-    background: var(--primary-50);
-    border: 1px solid var(--primary-100);
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--primary-700);
-    white-space: nowrap;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--color-text-primary);
 }
-.a01__minicart-item-thumb {
-    flex-shrink: 0;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    overflow: hidden;
-    background: var(--neutral-100);
+.a01__minicart-head-left i { font-size: 14px; }
+.a01__minicart-count {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-}
-.a01__minicart-item-thumb img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-.a01__minicart-item-thumb--icon {
-    color: var(--primary-300);
-    font-size: 14px;
-}
-.a01__minicart-item-qty {
-    color: var(--primary-500);
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    background: var(--primary-500);
+    color: #fff;
+    font-size: 11px;
     font-weight: 800;
 }
-
-.a01__minicart-total {
-    flex-shrink: 0;
+.a01__minicart-head-right {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0;
-    line-height: 1.1;
+    align-items: baseline;
+    gap: 6px;
 }
 .a01__minicart-total-label {
-    font-size: 10px;
+    font-size: 11px;
     color: var(--color-text-secondary);
     letter-spacing: 0.04em;
 }
@@ -575,6 +561,164 @@
     font-size: 16px;
     font-weight: 800;
     color: var(--color-text-price);
+    font-feature-settings: "tnum";
+}
+
+/* 카드 트랙 — 가로 스크롤 */
+.a01__minicart-track {
+    flex: 1;
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    min-height: 0;
+    margin: 0;
+    padding: 2px 0 2px;
+    list-style: none;
+}
+.a01__minicart-track::-webkit-scrollbar { display: none; }
+
+/* 개별 카드 */
+.a01__minicart-item {
+    flex: 0 0 auto;
+    width: 152px;
+    display: flex;
+    flex-direction: column;
+    background: var(--neutral-0);
+    border: 1px solid var(--neutral-100);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    scroll-snap-align: start;
+    overflow: hidden;
+    position: relative;
+}
+
+/* 사진 영역 — 카드 상단 */
+.a01__minicart-item-thumb {
+    position: relative;
+    width: 100%;
+    height: 78px;
+    background: var(--neutral-100);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+.a01__minicart-item-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.a01__minicart-item-thumb--icon i {
+    color: var(--neutral-300);
+    font-size: 24px;
+}
+
+/* 가격 오버레이 — 사진 우하단 */
+.a01__minicart-item-price-overlay {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.66);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+    font-feature-settings: "tnum";
+    backdrop-filter: blur(2px);
+}
+
+/* X 삭제 버튼 — 사진 우상단 */
+.a01__minicart-item-remove {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 2;
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.94);
+    color: var(--neutral-800);
+    font-size: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
+    cursor: pointer;
+}
+.a01__minicart-item-remove:active {
+    background: var(--neutral-100);
+    transform: scale(0.92);
+}
+
+/* 본문 영역 — 이름 + 수량 */
+.a01__minicart-item-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px 8px 8px;
+}
+.a01__minicart-item-name {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--neutral-800);
+    letter-spacing: -0.3px;
+    line-height: 1.2;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: keep-all;
+}
+
+/* 수량 스테퍼 — 카드 하단 */
+.a01__minicart-stepper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 28px;
+    padding: 0 2px;
+    border-radius: 8px;
+    background: var(--neutral-100, #f3efe9);
+}
+.a01__minicart-stepper-btn {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--primary-700);
+    font-size: 16px;
+    font-weight: 800;
+    cursor: pointer;
+}
+.a01__minicart-stepper-btn:active {
+    background: var(--primary-50);
+    transform: scale(0.94);
+}
+.a01__minicart-stepper-btn:disabled {
+    color: var(--neutral-300);
+    cursor: default;
+    background: transparent;
+    transform: none;
+}
+.a01__minicart-stepper-value {
+    flex: 1;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 800;
+    color: var(--neutral-800);
+    font-feature-settings: "tnum";
 }
 
 /* 빠른응답 칩 행 */

--- a/src/main/resources/static/front/js/common/api.js
+++ b/src/main/resources/static/front/js/common/api.js
@@ -22,15 +22,16 @@
 
     const LOG = '[Api]';
     // 로컬 개발: 페이지가 localhost 면 Spring 은 same-origin(`''`),
-    //           FastAPI(/ai/**) 는 로컬 FastAPI(localhost:8000).
-    //           ※ 로컬 Spring 과 로컬 FastAPI 가 같은 로컬 DB/세션을 공유해야
-    //             세션 검증이 일치한다. (운영 FastAPI 를 가리키면 세션 불일치로 502)
+    //           FastAPI(/ai/**) 는 원격 FastAPI(sslip.io HTTPS) 로 직결.
+    //           ※ 원격 FastAPI 는 원격 Spring 세션을 검증함 — 로컬 Spring 으로 만든
+    //             session_id 와 다를 수 있으므로 AI 화면은 /ai/order/start 로 새 세션 발급해 사용.
     // 운영: 둘 다 same-origin (`''`) — nginx 가 /ai/** 를 FastAPI 로 매핑.
-    const LOCAL_FASTAPI = 'http://localhost:8000';   // 로컬 NUNCHI-AI
+    // 참고: raw IP(43.201.20.11:8000)는 포트 닫혀 있음. sslip.io 도메인만 노출.
+    const LOCAL_FASTAPI = 'https://43-201-20-11.sslip.io';   // 원격 NUNCHI-AI (sslip.io DNS → 443 → FastAPI)
     const isLocalHost = (typeof location !== 'undefined') &&
         (location.hostname === 'localhost' || location.hostname === '127.0.0.1');
 
-    /** path 별 base URL 결정. /ai/** 는 FastAPI(로컬=8000, 운영=same-origin), 그 외는 Spring. */
+    /** path 별 base URL 결정. /ai/** 는 FastAPI(로컬=sslip.io HTTPS 직결, 운영=same-origin), 그 외는 Spring. */
     function resolveUrl(path) {
         if (path.startsWith('/ai/')) {
             return (isLocalHost ? LOCAL_FASTAPI : '') + path;

--- a/src/main/resources/static/front/js/common/api.js
+++ b/src/main/resources/static/front/js/common/api.js
@@ -317,6 +317,67 @@
                 .finally(() => { _chatInFlight = false; });
         },
         /**
+         * 사용자 발화 처리 — SSE 스트리밍.
+         * /ai/order/chat 과 요청 body 동일, 응답은 SSE 이벤트 스트림.
+         *
+         * 이벤트 종류:
+         *   - token : { type:"token", text:"오늘" }  — LLM 토큰 도착 즉시 (말풍선에 append)
+         *   - done  : { type:"done", reply, recommendations, menu_options, suggestions,
+         *              action, current_step }       — 전체 응답 완료 (후처리 분기 시점)
+         *   - error : { type:"error", message }     — 백엔드 오류
+         *
+         * 동시 호출 정책은 chat() 과 동일 — done 까지는 신규 호출 즉시 reject.
+         * OOD(clarify_responder) 응답은 token 없이 done 만 올 수 있다 — 호출부에서 fallback 필요.
+         *
+         * @param {{session_id:number, text:string, nunchi_signal?:string, mode?:string}} body
+         * @param {{onToken?:(t:string)=>void, onDone?:(d:object)=>void, onError?:(m:string)=>void}} [handlers]
+         * @returns {Promise<void>} 스트림 종료 시 resolve
+         */
+        chatStream(body, handlers) {
+            if (!body || body.session_id == null || !body.text) {
+                throw new Error('Ai.chatStream: session_id, text 필수');
+            }
+            if (_chatInFlight) {
+                const busy = new ApiError(429, '이전 음성 요청을 처리하고 있어요.', 0, '/ai/order/chat/stream');
+                busy._busy = true;
+                return Promise.reject(busy);
+            }
+            const payload = {
+                session_id: body.session_id,
+                text: body.text,
+                mode: body.mode || 'AVATAR',
+            };
+            if (body.nunchi_signal) payload.nunchi_signal = body.nunchi_signal;
+
+            const onToken = handlers && handlers.onToken;
+            const onDone  = handlers && handlers.onDone;
+            const onError = handlers && handlers.onError;
+
+            const url = resolveUrl('/ai/order/chat/stream');
+            _chatInFlight = true;
+
+            return fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'text/event-stream',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify(payload),
+            }).then((res) => {
+                if (!res.ok) {
+                    throw new ApiError(res.status, 'SSE 연결 실패: ' + res.status, res.status, '/ai/order/chat/stream');
+                }
+                if (!res.body) {
+                    throw new ApiError(0, 'SSE 응답 본문이 없습니다.', res.status, '/ai/order/chat/stream');
+                }
+                if (!window.SseParser) {
+                    throw new ApiError(0, 'SseParser 가 로드되지 않았습니다 (sse-parser.js 누락).', 0, '/ai/order/chat/stream');
+                }
+                return window.SseParser.consume(res.body, { onToken, onDone, onError });
+            }).finally(() => { _chatInFlight = false; });
+        },
+        /**
          * 추천/옵션 선택 후 메뉴를 장바구니에 직접 담음 (옵션 선택 UI 거친 뒤 사용).
          * @param {{session_id:number, menu_id:number, quantity:number, option_ids:number[]}} body
          * @returns {Promise<{sessionId, items, totalAmount}>}

--- a/src/main/resources/static/front/js/common/sse-parser.js
+++ b/src/main/resources/static/front/js/common/sse-parser.js
@@ -87,7 +87,11 @@
                     }
                     return;
                 }
-                buf += decoder.decode(value, { stream: true });
+                const chunk = decoder.decode(value, { stream: true });
+                // 개발 기간 — 원시 청크 도착 타이밍 가시화 (fetch buffering 여부 판별용)
+                console.debug('[SSE] chunk', value.byteLength, 'bytes');
+                // SSE 스펙: 이벤트 구분자는 \n\n 또는 \r\n\r\n — CRLF 를 LF 로 정규화 후 분할
+                buf += chunk.replace(/\r\n/g, '\n');
                 const parts = buf.split('\n\n');
                 buf = parts.pop(); // 마지막은 미완성일 수 있으므로 보관
                 for (const part of parts) {
@@ -109,7 +113,8 @@
      * @returns {string} — 다음 청크로 이월할 새 buf
      */
     function feedChunk(chunk, prevBuf, onEvent) {
-        const merged = (prevBuf || '') + chunk;
+        // SSE 스펙 \r\n\r\n 도 이벤트 구분자 — LF 로 정규화
+        const merged = ((prevBuf || '') + chunk).replace(/\r\n/g, '\n');
         const parts = merged.split('\n\n');
         const remainder = parts.pop();
         for (const part of parts) {

--- a/src/main/resources/static/front/js/common/sse-parser.js
+++ b/src/main/resources/static/front/js/common/sse-parser.js
@@ -54,6 +54,8 @@
      */
     function dispatchEvent(ev, handlers) {
         if (!ev || !ev.type || !handlers) return;
+        // 개발 기간 — 모든 SSE 이벤트를 콘솔에 출력 (운영 전 제거 또는 토글화)
+        console.debug('[SSE]', ev.type, ev);
         if (ev.type === 'token' && handlers.onToken) {
             handlers.onToken(ev.text || '');
         } else if (ev.type === 'done' && handlers.onDone) {

--- a/src/main/resources/static/front/js/common/sse-parser.js
+++ b/src/main/resources/static/front/js/common/sse-parser.js
@@ -1,0 +1,126 @@
+// ========================================================
+// sse-parser.js — Server-Sent Events 본문 파서
+//
+// 책임: ReadableStream 형태의 SSE 응답 본문을 파싱해 type 별 핸들러로 라우팅.
+// 호출처: api.js 의 Ai.chatStream() — /ai/order/chat/stream 응답 처리.
+//
+// 이벤트 포맷 (NUNCHI FastAPI):
+//   data: {"type":"token","text":"오늘"}\n\n
+//   data: {"type":"done","reply":"...","recommendations":[...],...}\n\n
+//   data: {"type":"error","message":"..."}\n\n
+//
+// 청크 경계가 이벤트 중간(\n\n 이전)에 떨어질 수 있으므로 잔여 buf 를 다음 청크로 이월.
+// JSON 파싱 실패한 라인은 건너뛰고 다음 라인 계속 처리.
+// kept_alive 등 알 수 없는 type 은 조용히 무시 (연결 유지 핑).
+//
+// UMD: 브라우저(window.SseParser) / Node(require) 양쪽 사용 가능.
+// ========================================================
+
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.SseParser = factory();
+    }
+})(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    /**
+     * 단일 SSE 이벤트 블록(여러 줄 가능) 을 파싱.
+     * @param {string} block — "data: {...}" 형태의 한 이벤트 (개행 포함 가능)
+     * @returns {object|null} — 파싱된 이벤트 객체, 또는 파싱 실패/빈 블록이면 null
+     */
+    function parseEventBlock(block) {
+        const lines = block.split('\n');
+        let dataStr = '';
+        for (const line of lines) {
+            if (line.startsWith('data:')) {
+                // SSE 스펙: "data:" 뒤 공백 1개는 무시
+                dataStr += line.slice(5).replace(/^ /, '');
+            }
+        }
+        if (!dataStr) return null;
+        try {
+            return JSON.parse(dataStr);
+        } catch (_) {
+            return null;
+        }
+    }
+
+    /**
+     * 파싱된 이벤트를 type 별 핸들러로 라우팅.
+     * @param {object} ev — { type, ...payload }
+     * @param {{onToken?:Function, onDone?:Function, onError?:Function}} handlers
+     */
+    function dispatchEvent(ev, handlers) {
+        if (!ev || !ev.type || !handlers) return;
+        if (ev.type === 'token' && handlers.onToken) {
+            handlers.onToken(ev.text || '');
+        } else if (ev.type === 'done' && handlers.onDone) {
+            handlers.onDone(ev);
+        } else if (ev.type === 'error' && handlers.onError) {
+            handlers.onError(ev.message || '오류가 발생했습니다.');
+        }
+        // 그 외 type (kept_alive 등) 은 조용히 무시
+    }
+
+    /**
+     * fetch().body (ReadableStream) 를 끝까지 읽으며 이벤트 단위로 핸들러 호출.
+     * @param {ReadableStream} stream — fetch Response.body
+     * @param {{onToken?:Function, onDone?:Function, onError?:Function}} handlers
+     * @returns {Promise<void>} — 스트림 종료 시 resolve
+     */
+    async function consume(stream, handlers) {
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        let buf = '';
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) {
+                    // 마지막 미완성 라인이 있으면 그것도 시도
+                    if (buf.trim()) {
+                        const ev = parseEventBlock(buf);
+                        if (ev) dispatchEvent(ev, handlers);
+                    }
+                    return;
+                }
+                buf += decoder.decode(value, { stream: true });
+                const parts = buf.split('\n\n');
+                buf = parts.pop(); // 마지막은 미완성일 수 있으므로 보관
+                for (const part of parts) {
+                    const ev = parseEventBlock(part);
+                    if (ev) dispatchEvent(ev, handlers);
+                }
+            }
+        } finally {
+            try { reader.releaseLock(); } catch (_) {}
+        }
+    }
+
+    /**
+     * 청크 단위로 누적 → 완성된 이벤트만 콜백.
+     * 테스트/특수 환경에서 ReadableStream 없이 청크를 직접 공급할 때 사용.
+     * @param {string} chunk — 새로 도착한 텍스트
+     * @param {string} prevBuf — 이전 잔여 버퍼
+     * @param {(ev:object)=>void} onEvent — 완성된 이벤트마다 호출
+     * @returns {string} — 다음 청크로 이월할 새 buf
+     */
+    function feedChunk(chunk, prevBuf, onEvent) {
+        const merged = (prevBuf || '') + chunk;
+        const parts = merged.split('\n\n');
+        const remainder = parts.pop();
+        for (const part of parts) {
+            const ev = parseEventBlock(part);
+            if (ev) onEvent(ev);
+        }
+        return remainder;
+    }
+
+    return {
+        parseEventBlock,
+        dispatchEvent,
+        consume,
+        feedChunk,
+    };
+});

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -439,18 +439,22 @@
     }
 
     // ========================================================
-    // 11. 사용자 발화 → FastAPI chat → reply 발화 + 후처리
+    // 11. 사용자 발화 → FastAPI chatStream (SSE) → 토큰 스트림 + done 후처리
+    //
+    // SSE 흐름:
+    //   onToken : 말풍선에 즉시 append, 문장 경계(. ! ? …) 마다 TTS 큐에 push
+    //   onDone  : 단계 갱신 + action / suggestions / menu_options / recommendations 처리
+    //   onError : 토스트 + 청취 재개
+    // OOD(clarify_responder) 응답은 token 없이 done 만 옴 → onDone 에서 reply 로 fallback TTS.
     // ========================================================
     async function handleUserUtterance(text) {
         if (state.aiSessionId == null) {
-            // FastAPI 세션이 없으면 reply 받을 수 없음 — 토스트만
             showToast('AI 세션이 없어요. 새로고침 해주세요.');
             if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
             return;
         }
 
-        // 추천 시트 열려있을 때 음성을 자연어로 변환 ("1번" → "데리야끼... 담아줘") 후 시트 닫음.
-        // chat 은 항상 호출 — AI 가 컨텍스트로 처리 (옵션 유무, 다음 단계 안내 등)
+        // 추천 시트 열려있을 때 음성을 자연어로 변환 후 시트 닫음.
         let chatText = text;
         const mapped = matchRecommendVoice(text);
         if (mapped) chatText = mapped;
@@ -459,75 +463,164 @@
             state.recommendCtx = null;
         }
 
-        const res = await callApi('AI 응답', () =>
-            window.Api.Ai.chat({
-                session_id: state.aiSessionId,
-                text: chatText
-            })
-        );
+        // 이전 발화 abort (barge-in) + 새 signal
+        if (state.speechAbort) {
+            try { state.speechAbort.abort(); } catch (_) {}
+        }
+        state.speechAbort = new AbortController();
+        const signal = state.speechAbort.signal;
 
-        // 디버그 — FastAPI chat 응답 전체 + step 필드 즉시 로깅
-        console.log('[A01] FastAPI chat 응답:', res);
-        if (res) {
-            console.log('[A01] current_step:', res.current_step, '| currentStep:', res.currentStep, '| step:', res.step);
+        // 말풍선 초기화 + 아바타 talking
+        $bubble.classList.add('is-visible');
+        $bubble.classList.remove('is-typing');
+        $bubbleText.textContent = '';
+        setAvatar('talking');
+
+        // SSE 스트리밍 누적 상태
+        let sentenceBuf = '';
+        let fullText = '';
+        let receivedAnyToken = false;
+        let ttsQueue = Promise.resolve();
+
+        function flushTts(sentence) {
+            const s = (sentence || '').trim();
+            if (!s) return;
+            // TTS 순서 보장 큐 — 직전 재생 끝난 뒤 다음 문장 합성/재생
+            ttsQueue = ttsQueue.then(() => {
+                if (signal.aborted) return null;
+                return startTtsPlayback(s, signal);
+            }).catch((e) => {
+                console.warn('[A01] TTS 큐 실패', e);
+                return null;
+            });
         }
 
-        if (!res || !res.reply) {
-            // 폴백 멘트 추가 금지 — 청취만 재개
+        let doneRes = null;
+        let errorMsg = null;
+
+        try {
+            await window.Api.Ai.chatStream(
+                { session_id: state.aiSessionId, text: chatText },
+                {
+                    onToken(chunk) {
+                        if (signal.aborted || !chunk) return;
+                        receivedAnyToken = true;
+                        fullText += chunk;
+                        sentenceBuf += chunk;
+                        $bubbleText.textContent += chunk;
+                        // 한국어/영문 문장 경계 — 마침표 류 + 공백 또는 끝
+                        if (/[.!?…](\s|$)/.test(sentenceBuf)) {
+                            flushTts(sentenceBuf);
+                            sentenceBuf = '';
+                        }
+                    },
+                    onDone(res) {
+                        doneRes = res;
+                        if (sentenceBuf.trim()) {
+                            flushTts(sentenceBuf);
+                            sentenceBuf = '';
+                        }
+                        // OOD(clarify_responder): 토큰 없이 done 만 — reply 로 fallback
+                        if (!receivedAnyToken && res && res.reply) {
+                            $bubbleText.textContent = res.reply;
+                            fullText = res.reply;
+                            flushTts(res.reply);
+                        }
+                    },
+                    onError(msg) {
+                        errorMsg = msg;
+                    },
+                }
+            );
+        } catch (e) {
+            // 네트워크 실패 / 429 (_busy) 등
+            console.warn('[A01] chatStream 실패', e);
+            if (!e || !e._busy) {
+                const msg = (e && e.message) || 'AI 응답을 받지 못했어요.';
+                showToast(msg);
+            }
+            setAvatar('idle');
             if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
             return;
         }
 
-        // 단계 인디케이터 갱신 — 서버 currentStep 우선, fallback 으로 reply 키워드 추정.
-        // CHECKOUT 진입(승/전 → 결) 감지를 위해 prev fsm 저장.
+        // 백엔드 error 이벤트
+        if (errorMsg) {
+            showToast(errorMsg);
+            appendLog('ai', errorMsg);
+            ttsQueue.then(() => setAvatar('idle'));
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            return;
+        }
+
+        // done 없음 또는 빈 응답 — 폴백 멘트 추가 금지, 청취만 재개
+        if (!doneRes || (!fullText && !(doneRes && doneRes.reply))) {
+            setAvatar('idle');
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            return;
+        }
+
+        console.log('[A01] chatStream done:', doneRes);
+        console.log('[A01] current_step:', doneRes.current_step, '| currentStep:', doneRes.currentStep, '| step:', doneRes.step);
+
+        const reply = doneRes.reply || fullText;
+        appendLog('ai', reply);
+
+        // 단계 인디케이터 갱신 — CHECKOUT 진입 감지를 위해 prev fsm 저장
         const prevFsm = state.fsm;
-        applyStep(res);
+        applyStep(doneRes);
         const enteredCheckout = state.fsm === 'confirm' && prevFsm !== 'confirm';
         console.log('[A01] step 분석:', {
             prevFsm,
             currFsm: state.fsm,
             enteredCheckout,
-            replyComplete: !!(window.ReplyKeywords && window.ReplyKeywords.replyHasComplete(res.reply))
+            replyComplete: !!(window.ReplyKeywords && window.ReplyKeywords.replyHasComplete(reply))
         });
 
-        await aiSpeakChained(res.reply);
-
-        // AI 화면 원격조작 — navigate 등 (음성=터치). LLM 이 준 화면 명령을 그대로 반영.
-        // navigate 면 페이지를 떠나므로 이후 후처리는 생략.
-        if (window.AiAction && res.action) {
-            window.AiAction.handle(res.action);
-            if (res.action.type === 'navigate' && res.action.page) return;
+        // AI 화면 원격조작 — navigate 면 페이지 떠나므로 이후 후처리 생략
+        if (window.AiAction && doneRes.action) {
+            window.AiAction.handle(doneRes.action);
+            if (doneRes.action.type === 'navigate' && doneRes.action.page) return;
         }
 
-        // reply 후처리
-        const reply = res.reply;
+        // 카트 변경 키워드 → 카트 재조회
         if (window.ReplyKeywords && window.ReplyKeywords.replyHasCartChange(reply)) {
             await refreshCart();
         }
-        // 결제 라우팅 — FastAPI 가 동기화한 current_step==CHECKOUT 진입 시 P01 이동(명세 정합).
-        // 폴백: step 누락 응답 대비 replyHasComplete 키워드 매칭 유지.
+
+        // 결제 라우팅 — CHECKOUT 진입 또는 완료 키워드
         const replyComplete = window.ReplyKeywords && window.ReplyKeywords.replyHasComplete(reply);
         if (enteredCheckout || replyComplete) {
             await goToPayment();
             return;
         }
 
-        // suggestions → 퀵바 chip 렌더 (분기 전 우선 갱신, 없으면 비움)
-        renderChips(res.suggestions);
+        // suggestions 칩 갱신
+        renderChips(doneRes.suggestions);
 
-        // 옵션 선택이 필요한 메뉴 → 옵션 시트
-        if (res.menu_options) {
-            openOptionSheet(res.menu_options);
+        // TTS 큐 끝나면 아바타 idle + 청취 재개
+        const finalize = () => {
+            ttsQueue.then(() => {
+                setAvatar('idle');
+                if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            });
+        };
+
+        // 옵션 시트는 즉시 열고 TTS 끝나면 청취 재개
+        if (doneRes.menu_options) {
+            openOptionSheet(doneRes.menu_options);
+            finalize();
             return;
         }
 
-        // 추천 메뉴 → 추천 시트 (시트 열린 동안에도 마이크 ON 유지)
-        if (Array.isArray(res.recommendations) && res.recommendations.length > 0) {
-            openRecommendSheet(res.recommendations);
+        // 추천 시트도 즉시 열고 TTS 끝나면 마이크 ON 유지
+        if (Array.isArray(doneRes.recommendations) && doneRes.recommendations.length > 0) {
+            openRecommendSheet(doneRes.recommendations);
+            finalize();
             return;
         }
 
-        if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+        finalize();
     }
 
     /**

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -232,6 +232,16 @@
         }
     }
 
+    /** Append-mode typewriter — 말풍선 초기화 안 하고 한 글자씩 끝에 추가.
+     *  SSE 큐 안에서 문장 단위로 호출 (이전 문장 누적된 상태 유지). */
+    async function typeChunk(text, speed, signal) {
+        for (let i = 0; i < text.length; i++) {
+            if (signal && signal.aborted) return;
+            $bubbleText.textContent += text[i];
+            await sleep(speed, signal);
+        }
+    }
+
     /** 재생 중인 TTS 오디오 정리. */
     function stopCurrentAudio() {
         if (state.currentAudio) {
@@ -261,19 +271,33 @@
      * @returns {Promise<void>} 재생 종료 시점에 resolve
      */
     function startTtsPlayback(text, signal, opts) {
+        // 모든 경로 공통 — meta/play-start 콜백 (abort 시엔 firePlayStart 무효).
+        const fireMeta = (d) => {
+            if (opts && opts.onMeta) try { opts.onMeta(d); } catch (_) {}
+        };
+        const firePlayStart = () => {
+            if (signal && signal.aborted) return;
+            if (opts && opts.onPlayStart) try { opts.onPlayStart(); } catch (_) {}
+        };
+
         if (state.muted) {
-            if (opts && opts.onMeta) opts.onMeta(null);
+            // 무음이라도 텍스트는 보여줘야 함 → onPlayStart 즉시 발화 (typewriter 진행).
+            fireMeta(null);
+            firePlayStart();
             return Promise.resolve();
         }
         if (!window.Api || !window.Api.Voice) {
-            if (opts && opts.onMeta) opts.onMeta(null);
+            fireMeta(null);
+            firePlayStart();
             return Promise.resolve();
         }
         stopCurrentAudio();
         return window.Api.Voice.synthesize(text)
             .then((blob) => {
                 if (!blob || (signal && signal.aborted)) {
-                    if (opts && opts.onMeta) opts.onMeta(null);
+                    fireMeta(null);
+                    // blob 없음(서버 무응답) — 텍스트는 보여줘야 함. abort 시엔 자동으로 skip.
+                    if (!blob) firePlayStart();
                     return;
                 }
                 const url = URL.createObjectURL(blob);
@@ -308,18 +332,14 @@
                         if (metaTimer) { clearTimeout(metaTimer); metaTimer = null; }
                         if (signal && signal.aborted) { finish(); return; }
                         const d = isFinite(audio.duration) ? audio.duration : null;
-                        if (opts && opts.onMeta) {
-                            try { opts.onMeta(d); } catch (_) {}
-                        }
-                        // play() 가 실제 재생 시작에 resolve — 그때 onPlayStart 발화
-                        // (talking 영상 전환 등 TTS 와 동기화될 동작을 여기서 트리거)
+                        fireMeta(d);
+                        // play() resolve = 실제 재생 시작 — onPlayStart 발화
                         audio.play().then(() => {
-                            if (signal && signal.aborted) return;
-                            if (opts && opts.onPlayStart) {
-                                try { opts.onPlayStart(); } catch (_) {}
-                            }
+                            firePlayStart();
                         }).catch((e) => {
                             console.warn('[A01] TTS 재생 실패', e);
+                            // 재생 실패해도 텍스트는 보여줘야 함
+                            firePlayStart();
                             finish();
                         });
                     };
@@ -338,7 +358,8 @@
             })
             .catch((e) => {
                 console.warn('[A01] TTS 합성 실패', e);
-                if (opts && opts.onMeta) opts.onMeta(null);
+                fireMeta(null);
+                firePlayStart();   // 합성 실패해도 텍스트는 보여줘야 함
             });
     }
 
@@ -561,14 +582,30 @@
         function flushTts(sentence) {
             const s = (sentence || '').trim();
             if (!s) return;
-            // TTS 순서 보장 큐 — 직전 재생 끝난 뒤 다음 문장 합성/재생
-            // onPlayStart: 첫 문장 재생 시작 시점에 talking 영상 ON (이후는 no-op)
-            ttsQueue = ttsQueue.then(() => {
-                if (signal.aborted) return null;
-                return startTtsPlayback(s, signal, { onPlayStart: switchToTalking });
+            // TTS + typewriter 동기 큐 — 직전 재생/타이핑 끝난 뒤 다음 문장 진행.
+            // onPlayStart 시점에:
+            //   1) talking 영상 ON (첫 호출만)
+            //   2) TTS duration 기반 속도로 typewriter 시작 → 글자가 소리와 함께 노출됨
+            //   3) 0.88 배율로 TTS 보다 약간 빠르게 (글자 다 보인 후 소리 살짝 더)
+            ttsQueue = ttsQueue.then(async () => {
+                if (signal.aborted) return;
+                let duration = null;
+                let typePromise = Promise.resolve();
+                const playPromise = startTtsPlayback(s, signal, {
+                    onMeta: (d) => { duration = d; },
+                    onPlayStart: () => {
+                        switchToTalking();
+                        const base = (duration && duration > 0 && s.length > 0)
+                            ? (duration * 1000 * 0.88) / s.length
+                            : 70;   // duration 없을 때(무음/실패) 기본 속도
+                        const speed = Math.max(28, Math.min(180, base));
+                        typePromise = typeChunk(s, speed, signal);
+                    },
+                });
+                await playPromise;
+                await typePromise;   // 글자가 미완이면 끝까지 기다림
             }).catch((e) => {
-                console.warn('[A01] TTS 큐 실패', e);
-                return null;
+                console.warn('[A01] TTS/typewriter 큐 실패', e);
             });
         }
 
@@ -584,8 +621,8 @@
                         receivedAnyToken = true;
                         fullText += chunk;
                         sentenceBuf += chunk;
-                        $bubbleText.textContent += chunk;
-                        // 한국어/영문 문장 경계 — 마침표 류 + 공백 또는 끝
+                        // 글자는 화면에 즉시 X — flushTts 큐 안에서 TTS 와 sync 된 typewriter 가 노출.
+                        // 문장 경계에 도달하면 해당 문장을 TTS + typewriter 큐에 넣음.
                         if (/[.!?…](\s|$)/.test(sentenceBuf)) {
                             flushTts(sentenceBuf);
                             sentenceBuf = '';
@@ -597,9 +634,9 @@
                             flushTts(sentenceBuf);
                             sentenceBuf = '';
                         }
-                        // OOD(clarify_responder): 토큰 없이 done 만 — reply 로 fallback
+                        // OOD(clarify_responder): 토큰 없이 done 만 — reply 로 fallback.
+                        // 즉시 표시 X — flushTts 큐 안 typewriter 가 TTS 와 sync 해서 노출.
                         if (!receivedAnyToken && res && res.reply) {
-                            $bubbleText.textContent = res.reply;
                             fullText = res.reply;
                             flushTts(res.reply);
                         }

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -245,54 +245,84 @@
 
     /**
      * Google TTS 호출 → Audio 재생.
-     * @returns {Promise<number|null>} 음성 길이(초). 실패/뮤트 시 null.
-     *   typewriter 속도 동기화에 사용.
+     * 반환 Promise 는 "재생 종료(audio.ended) / abort / 합성 실패" 시점에 resolve.
+     * → 호출자(특히 ttsQueue 체인) 가 진짜로 재생 끝난 뒤 다음 단계로 진행하도록 보장.
+     * → 마이크 ON(endTurn) 을 재생 도중에 켜서 STT 가 TTS echo 를 듣는 문제 방지.
+     *
+     * duration(초) 은 typewriter 속도 동기화에 필요 — 메타데이터 시점 즉시 opts.onMeta(d) 콜백으로 전달.
+     *
+     * @param {string} text
+     * @param {AbortSignal} [signal]
+     * @param {{onMeta?: (duration:number|null)=>void}} [opts]
+     * @returns {Promise<void>} 재생 종료 시점에 resolve
      */
-    function startTtsPlayback(text, signal) {
-        if (state.muted) return Promise.resolve(null);
-        if (!window.Api || !window.Api.Voice) return Promise.resolve(null);
+    function startTtsPlayback(text, signal, opts) {
+        if (state.muted) {
+            if (opts && opts.onMeta) opts.onMeta(null);
+            return Promise.resolve();
+        }
+        if (!window.Api || !window.Api.Voice) {
+            if (opts && opts.onMeta) opts.onMeta(null);
+            return Promise.resolve();
+        }
         stopCurrentAudio();
         return window.Api.Voice.synthesize(text)
             .then((blob) => {
-                if (!blob || (signal && signal.aborted)) return null;
+                if (!blob || (signal && signal.aborted)) {
+                    if (opts && opts.onMeta) opts.onMeta(null);
+                    return;
+                }
                 const url = URL.createObjectURL(blob);
                 const audio = new Audio(url);
                 audio.muted = state.muted;
                 state.currentAudio = audio;
                 state.currentAudioUrl = url;
-                audio.addEventListener('ended', () => {
-                    if (state.currentAudio === audio) stopCurrentAudio();
-                });
-                if (signal) {
-                    signal.addEventListener('abort', () => {
+
+                return new Promise((resolveEnded) => {
+                    let settled = false;
+                    const finish = () => {
+                        if (settled) return;
+                        settled = true;
                         if (state.currentAudio === audio) stopCurrentAudio();
-                    }, { once: true });
-                }
-                // metadata 로드 후 duration 확보 + 재생 시작
-                return new Promise((resolve) => {
+                        resolveEnded();
+                    };
+
+                    audio.addEventListener('ended', finish);
+                    audio.addEventListener('error', (e) => {
+                        console.warn('[A01] TTS audio error', e);
+                        finish();
+                    });
+                    if (signal) {
+                        signal.addEventListener('abort', finish, { once: true });
+                    }
+
                     const onMeta = () => {
                         audio.removeEventListener('loadedmetadata', onMeta);
-                        // 로딩 중 사용자가 끼어들었다면 재생 시작 X
-                        if (signal && signal.aborted) {
-                            if (state.currentAudio === audio) stopCurrentAudio();
-                            resolve(null);
-                            return;
-                        }
+                        if (signal && signal.aborted) { finish(); return; }
                         const d = isFinite(audio.duration) ? audio.duration : null;
-                        audio.play().catch((e) => console.warn('[A01] TTS 재생 실패', e));
-                        resolve(d);
+                        if (opts && opts.onMeta) {
+                            try { opts.onMeta(d); } catch (_) {}
+                        }
+                        audio.play().catch((e) => {
+                            console.warn('[A01] TTS 재생 실패', e);
+                            finish();
+                        });
                     };
                     audio.addEventListener('loadedmetadata', onMeta);
-                    // 1.5s 안전 타임아웃 — metadata 못 받아도 typewriter 시작
+
+                    // 메타 못 받아도 호출자가 무한 대기 안 하게 안전 타임아웃 (8s)
+                    // — 재생 종료 의미라 1.5s 보다 길게 잡음. 실제 재생은 ended 가 우선 트리거.
                     setTimeout(() => {
-                        audio.removeEventListener('loadedmetadata', onMeta);
-                        resolve(isFinite(audio.duration) ? audio.duration : null);
-                    }, 1500);
+                        if (!settled) {
+                            console.warn('[A01] TTS 재생 타임아웃 (8s) — 강제 종료');
+                            finish();
+                        }
+                    }, 8000);
                 });
             })
             .catch((e) => {
                 console.warn('[A01] TTS 합성 실패', e);
-                return null;
+                if (opts && opts.onMeta) opts.onMeta(null);
             });
     }
 
@@ -301,18 +331,25 @@
 
         appendLog('ai', text);
 
-        // TTS 시작 + duration 받아서 typewriter 속도 동기화
-        const ttsPromise = startTtsPlayback(text, signal);
+        // TTS 재생 시작(메타 도착) 시점에 duration 받음 → typewriter 속도 동기화
+        // ttsPromise 자체는 재생 종료 시점에 resolve — typewriter 와 병렬 진행
+        let duration = null;
+        const ttsPromise = startTtsPlayback(text, signal, {
+            onMeta: (d) => { duration = d; },
+        });
         setAvatar('talking');
 
         try {
-            const duration = await ttsPromise;  // 초 단위 또는 null
             // typewriter 글자당 ms — TTS duration 으로 보정 (bias 0.95 살짝 빠르게)
+            // duration 은 메타 도착 시점에 채워지므로, 첫 글자 출력 전 마이크로타스크 한 번 양보
+            await Promise.resolve();
             let speed = 110; // 기본값 (TTS 실패 시 한국어 평균 발화 속도)
             if (duration && duration > 0 && text.length > 0) {
                 speed = Math.max(40, (duration * 1000 * 0.95) / text.length);
             }
             await typewriter(text, { speed, signal });
+            // 재생이 typewriter 보다 길면 끝날 때까지 대기 (마이크 ON 시점 일치)
+            await ttsPromise;
             await sleep(300, signal);
         } catch (e) {
             if (!e || e.name !== 'AbortError') throw e;
@@ -598,12 +635,19 @@
         // suggestions 칩 갱신
         renderChips(doneRes.suggestions);
 
-        // TTS 큐 끝나면 아바타 idle + 청취 재개
+        // TTS 큐 끝나면 아바타 idle + 청취 재개.
+        // 200ms 잔향 가드: 스피커 음향이 마이크로 되돌아오는 echo 안정화 시간.
+        // (abort 시엔 sleep 이 reject → catch 로 흡수, endTurn 호출 안 함)
         const finalize = () => {
-            ttsQueue.then(() => {
-                setAvatar('idle');
-                if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
-            });
+            ttsQueue
+                .then(() => sleep(200, signal))
+                .then(() => {
+                    setAvatar('idle');
+                    if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+                })
+                .catch(() => {
+                    setAvatar('idle');
+                });
         };
 
         // 옵션 시트는 즉시 열고 TTS 끝나면 청취 재개

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -280,9 +280,11 @@
 
                 return new Promise((resolveEnded) => {
                     let settled = false;
+                    let metaTimer = null;
                     const finish = () => {
                         if (settled) return;
                         settled = true;
+                        if (metaTimer) { clearTimeout(metaTimer); metaTimer = null; }
                         if (state.currentAudio === audio) stopCurrentAudio();
                         resolveEnded();
                     };
@@ -298,6 +300,8 @@
 
                     const onMeta = () => {
                         audio.removeEventListener('loadedmetadata', onMeta);
+                        // 메타 도착 → 재생 시작. 이 후로는 audio.ended 가 종료 시그널.
+                        if (metaTimer) { clearTimeout(metaTimer); metaTimer = null; }
                         if (signal && signal.aborted) { finish(); return; }
                         const d = isFinite(audio.duration) ? audio.duration : null;
                         if (opts && opts.onMeta) {
@@ -310,14 +314,15 @@
                     };
                     audio.addEventListener('loadedmetadata', onMeta);
 
-                    // 메타 못 받아도 호출자가 무한 대기 안 하게 안전 타임아웃 (8s)
-                    // — 재생 종료 의미라 1.5s 보다 길게 잡음. 실제 재생은 ended 가 우선 트리거.
-                    setTimeout(() => {
+                    // 메타데이터 로드 실패(네트워크/디코딩 에러) 시에만 발동하는 안전망.
+                    // 메타 도착 후엔 timer clear 됨 → 실제 재생 길이는 제한 없음
+                    // (긴 응답도 audio.ended 까지 끝까지 재생).
+                    metaTimer = setTimeout(() => {
                         if (!settled) {
-                            console.warn('[A01] TTS 재생 타임아웃 (8s) — 강제 종료');
+                            console.warn('[A01] TTS 메타데이터 로드 타임아웃 (5s) — 강제 종료');
                             finish();
                         }
-                    }, 8000);
+                    }, 5000);
                 });
             })
             .catch((e) => {

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -500,7 +500,12 @@
         // 빈 장바구니 + 종료/포기 의사 → /summary 로 라우팅 (FastAPI 우회).
         // (장바구니에 담긴 게 있으면 정상 흐름 유지 — FastAPI 가 결제/요약 단계로 안내)
         if (window.ReplyKeywords && window.ReplyKeywords.userWantsToQuit(text) && getCartCount() === 0) {
-            console.log('[A01] 빈 장바구니 + 종료 의사 → /summary 라우팅');
+            console.warn('[A01] quit-gate 발동 → /summary 라우팅', {
+                text,
+                cartCount: getCartCount(),
+                matchedQuit: window.ReplyKeywords.QUIT_PATTERN.test(text),
+                hasInquiry: window.ReplyKeywords.INQUIRY_PATTERN.test(text),
+            });
             appendLog('user', text);
             if (window.ConvEngine) window.ConvEngine.stop();
             AppState.set('CURRENT_STEP', 'P01');

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -254,7 +254,10 @@
      *
      * @param {string} text
      * @param {AbortSignal} [signal]
-     * @param {{onMeta?: (duration:number|null)=>void}} [opts]
+     * @param {{onMeta?: (duration:number|null)=>void, onPlayStart?: ()=>void}} [opts]
+     *   onMeta      — 메타데이터 로드 직후 (typewriter 속도 동기화용)
+     *   onPlayStart — audio.play() 가 resolve 된 직후 = 실제 소리 재생 시작 시점
+     *                 (talking 영상 전환 등 TTS 와 sync 되어야 할 동작)
      * @returns {Promise<void>} 재생 종료 시점에 resolve
      */
     function startTtsPlayback(text, signal, opts) {
@@ -308,7 +311,14 @@
                         if (opts && opts.onMeta) {
                             try { opts.onMeta(d); } catch (_) {}
                         }
-                        audio.play().catch((e) => {
+                        // play() 가 실제 재생 시작에 resolve — 그때 onPlayStart 발화
+                        // (talking 영상 전환 등 TTS 와 동기화될 동작을 여기서 트리거)
+                        audio.play().then(() => {
+                            if (signal && signal.aborted) return;
+                            if (opts && opts.onPlayStart) {
+                                try { opts.onPlayStart(); } catch (_) {}
+                            }
+                        }).catch((e) => {
                             console.warn('[A01] TTS 재생 실패', e);
                             finish();
                         });
@@ -339,11 +349,12 @@
 
         // TTS 재생 시작(메타 도착) 시점에 duration 받음 → typewriter 속도 동기화
         // ttsPromise 자체는 재생 종료 시점에 resolve — typewriter 와 병렬 진행
+        // onPlayStart: 실제 소리 재생 시점에 talking 영상 ON (그 전엔 idle 유지)
         let duration = null;
         const ttsPromise = startTtsPlayback(text, signal, {
             onMeta: (d) => { duration = d; },
+            onPlayStart: () => setAvatar('talking'),
         });
-        setAvatar('talking');
 
         try {
             // typewriter 글자당 ms — TTS duration 으로 보정 (bias 0.95 살짝 빠르게)
@@ -529,25 +540,32 @@
         state.speechAbort = new AbortController();
         const signal = state.speechAbort.signal;
 
-        // 말풍선 초기화 + 아바타 talking
+        // 말풍선 초기화 — 아바타는 idle 유지. TTS 실제 재생 시작될 때 talking 으로 전환.
         $bubble.classList.add('is-visible');
         $bubble.classList.remove('is-typing');
         $bubbleText.textContent = '';
-        setAvatar('talking');
 
         // SSE 스트리밍 누적 상태
         let sentenceBuf = '';
         let fullText = '';
         let receivedAnyToken = false;
         let ttsQueue = Promise.resolve();
+        let talkingShown = false;
+
+        const switchToTalking = () => {
+            if (talkingShown || signal.aborted) return;
+            talkingShown = true;
+            setAvatar('talking');
+        };
 
         function flushTts(sentence) {
             const s = (sentence || '').trim();
             if (!s) return;
             // TTS 순서 보장 큐 — 직전 재생 끝난 뒤 다음 문장 합성/재생
+            // onPlayStart: 첫 문장 재생 시작 시점에 talking 영상 ON (이후는 no-op)
             ttsQueue = ttsQueue.then(() => {
                 if (signal.aborted) return null;
-                return startTtsPlayback(s, signal);
+                return startTtsPlayback(s, signal, { onPlayStart: switchToTalking });
             }).catch((e) => {
                 console.warn('[A01] TTS 큐 실패', e);
                 return null;

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -87,6 +87,7 @@
     const $minicartFilled = document.querySelector('[data-minicart-filled]');
     const $minicartList   = document.querySelector('[data-minicart-list]');
     const $minicartTotal  = document.querySelector('[data-minicart-total]');
+    const $minicartCount  = document.querySelector('[data-minicart-count]');
 
     const $chipRow     = document.querySelector('[data-chip-row]');
     const $input       = document.querySelector('[data-input]');
@@ -827,6 +828,7 @@
         renderMinicart();
     }
 
+    /** 카드형 카트 렌더 (N02 스타일 참조) — 사진 상단, 가격 오버레이, 수량 스테퍼. */
     function renderMinicart() {
         if (!state.cart.items.length) {
             $minicartEmpty.hidden = false;
@@ -835,47 +837,146 @@
         }
         $minicartEmpty.hidden = true;
         $minicartFilled.hidden = false;
-        $minicartList.innerHTML = '';
-        state.cart.items.forEach((it) => {
-            const $li = document.createElement('li');
-            $li.className = 'a01__minicart-item';
-            const display = it.menuName || '';
-            const shortName = display.length > 6 ? display.slice(0, 6) + '…' : display;
-            const imgUrl = state.menuImageCache.get(it.menuId);
+        $minicartList.replaceChildren();
 
-            // 썸네일 — 이미지 또는 아이콘 (DOM API, XSS 방지)
-            const $thumb = document.createElement('span');
-            $thumb.className = 'a01__minicart-item-thumb';
-            const setIconFallback = () => {
-                $thumb.classList.add('a01__minicart-item-thumb--icon');
-                $thumb.replaceChildren();
-                const $icon = document.createElement('i');
-                $icon.className = 'xi xi-restaurant';
-                $icon.setAttribute('aria-hidden', 'true');
-                $thumb.appendChild($icon);
-            };
-            if (imgUrl) {
-                const $img = document.createElement('img');
-                $img.alt = '';
-                $img.src = imgUrl;  // setter, HTML 파싱 X
-                $img.addEventListener('error', setIconFallback);
-                $thumb.appendChild($img);
-            } else {
-                setIconFallback();
+        state.cart.items.forEach((it) => {
+            $minicartList.appendChild(buildMinicartCard(it));
+        });
+
+        $minicartCount.textContent = String(getCartCount());
+        $minicartTotal.textContent = fmtPrice(getCartTotal());
+    }
+
+    /** 단일 카드 DOM 생성 (XSS 방지 — innerHTML 대신 DOM API). */
+    function buildMinicartCard(it) {
+        const itemId = it.itemId;
+        const $li = document.createElement('li');
+        $li.className = 'a01__minicart-item';
+        $li.dataset.cartItem = itemId;
+
+        // 썸네일 + 가격 오버레이 + X 버튼
+        const $thumb = document.createElement('div');
+        $thumb.className = 'a01__minicart-item-thumb';
+        const imgUrl = it.imageUrl || state.menuImageCache.get(it.menuId);
+        const setIconFallback = () => {
+            $thumb.classList.add('a01__minicart-item-thumb--icon');
+            // 가격/X 노드는 유지하고 img/i 만 갈아끼움
+            const old = $thumb.querySelector('img, i');
+            if (old) old.remove();
+            const $icon = document.createElement('i');
+            $icon.className = 'xi xi-restaurant';
+            $icon.setAttribute('aria-hidden', 'true');
+            $thumb.prepend($icon);
+        };
+        if (imgUrl) {
+            const $img = document.createElement('img');
+            $img.alt = '';
+            $img.src = imgUrl;
+            $img.addEventListener('error', setIconFallback);
+            $thumb.appendChild($img);
+        } else {
+            setIconFallback();
+        }
+
+        // 가격 오버레이 — 우하단
+        const $price = document.createElement('span');
+        $price.className = 'a01__minicart-item-price-overlay';
+        $price.textContent = fmtPrice(it.itemTotal != null ? it.itemTotal : (it.unitPrice || 0) * (it.quantity || 1));
+        $thumb.appendChild($price);
+
+        // 삭제 버튼 — 우상단
+        const $remove = document.createElement('button');
+        $remove.type = 'button';
+        $remove.className = 'a01__minicart-item-remove';
+        $remove.dataset.cartRemove = itemId;
+        $remove.setAttribute('aria-label', '삭제');
+        const $closeIcon = document.createElement('i');
+        $closeIcon.className = 'xi xi-close-thin';
+        $closeIcon.setAttribute('aria-hidden', 'true');
+        $remove.appendChild($closeIcon);
+        $thumb.appendChild($remove);
+
+        // 본문 — 이름 + 수량 스테퍼
+        const $body = document.createElement('div');
+        $body.className = 'a01__minicart-item-body';
+
+        const $name = document.createElement('span');
+        $name.className = 'a01__minicart-item-name';
+        $name.textContent = it.menuName || '';
+        $body.appendChild($name);
+
+        const $stepper = document.createElement('div');
+        $stepper.className = 'a01__minicart-stepper';
+        const qty = it.quantity || 1;
+        const $minus = document.createElement('button');
+        $minus.type = 'button';
+        $minus.className = 'a01__minicart-stepper-btn';
+        $minus.dataset.cartQty = itemId;
+        $minus.dataset.delta = '-1';
+        $minus.setAttribute('aria-label', '수량 감소');
+        $minus.textContent = '−';
+        if (qty <= 1) $minus.disabled = true;   // 1 에서 −는 삭제로 유도 (X 버튼)
+
+        const $val = document.createElement('span');
+        $val.className = 'a01__minicart-stepper-value';
+        $val.textContent = String(qty);
+
+        const $plus = document.createElement('button');
+        $plus.type = 'button';
+        $plus.className = 'a01__minicart-stepper-btn';
+        $plus.dataset.cartQty = itemId;
+        $plus.dataset.delta = '1';
+        $plus.setAttribute('aria-label', '수량 증가');
+        $plus.textContent = '+';
+
+        $stepper.append($minus, $val, $plus);
+        $body.appendChild($stepper);
+
+        $li.append($thumb, $body);
+        return $li;
+    }
+
+    /** 미니카트 클릭 위임 — 수량 +/− 및 삭제. 한 번 등록. */
+    function bindMinicartHandlers() {
+        if (!$minicartList || $minicartList.dataset.bound === '1') return;
+        $minicartList.dataset.bound = '1';
+        $minicartList.addEventListener('click', async (e) => {
+            const target = e.target.closest('[data-cart-remove], [data-cart-qty]');
+            if (!target) return;
+            if (!state.sessionId) return;
+
+            if (target.dataset.cartRemove) {
+                const itemId = target.dataset.cartRemove;
+                target.disabled = true;
+                const cartResp = await callApi('항목 삭제', () =>
+                    window.Api.cart.removeItem(state.sessionId, itemId)
+                );
+                if (cartResp) applyCartResponse(cartResp);
+                return;
             }
 
-            const $name = document.createElement('span');
-            $name.className = 'a01__minicart-item-name';
-            $name.textContent = shortName;
-
-            const $qty = document.createElement('span');
-            $qty.className = 'a01__minicart-item-qty';
-            $qty.textContent = '×' + (it.quantity || 1);
-
-            $li.append($thumb, $name, $qty);
-            $minicartList.appendChild($li);
+            if (target.dataset.cartQty) {
+                const itemId = target.dataset.cartQty;
+                const delta = Number(target.dataset.delta || 0);
+                const item = state.cart.items.find((it) => it.itemId === itemId);
+                if (!item) return;
+                const next = (item.quantity || 1) + delta;
+                if (next <= 0) {
+                    // 0 이하는 삭제로 처리 (현재는 −가 1에서 disabled 라 거의 도달 X)
+                    target.disabled = true;
+                    const cartResp = await callApi('항목 삭제', () =>
+                        window.Api.cart.removeItem(state.sessionId, itemId)
+                    );
+                    if (cartResp) applyCartResponse(cartResp);
+                    return;
+                }
+                target.disabled = true;
+                const cartResp = await callApi('수량 변경', () =>
+                    window.Api.cart.updateItem(state.sessionId, itemId, next)
+                );
+                if (cartResp) applyCartResponse(cartResp);
+            }
         });
-        $minicartTotal.textContent = fmtPrice(getCartTotal());
     }
 
     // ========================================================
@@ -1209,6 +1310,7 @@
         renderMinicart();
         renderSteps();
         renderChips();
+        bindMinicartHandlers();
         bind();
         bootVideos();
 

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -496,6 +496,17 @@
             return;
         }
 
+        // 빈 장바구니 + 종료/포기 의사 → /summary 로 라우팅 (FastAPI 우회).
+        // (장바구니에 담긴 게 있으면 정상 흐름 유지 — FastAPI 가 결제/요약 단계로 안내)
+        if (window.ReplyKeywords && window.ReplyKeywords.userWantsToQuit(text) && getCartCount() === 0) {
+            console.log('[A01] 빈 장바구니 + 종료 의사 → /summary 라우팅');
+            appendLog('user', text);
+            if (window.ConvEngine) window.ConvEngine.stop();
+            AppState.set('CURRENT_STEP', 'P01');
+            location.href = '/summary';
+            return;
+        }
+
         // 추천 시트 열려있을 때 음성을 자연어로 변환 후 시트 닫음.
         let chatText = text;
         const mapped = matchRecommendVoice(text);
@@ -1085,6 +1096,14 @@
         return null;
     }
 
+    /** LISTENING 진입 후 listenTimeoutMs 안에 한 마디도 안 들리면 호출됨.
+     *  ConvEngine 이 stop() 으로 INACTIVE 전환 + recognition 종료까지 처리 완료된 상태. */
+    function onConvListenTimeout() {
+        console.log('[A01] 발화 없음 → 자동 청취 종료');
+        setAvatar('idle');
+        showToast('한참 기다렸어요. 마이크 버튼을 다시 눌러주세요.');
+    }
+
     /** 사용자 발화 interim(실시간 부분) — 입력바에 표시. */
     function onConvInterim(text) {
         if (!$input) return;
@@ -1205,7 +1224,9 @@
             onInterim: onConvInterim,
             onSilencePrompt: onConvSilencePrompt,
             onModeChange: onConvModeChange,
-            onBargeIn: onConvBargeIn
+            onBargeIn: onConvBargeIn,
+            onListenTimeout: onConvListenTimeout,
+            listenTimeoutMs: 80000   // 80초 안에 한 마디도 안 들리면 자동 종료
         });
 
         onConvModeChange('INACTIVE');

--- a/src/main/resources/static/front/js/flowA/conversation-engine.js
+++ b/src/main/resources/static/front/js/flowA/conversation-engine.js
@@ -40,8 +40,13 @@
         onInterim: null,         // (text) => void          — partial result (실시간)
         onSilencePrompt: null,   // () => string | null
         onBargeIn: null,
-        onModeChange: null
+        onModeChange: null,
+        onListenTimeout: null    // () => void  — listenTimeoutMs 안에 한 마디도 안 들리면 호출
     };
+
+    // LISTENING 진입 후 한 마디도 안 들렸을 때 자동 종료까지의 시간(ms).
+    // init({ listenTimeoutMs: N }) 으로 호스트가 설정. null/0 = 무제한.
+    let listenTimeoutMs = null;
 
     const state = {
         mode: MODE.INACTIVE,
@@ -52,6 +57,7 @@
         finalAccum: '',
         interimAccum: '',
         lastInterimAt: 0,
+        listenStartedAt: 0,      // LISTENING 진입 시각 — interim 도착 시 갱신, timeout 비교 기준
         silenceTimer: null,
         wantsRunning: false,
         startScheduled: false
@@ -95,6 +101,10 @@
             }
             state.interimAccum = interim;
             state.lastInterimAt = Date.now();
+            // 발화 시작 감지 → listenStartedAt 도 갱신해서 listenTimeout 안 터지게 함
+            if (interim || state.finalAccum) {
+                state.listenStartedAt = Date.now();
+            }
 
             // 실시간 interim 콘솔 + 콜백
             if (interim) {
@@ -195,6 +205,21 @@
         state.lastInterimAt = Date.now();
         state.silenceTimer = setInterval(() => {
             if (state.mode !== MODE.LISTENING) return;
+
+            // listenTimeoutMs 도달 — LISTENING 진입 후 한 마디도 안 들렸을 때 종료
+            // (발화 시작했으면 onresult 에서 listenStartedAt 갱신되어 여기 통과 안 함)
+            if (listenTimeoutMs && state.listenStartedAt &&
+                Date.now() - state.listenStartedAt >= listenTimeoutMs) {
+                console.log(LOG, '⏱️ 발화 시작 대기 시간 초과 → 자동 종료', listenTimeoutMs, 'ms');
+                _clearSilenceTimer();
+                stop();
+                if (handlers.onListenTimeout) {
+                    try { handlers.onListenTimeout(); }
+                    catch (e) { console.warn(LOG, 'onListenTimeout 처리 실패', e); }
+                }
+                return;
+            }
+
             if (Date.now() - state.lastInterimAt < SILENCE_MS) return;
             _clearSilenceTimer();
 
@@ -249,8 +274,14 @@
     // ----------------------------------------------------
 
     function init(opts) {
-        handlers = Object.assign({}, handlers, opts || {});
-        console.log(LOG, '초기화 — 음성인식 지원:', state.supported);
+        const o = opts || {};
+        // listenTimeoutMs 옵션 분리 — 핸들러가 아니라 모듈 설정값
+        if (Object.prototype.hasOwnProperty.call(o, 'listenTimeoutMs')) {
+            listenTimeoutMs = o.listenTimeoutMs || null;
+        }
+        handlers = Object.assign({}, handlers, o);
+        console.log(LOG, '초기화 — 음성인식 지원:', state.supported,
+            '| listenTimeoutMs:', listenTimeoutMs || 'unlimited');
     }
 
     function start() {
@@ -303,6 +334,7 @@
         setMode(MODE.LISTENING);
         state.finalAccum = '';
         state.interimAccum = '';
+        state.listenStartedAt = Date.now();   // 발화 대기 타이머 기준점
         if (state.supported) {
             _ensureRecognition();
             _scheduleStart();
@@ -338,6 +370,7 @@
             setMode(MODE.LISTENING);
             state.finalAccum = '';
             state.interimAccum = '';
+            state.listenStartedAt = Date.now();   // 발화 대기 타이머 기준점
             if (state.supported) {
                 _ensureRecognition();
                 _scheduleStart();

--- a/src/main/resources/static/front/js/flowA/reply-keywords.js
+++ b/src/main/resources/static/front/js/flowA/reply-keywords.js
@@ -22,8 +22,12 @@
 
     const CART_PATTERN = /(담았어요|비웠어요|장바구니|담아드렸어요)/;
     const COMPLETE_PATTERN = /(결제가 완료|세션이 종료)/;
-    // 사용자 발화 — 대화 종료/주문 포기 의사. 빈 장바구니 상태에서 정상 종료 처리.
-    const QUIT_PATTERN = /(그만|끝낼래|끝낼게|끝낼래요|끝내자|끝내 ?줘|취소|종료|안 ?할래|안 ?할게|관둘래|관둬|그만 ?할래|그만 ?하고|나갈래|나갈게|그냥 ?나갈)/;
+    // 사용자 발화 — 명확한 종료/주문 포기 의사. 단어 단독("그만"/"끝"/"취소") 으로는 매칭 X.
+    // 의도가 분명한 어미 조합만 인식해서 조회/일반 대화의 false positive 차단.
+    const QUIT_PATTERN = /(그만 ?할(래|게|래요)|그만 ?하(자|고 ?싶)|그만 ?둘래|끝낼(래|게|래요)|끝내(자|줘|드려)|주문 ?(취소|그만|안 ?할게|안 ?할래)|관둘래|관둬|관두자|나갈래|나갈게|그냥 ?나갈|돌아갈래|돌아갈게)/;
+    // 조회/확인 의도 — QUIT 패턴과 함께 나오면 quit 무효화
+    // (예: "장바구니 확인", "메뉴 보여줘", "얼마야" — 의도는 결제 끝내기가 아님)
+    const INQUIRY_PATTERN = /(확인|보여|알려|얼마|뭐|어떻|어디|어느|있어|있나|있을|어때|볼래|볼게|구경|찾|추천)/;
 
     // step 추정 키워드
     const STEP_CHECKOUT_PATTERN = /(결제|마무리|주문할게|주문 확정|총 ?[\d,]+원|결제 ?화면)/;
@@ -40,9 +44,11 @@
         return COMPLETE_PATTERN.test(text);
     }
 
-    /** 사용자 발화에 대화 종료/주문 포기 의사가 있는지 매칭. */
+    /** 사용자 발화에 명확한 대화 종료/주문 포기 의사가 있는지 매칭.
+     *  조회/확인 의도가 같이 들어있으면 quit 의사 아님으로 본다. */
     function userWantsToQuit(text) {
         if (typeof text !== 'string' || text.length === 0) return false;
+        if (INQUIRY_PATTERN.test(text)) return false;
         return QUIT_PATTERN.test(text);
     }
 
@@ -61,6 +67,6 @@
 
     return {
         replyHasCartChange, replyHasComplete, userWantsToQuit, guessStep,
-        CART_PATTERN, COMPLETE_PATTERN, QUIT_PATTERN
+        CART_PATTERN, COMPLETE_PATTERN, QUIT_PATTERN, INQUIRY_PATTERN
     };
 });

--- a/src/main/resources/static/front/js/flowA/reply-keywords.js
+++ b/src/main/resources/static/front/js/flowA/reply-keywords.js
@@ -22,6 +22,8 @@
 
     const CART_PATTERN = /(담았어요|비웠어요|장바구니|담아드렸어요)/;
     const COMPLETE_PATTERN = /(결제가 완료|세션이 종료)/;
+    // 사용자 발화 — 대화 종료/주문 포기 의사. 빈 장바구니 상태에서 정상 종료 처리.
+    const QUIT_PATTERN = /(그만|끝낼래|끝낼게|끝낼래요|끝내자|끝내 ?줘|취소|종료|안 ?할래|안 ?할게|관둘래|관둬|그만 ?할래|그만 ?하고|나갈래|나갈게|그냥 ?나갈)/;
 
     // step 추정 키워드
     const STEP_CHECKOUT_PATTERN = /(결제|마무리|주문할게|주문 확정|총 ?[\d,]+원|결제 ?화면)/;
@@ -38,6 +40,12 @@
         return COMPLETE_PATTERN.test(text);
     }
 
+    /** 사용자 발화에 대화 종료/주문 포기 의사가 있는지 매칭. */
+    function userWantsToQuit(text) {
+        if (typeof text !== 'string' || text.length === 0) return false;
+        return QUIT_PATTERN.test(text);
+    }
+
     /**
      * reply 텍스트 → 단계 추정. 서버 currentStep 미제공 시 fallback.
      * BROWSE 는 부트 기본값으로 두고 적극 추정 X — 반환 X.
@@ -52,7 +60,7 @@
     }
 
     return {
-        replyHasCartChange, replyHasComplete, guessStep,
-        CART_PATTERN, COMPLETE_PATTERN
+        replyHasCartChange, replyHasComplete, userWantsToQuit, guessStep,
+        CART_PATTERN, COMPLETE_PATTERN, QUIT_PATTERN
     };
 });

--- a/src/main/resources/templates_front/flowA/A01-avatar.html
+++ b/src/main/resources/templates_front/flowA/A01-avatar.html
@@ -124,23 +124,33 @@
     </section>
 
     <!-- ========================================================
-         ⑤ 미니 카트 + 빠른응답 칩 (140px)
+         ⑤ 미니 카트 + 빠른응답 칩 (220px) — 카드형 카트 + 수량 조절
          ======================================================== -->
     <section class="a01__quickbar fade-up" style="--delay: 320ms;">
         <!-- 미니 카트 -->
         <div class="a01__minicart" data-minicart>
+            <!-- 빈 상태 -->
             <div class="a01__minicart-empty" data-minicart-empty>
                 <i class="xi xi-cart" aria-hidden="true"></i>
                 <span>아직 담은 메뉴가 없어요</span>
             </div>
+
+            <!-- 채워진 상태 -->
             <div class="a01__minicart-filled" data-minicart-filled hidden>
-                <ul class="a01__minicart-list" data-minicart-list>
-                    <!-- JS 동적 -->
-                </ul>
-                <div class="a01__minicart-total">
-                    <span class="a01__minicart-total-label">합계</span>
-                    <span class="a01__minicart-total-value" data-minicart-total>₩ 0</span>
+                <div class="a01__minicart-head">
+                    <div class="a01__minicart-head-left">
+                        <i class="xi xi-cart" aria-hidden="true"></i>
+                        <span>장바구니</span>
+                        <span class="a01__minicart-count" data-minicart-count>0</span>
+                    </div>
+                    <div class="a01__minicart-head-right">
+                        <span class="a01__minicart-total-label">합계</span>
+                        <span class="a01__minicart-total-value" data-minicart-total>₩ 0</span>
+                    </div>
                 </div>
+                <ul class="a01__minicart-track" data-minicart-list>
+                    <!-- JS 동적 — 카드형 항목 -->
+                </ul>
             </div>
         </div>
 

--- a/src/main/resources/templates_front/flowA/A01-avatar.html
+++ b/src/main/resources/templates_front/flowA/A01-avatar.html
@@ -185,6 +185,7 @@
 <script src="/lib/jquery-3.7.0.min.js"></script>
 <script src="/js/common/confirm-modal.js"></script>
 <script src="/js/common/app-state.js"></script>
+<script src="/js/common/sse-parser.js"></script>
 <script src="/js/common/api.js"></script>
 <script src="/js/common/ai-action.js"></script>
 <script src="/js/flowA/reply-keywords.js"></script>

--- a/tests/sse-parser.test.js
+++ b/tests/sse-parser.test.js
@@ -1,0 +1,233 @@
+// sse-parser.test.js — /ai/order/chat/stream 응답 파싱 단위 테스트.
+// Node 기본 test runner (`node --test`) 로 실행.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    parseEventBlock,
+    dispatchEvent,
+    consume,
+    feedChunk,
+} = require('../src/main/resources/static/front/js/common/sse-parser.js');
+
+// ---------- parseEventBlock ----------
+describe('parseEventBlock', () => {
+    it('단일 라인 data: 정상 파싱', () => {
+        const ev = parseEventBlock('data: {"type":"token","text":"오늘"}');
+        assert.deepEqual(ev, { type: 'token', text: '오늘' });
+    });
+
+    it('"data:" 뒤 공백이 없어도 파싱 (SSE 스펙 허용)', () => {
+        const ev = parseEventBlock('data:{"type":"token","text":"x"}');
+        assert.deepEqual(ev, { type: 'token', text: 'x' });
+    });
+
+    it('멀티라인 data: 누적', () => {
+        const block = 'data: {"type":"done",\ndata: "reply":"안녕"}';
+        const ev = parseEventBlock(block);
+        assert.deepEqual(ev, { type: 'done', reply: '안녕' });
+    });
+
+    it('data 가 아닌 라인은 무시 (event/id/retry/주석)', () => {
+        const block = 'event: token\nid: 1\n: 주석\ndata: {"type":"token","text":"y"}';
+        const ev = parseEventBlock(block);
+        assert.deepEqual(ev, { type: 'token', text: 'y' });
+    });
+
+    it('잘못된 JSON 은 null', () => {
+        assert.equal(parseEventBlock('data: not json'), null);
+    });
+
+    it('빈 블록은 null', () => {
+        assert.equal(parseEventBlock(''), null);
+        assert.equal(parseEventBlock('\n\n'), null);
+    });
+});
+
+// ---------- dispatchEvent ----------
+describe('dispatchEvent', () => {
+    it('token 이벤트 → onToken(text)', () => {
+        let received;
+        dispatchEvent({ type: 'token', text: '메뉴' }, {
+            onToken: (t) => { received = t; },
+        });
+        assert.equal(received, '메뉴');
+    });
+
+    it('done 이벤트 → onDone(전체 객체)', () => {
+        let received;
+        const ev = { type: 'done', reply: '안녕', recommendations: [{ menu_id: 1 }] };
+        dispatchEvent(ev, { onDone: (d) => { received = d; } });
+        assert.deepEqual(received, ev);
+    });
+
+    it('error 이벤트 → onError(message)', () => {
+        let received;
+        dispatchEvent({ type: 'error', message: '실패' }, {
+            onError: (m) => { received = m; },
+        });
+        assert.equal(received, '실패');
+    });
+
+    it('알 수 없는 type (kept_alive 등) 은 무시', () => {
+        let called = false;
+        dispatchEvent({ type: 'kept_alive' }, {
+            onToken: () => { called = true; },
+            onDone:  () => { called = true; },
+            onError: () => { called = true; },
+        });
+        assert.equal(called, false);
+    });
+
+    it('text 누락 token → 빈 문자열로 호출', () => {
+        let received;
+        dispatchEvent({ type: 'token' }, { onToken: (t) => { received = t; } });
+        assert.equal(received, '');
+    });
+
+    it('message 누락 error → 기본 메시지', () => {
+        let received;
+        dispatchEvent({ type: 'error' }, { onError: (m) => { received = m; } });
+        assert.equal(received, '오류가 발생했습니다.');
+    });
+
+    it('핸들러 미정의 시 noop (throw 없음)', () => {
+        assert.doesNotThrow(() => {
+            dispatchEvent({ type: 'token', text: 'x' }, {});
+        });
+    });
+
+    it('null 이벤트는 무시', () => {
+        assert.doesNotThrow(() => {
+            dispatchEvent(null, { onToken: () => { throw new Error('called'); } });
+        });
+    });
+});
+
+// ---------- feedChunk ----------
+describe('feedChunk', () => {
+    it('완전한 이벤트 1개 → 콜백 1회 호출, remainder 빈 문자열', () => {
+        const got = [];
+        const rem = feedChunk('data: {"type":"token","text":"a"}\n\n', '', (ev) => got.push(ev));
+        assert.equal(got.length, 1);
+        assert.equal(got[0].text, 'a');
+        assert.equal(rem, '');
+    });
+
+    it('이벤트 2개 + 미완성 1개 → 콜백 2회, remainder 에 미완성 보관', () => {
+        const got = [];
+        const chunk = 'data: {"type":"token","text":"a"}\n\n'
+                    + 'data: {"type":"token","text":"b"}\n\n'
+                    + 'data: {"type":"to';
+        const rem = feedChunk(chunk, '', (ev) => got.push(ev));
+        assert.equal(got.length, 2);
+        assert.equal(rem, 'data: {"type":"to');
+    });
+
+    it('청크 경계가 이벤트 중간에 떨어져도 prevBuf 와 합쳐 처리', () => {
+        const got = [];
+        // 1차: 미완성 끝
+        let buf = feedChunk('data: {"type":"to', '', (ev) => got.push(ev));
+        assert.equal(got.length, 0);
+        // 2차: 나머지가 들어와 완성
+        buf = feedChunk('ken","text":"x"}\n\n', buf, (ev) => got.push(ev));
+        assert.equal(got.length, 1);
+        assert.equal(got[0].text, 'x');
+        assert.equal(buf, '');
+    });
+
+    it('JSON 파싱 실패 라인은 건너뛰고 다음 이벤트는 정상 처리', () => {
+        const got = [];
+        const chunk = 'data: not json\n\ndata: {"type":"token","text":"ok"}\n\n';
+        feedChunk(chunk, '', (ev) => got.push(ev));
+        assert.equal(got.length, 1);
+        assert.equal(got[0].text, 'ok');
+    });
+
+    it('done 이벤트의 복합 payload 도 그대로 파싱', () => {
+        const got = [];
+        const block = 'data: {"type":"done","reply":"안녕","recommendations":[{"menu_id":13}],"action":{"type":"highlight_menu","menu_id":13},"current_step":"SELECT"}\n\n';
+        feedChunk(block, '', (ev) => got.push(ev));
+        assert.equal(got.length, 1);
+        assert.equal(got[0].type, 'done');
+        assert.equal(got[0].reply, '안녕');
+        assert.equal(got[0].recommendations[0].menu_id, 13);
+        assert.equal(got[0].action.type, 'highlight_menu');
+        assert.equal(got[0].current_step, 'SELECT');
+    });
+});
+
+// ---------- consume (ReadableStream 통합) ----------
+describe('consume', () => {
+    /** 청크 배열을 ReadableStream 으로 감싸는 헬퍼. */
+    function streamOf(chunks) {
+        const enc = new TextEncoder();
+        let i = 0;
+        return new ReadableStream({
+            pull(controller) {
+                if (i < chunks.length) {
+                    controller.enqueue(enc.encode(chunks[i++]));
+                } else {
+                    controller.close();
+                }
+            },
+        });
+    }
+
+    it('token → done 순서 그대로 핸들러 호출', async () => {
+        const tokens = [];
+        let done;
+        const stream = streamOf([
+            'data: {"type":"token","text":"오늘"}\n\n',
+            'data: {"type":"token","text":" 인기"}\n\n',
+            'data: {"type":"done","reply":"오늘 인기 메뉴"}\n\n',
+        ]);
+        await consume(stream, {
+            onToken: (t) => tokens.push(t),
+            onDone:  (d) => { done = d; },
+        });
+        assert.deepEqual(tokens, ['오늘', ' 인기']);
+        assert.equal(done.reply, '오늘 인기 메뉴');
+    });
+
+    it('청크가 이벤트 중간에 잘려도 끝까지 파싱', async () => {
+        const tokens = [];
+        const stream = streamOf([
+            'data: {"type":"to',
+            'ken","text":"x"}\n\nda',
+            'ta: {"type":"token","text":"y"}\n\n',
+        ]);
+        await consume(stream, { onToken: (t) => tokens.push(t) });
+        assert.deepEqual(tokens, ['x', 'y']);
+    });
+
+    it('error 이벤트가 오면 onError 호출 (스트림은 정상 종료)', async () => {
+        let err;
+        const stream = streamOf([
+            'data: {"type":"error","message":"실패했어요"}\n\n',
+        ]);
+        await consume(stream, { onError: (m) => { err = m; } });
+        assert.equal(err, '실패했어요');
+    });
+
+    it('kept_alive 는 무시되고 다른 이벤트는 정상 처리', async () => {
+        const tokens = [];
+        const stream = streamOf([
+            'data: {"type":"kept_alive"}\n\n',
+            'data: {"type":"token","text":"z"}\n\n',
+        ]);
+        await consume(stream, { onToken: (t) => tokens.push(t) });
+        assert.deepEqual(tokens, ['z']);
+    });
+
+    it('마지막 이벤트에 끝 \\n\\n 이 없어도 처리 (close 시 잔여 buf flush)', async () => {
+        const tokens = [];
+        const stream = streamOf([
+            'data: {"type":"token","text":"a"}\n\n',
+            'data: {"type":"token","text":"b"}', // 끝 \n\n 없음
+        ]);
+        await consume(stream, { onToken: (t) => tokens.push(t) });
+        assert.deepEqual(tokens, ['a', 'b']);
+    });
+});

--- a/tests/sse-parser.test.js
+++ b/tests/sse-parser.test.js
@@ -156,6 +156,16 @@ describe('feedChunk', () => {
         assert.equal(got[0].action.type, 'highlight_menu');
         assert.equal(got[0].current_step, 'SELECT');
     });
+
+    it('CRLF(\\r\\n\\r\\n) 구분자도 LF 와 동일하게 처리 (SSE 스펙)', () => {
+        const got = [];
+        const block = 'data: {"type":"token","text":"안녕"}\r\n\r\ndata: {"type":"done","reply":"끝"}\r\n\r\n';
+        const remainder = feedChunk(block, '', (ev) => got.push(ev));
+        assert.equal(got.length, 2);
+        assert.deepEqual(got[0], { type: 'token', text: '안녕' });
+        assert.equal(got[1].type, 'done');
+        assert.equal(remainder, '');
+    });
 });
 
 // ---------- consume (ReadableStream 통합) ----------


### PR DESCRIPTION
## Summary

  A01 아바타 모드에서 FastAPI SSE 응답을 받아 TTS · 말풍선 · 영상 ·
  마이크 타이밍을 정렬하고, 미니 카트를 카드형 UI 로 재설계했습니다.
  대화 종료 시나리오와 발화 대기 타이머도 함께 보강했습니다.

  ### 1. SSE chatStream 클라이언트 (`/ai/order/chat/stream`)
  - `sse-parser.js` 신규 — `token` / `done` / `error` 이벤트 분리
  dispatch, 청크 경계 잔여 buf 이월, CRLF/LF 둘 다 처리
  - `api.js` `Ai.chatStream(body, handlers)` 신규 — fetch +
  ReadableStream 으로 토큰 단위 수신
  - `tests/sse-parser.test.js` 25 케이스 (Node `node --test`)

  ### 2. 말풍선 · TTS · 영상 동기화
  - TTS 재생 종료 시점에 마이크 ON (이전엔 재생 중 ON → STT 가 TTS
  echo 인식하던 문제 해결)
  - talking 영상은 **실제 audio.play() resolve 시점**에 전환 (이전엔
  응답 도착 직후 전환되어 입만 움직이는 무음 구간 발생)
  - 말풍선 typewriter 를 TTS duration 기반 속도로 진행 (TTS 보다 약
  12% 빠르게)
  - 잔향 가드 200ms (재생 종료 후 마이크 ON 직전 echo cancellation
  안정화 시간)

  ### 3. 미니 카트 카드형 재설계 (N02 스타일 참고)
  - 36px 칩형 → 152px 카드형. 음식 사진 상단(78px), 우상단 X 삭제,
  우하단 가격 오버레이, 본문 메뉴명 + 수량 스테퍼(− 값 +)
  - 그리드 재배분: 아바타 720 → 640, 퀵바 140 → 220 (총 합 1280 유지)
  - 수량 ±, 삭제 모두 Spring 카트 API 직접 호출 (`PUT/DELETE
  /api/orders/cart/...`), 응답 즉시 반영

  ### 4. 발화 대기 80초 타이머
  - LISTENING 진입 후 한 마디도 안 들리면 80초 후 자동 종료 + 토스트
  - 발화 시작(interim 도착)하면 타이머 리셋 — 발화 중간 멈춤은 영향
  없음

  ### 5. 빈 장바구니 + 종료 의사 → /summary 라우팅
  - `reply-keywords.js` 에 `QUIT_PATTERN` + `INQUIRY_PATTERN` 추가
  - 명확한 종료 어미만 매칭 (`그만할래/끝낼게/주문
  취소/관둘래/나갈래` 등) + 조회 의도(`확인/보여/알려` 등) 있으면
  차단
  - 21/21 매칭 / 19/19 false-positive 차단 검증
  - 빈 카트일 때만 발동 — 담긴 게 있으면 정상 결제 흐름 유지

  ### 6. 기타
  - FastAPI 로컬 URL → `https://43-201-20-11.sslip.io` (raw IP 8000
  포트 닫혀있음 검증)
  - `.gitignore` 에 `*.pem`, `*.key` 추가 (SSH 키 커밋 차단)

  ## 🙏 Question & PR point

  - **백엔드 의존성**: 토큰 스트리밍은 추천/장문 경로에서만 동작.
  잡담/OOD 짧은 응답은 의도적으로 `done` 한 줄만 송신 (비용 절감
  설계로 확인됨). 프론트는 두 경로 모두 `onDone` 폴백 처리.
  - **세션 ID 공유**: A01 의 `state.sessionId === state.aiSessionId`
  동일 값. 카트 직접 호출(Spring) / AI 호출(FastAPI 경유) 모두 같은
  ID 사용.
  - **운영 키오스크 echo**: 잔향 가드 200ms 는 일반 노트북 환경 기준.
   운영 시 외부 스피커 환경에 따라 100~400ms 사이로 튜닝 권장.
  - **바지인 미적용**: TTS 재생 중 마이크 끄는 보수적 안 채택 (사용자
   의사). 헤드폰 환경에서 끼어들기 원하면 별도 작업 필요.
  - **테스트**: 정적 분석 + SSE 파서 단위 테스트만 자동화. 실제
  마이크 / TTS 동기는 브라우저 수동 검증 필요. 브라우저는 강력
  새로고침(Cmd+Shift+R) 권장.