### PR TITLE
feat: 영수증 프린트

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -70,3 +70,9 @@ management:
   metrics:
     tags:
       application: nunchi
+
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      percentiles:
+        "[http.server.requests]": 0.95, 0.99

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,6 +59,15 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    tags:
+      application: nunchi
+
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      percentiles:
+        "[http.server.requests]": 0.95, 0.99
 
 fastapi:
   base-url: ${LOCAL_FASTAPI_URL}

--- a/src/main/resources/static/front/js/flowP/P04-processing.js
+++ b/src/main/resources/static/front/js/flowP/P04-processing.js
@@ -190,6 +190,16 @@
             sessionStorage.setItem('orderId', String(orderId));
 
             try {
+                sessionStorage.setItem('printOrder', JSON.stringify({
+                    orderNumber: 'A-' + order.orderId,
+                    items: (order.items || []).map((item) => ({
+                        menuName: item.menuName || '',
+                        quantity: item.quantity || 0
+                    }))
+                }));
+            } catch (_) {}
+
+            try {
                 sessionStorage.setItem('orderSummary', JSON.stringify({
                     totalAmount: order.totalAmount,
                     itemCount:   (order.items || []).length,

--- a/src/main/resources/static/front/js/flowP/P05-complete.js
+++ b/src/main/resources/static/front/js/flowP/P05-complete.js
@@ -37,7 +37,7 @@
     const FLOW_KEYS_TO_CLEAR = [
         STORE_KEY, METHOD_KEY, STATUS_KEY, ORDERNO_KEY, ORDER_SUMMARY_KEY,
         SESSION_ID_KEY, 'mode', 'dineOption', 'currentFloor', 'currentStore',
-        'currentStep', 'orderId', 'paymentId'
+        'currentStep', 'orderId', 'paymentId', 'printOrder'
     ];
 
     function loadOrderSummary() {
@@ -129,16 +129,47 @@
         setTimeout(() => choose('receipt'), 20000);
     }
 
+    async function printOrderTicket(kind) {
+        const raw = sessionStorage.getItem('printOrder');
+        if (!raw) {
+            console.warn('[P05] printOrder 없음');
+            return;
+        }
+
+        const printOrder = JSON.parse(raw);
+
+        const items = (printOrder.items || []).map((item) => {
+            return `${item.menuName} x${item.quantity}`;
+        });
+
+        await fetch('http://localhost:9100/print', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                type: kind,
+                orderNumber: printOrder.orderNumber,
+                items: items
+            }),
+        });
+    }
     function afterOutputChosen(kind) {
         if (receiptTitleEl) {
             receiptTitleEl.textContent = kind === 'ticket'
                 ? '번호표가 출력되고 있어요'
                 : '영수증이 출력되고 있어요';
         }
+
+        printOrderTicket(kind).catch((e) => {
+            console.warn('[P05] 프린터 출력 실패', e);
+        });
+
         if (receiptEl) receiptEl.hidden = false;
         setTimeout(markReceiptDone, 3000);
         startCountdown();
     }
+
 
     /* ---------- Auto-reset countdown ---------- */
     const AUTO_SEC = 15;


### PR DESCRIPTION
## 📣 Related Issue

- close #134 

## 📝 Summary

키오스크 주문 완료 후 내장 영수증 프린터에서 주문번호표/영수증 출력이 가능하도록 프론트 출력 트리거를 추가했습니다.

이번 작업은 PG/VAN 결제 연동이 아닌, 시연용 주문 완료 흐름에서 로컬 프린터 출력 프로그램을 호출하는 방식입니다.

## 🙏 Question & PR point

- 키오스크 내장 프린터는 Windows 기준 `COM1` 포트로 출력되는 것을 확인했습니다.
- 실제 출력은 배포 서버가 아니라 키오스크 로컬에서 실행되는 `print_agent.py`가 담당합니다.
- 프론트는 주문 확정 후 주문 정보를 `sessionStorage`에 저장하고, 완료 화면에서 영수증/번호표 선택 시 `http://localhost:9100/print`를 호출합니다.
- `localhost:9100`은 배포 서버가 아니라 키오스크 자기 자신을 의미합니다.
- 출력 실패가 주문 완료 흐름을 막지 않도록 프론트에서는 예외를 `console.warn`으로 처리합니다.
- 키오스크 실사용 테스트 전에는 반드시 로컬 출력 서버를 실행해야 합니다.

```cmd
python C:\nunchi\print_agent.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주문 완료 후 영수증과 번호표를 자동으로 인쇄하는 기능이 추가되었습니다. 카드 결제 승인 후 주문 정보가 저장되고 프린터로 전송되어 인쇄됩니다.

* **Chores**
  * 애플리케이션 메트릭 모니터링을 위한 설정이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->