### PR TITLE
[Feat] expose prometheus actuator endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,9 @@ dependencies {
 
 	implementation 'org.apache.poi:poi-ooxml:5.4.1'
 
+	// server 모니터링
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 }
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "nunchi-spring"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets:
+          - "host.docker.internal:8080"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -63,7 +63,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics
+        include: health,info,metrics,prometheus
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## 📣 Related Issue

- close #129 이슈번호

## 📝 Summary

- Spring Boot Actuator Prometheus metric endpoint를 노출했습니다.
- `micrometer-registry-prometheus` 의존성을 추가했습니다.
- dev 환경 Actuator 노출 endpoint에 `prometheus`를 추가했습니다.
- `/actuator/prometheus`에서 `http_server_requests_seconds_count`, `http_server_requests_seconds_sum`, `http_server_requests_seconds_max` metric이 정상 출력되는 것을 확인했습니다.
- Prometheus가 Spring Boot metric을 수집할 수 있도록 서버 모니터링 연동 기반을 구성했습니다.

## 🙏 Question & PR point

- 기존에는 `/actuator/metrics/http.server.requests`를 curl로 직접 조회해야 했지만, Prometheus 연동을 위해 `/actuator/prometheus` endpoint를 추가했습니다.
- 해당 endpoint는 Prometheus scrape 전용 metric 형식으로 출력됩니다.
- EC2 서버의 Prometheus target은 docker-compose 기준 Spring 서비스명인 `app:8080`으로 설정할 예정입니다.
- 현재 로컬에서는 `/actuator/prometheus` 정상 동작을 확인했으며, 서버 반영 후 Prometheus target 상태가 `UP`인지 추가 확인이 필요합니다.
- Grafana Dashboard에서는 API 요청 수, 평균 응답 시간, 최대 응답 시간, 에러율을 시각화할 예정입니다.

## 📬 Postman

- 별도 Postman 테스트는 없습니다.
- Actuator endpoint 확인은 curl로 진행했습니다.

```bash
curl http://localhost:8080/actuator/prometheus | grep http_server_requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 애플리케이션 메트릭 수집 및 모니터링 기능 추가
  * Prometheus 통합으로 서버 상태 실시간 추적 가능
  * 개발 환경에서 상세한 메트릭 노출

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->