### PR TITLE
[Fix] 3차 QA — 결제 진행 애니메이션·하드웨어 영수증 출력·출력 버튼 정리

### DIFF
--- a/scripts/kiosk-launch.sh
+++ b/scripts/kiosk-launch.sh
@@ -17,11 +17,10 @@ CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 # 키오스크용 임시 프로필 (기존 개인 프로필과 분리)
 PROFILE_DIR="${TMPDIR:-/tmp}/nunchi-kiosk-profile"
 
-# 영수증 출력(P05)은 window.print() 로 80mm 감열 프린터에 인쇄한다 (js/common/receipt.js).
-# 운영(실매장)에서는 아래 --kiosk-printing 을 켜면 인쇄 대화상자 없이 OS 기본 프린터로
-# 즉시 발급된다. 이때 OS 기본 프린터를 영수증(감열) 프린터로 지정해 둘 것.
-# QA 단계에서는 주석 유지 → 인쇄 미리보기로 레이아웃만 확인. (QA2 #5)
-#   --kiosk-printing \
+# 영수증/번호표 출력(P05)은 크롬 인쇄가 아니라 로컬 프린트 에이전트(scripts/print_server.py,
+# 127.0.0.1:9100)로 텍스트 양식을 보내 실제 감열 프린터에 인쇄한다. (QA3 #2)
+# → 키오스크 PC 에서 print_server.py 와 print_ticket.bat 이 실행 중이어야 함.
+# (양식 미리보기만 보려면 브라우저 콘솔에서 NunchiReceipt.printPreview({...}) 사용)
 
 exec "$CHROME" \
   --kiosk "$URL" \

--- a/scripts/print_server.py
+++ b/scripts/print_server.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# ============================================================
+# print_server.py — NUNCHI 키오스크 로컬 프린트 에이전트 (감열 영수증 프린터)
+#
+# 역할:
+#   키오스크 프론트(receipt.js)가 POST /print 로 보낸 "텍스트 양식(lines)" 을
+#   CP949 로 인코딩해 ticket.txt 로 저장한 뒤, print_ticket.bat 으로 실제
+#   감열 프린터(WSP-CP383 등)에 인쇄한다.
+#
+# 요청 본문(JSON):
+#   {
+#     "type": "receipt" | "ticket",
+#     "orderNumber": "A-12",
+#     "lines": ["...영수증 한 줄...", "..."]   # 프론트에서 폭(32칸)에 맞춰 정렬한 양식
+#   }
+#   - lines 가 있으면 그대로 인쇄(프론트가 양식을 만든다).
+#   - lines 가 없으면(구버전 호출) 아래 build_ticket 의 기본 양식으로 폴백.
+#
+# 실행:  python print_server.py   (Windows, 키오스크 PC)
+# ============================================================
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import subprocess
+from pathlib import Path
+from datetime import datetime
+import traceback
+
+HOST = "127.0.0.1"
+PORT = 9100
+
+BASE_DIR = Path(r"C:\Users\G_Series\Desktop")
+TICKET_PATH = BASE_DIR / "ticket.txt"
+BAT_PATH = BASE_DIR / "print_ticket.bat"
+
+
+def safe_line(text, max_len=48):
+    if text is None:
+        return ""
+    text = str(text).replace("\r", " ").replace("\n", " ")
+    return text[:max_len]
+
+
+def build_ticket(data):
+    # 1) 프론트가 만든 양식(lines)이 오면 그대로 인쇄한다.
+    lines = data.get("lines")
+    if isinstance(lines, list) and lines:
+        out = [safe_line(ln) for ln in lines]
+        out += ["", "", ""]   # 절취용 여백
+        return "\r\n".join(out)
+
+    # 2) (폴백) lines 가 없으면 기존 기본 양식으로 생성.
+    order_number = safe_line(data.get("orderNumber", "A-000"), 16)
+    items = data.get("items", [])
+    print_type = data.get("type", "ticket")
+
+    title = "주문번호표" if print_type == "ticket" else "영수증"
+
+    fb = []
+    fb.append("----------------")
+    fb.append(" NUNCHI KIOSK")
+    fb.append("----------------")
+    fb.append(title)
+    fb.append("번호: " + order_number)
+    fb.append(datetime.now().strftime("%Y-%m-%d %H:%M"))
+    fb.append("")
+
+    if isinstance(items, list) and items:
+        for item in items:
+            fb.append(safe_line(item, 24))
+    else:
+        fb.append("주문 항목 없음")
+
+    fb.append("")
+    fb.append("잠시만 기다려주세요")
+    fb.append("----------------")
+    fb.append("")
+    fb.append("")
+    fb.append("")
+
+    return "\r\n".join(fb)
+
+
+class PrintHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, status=200):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self._set_headers(200)
+        self.wfile.write(b'{"ok":true}')
+
+    def do_POST(self):
+        if self.path != "/print":
+            self._set_headers(404)
+            self.wfile.write(b'{"ok":false,"msg":"not found"}')
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length).decode("utf-8")
+            data = json.loads(body) if body else {}
+
+            BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+            ticket = build_ticket(data)
+
+            # WSP-CP383(RX) 한글 출력용: CP949
+            TICKET_PATH.write_bytes(ticket.encode("cp949", errors="replace"))
+
+            result = subprocess.run(
+                ["cmd", "/c", str(BAT_PATH), str(TICKET_PATH)],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            if result.returncode != 0:
+                print("[PRINT_AGENT] print failed:", result.stderr)
+                self._set_headers(500)
+                self.wfile.write(b'{"ok":false,"msg":"print failed"}')
+                return
+
+            print("[PRINT_AGENT] printed:", data.get("type"), data.get("orderNumber"))
+            self._set_headers(200)
+            self.wfile.write(b'{"ok":true}')
+
+        except Exception as e:
+            print("[PRINT_AGENT] error:", e)
+            traceback.print_exc()
+            self._set_headers(500)
+            self.wfile.write(b'{"ok":false,"msg":"server error"}')
+
+
+if __name__ == "__main__":
+    server = HTTPServer((HOST, PORT), PrintHandler)
+    print(f"[PRINT_AGENT] running at http://{HOST}:{PORT}")
+    print("[PRINT_AGENT] POST /print")
+    server.serve_forever()

--- a/src/main/resources/static/front/css/common/payment-modal.css
+++ b/src/main/resources/static/front/css/common/payment-modal.css
@@ -249,21 +249,22 @@
 .paymod__anim .p04,
 .paymod__anim .p07 { padding: 0; }
 
-/* ── 영수증/번호표 선택 — 세로 큰 버튼 2개 (QA R3) ── */
+/* ── 영수증/번호표 선택 — 2열(나란히) · 세로로 긴 버튼 (QA R3) ── */
 .paymod__output {
     display: flex;
-    flex-direction: column;     /* 세로 2개 */
+    flex-direction: row;        /* 2열 나란히 */
     gap: 14px;
     margin-top: 14px;
 }
 .paymod__output-btn {
-    width: 100%;
+    flex: 1 1 0;                 /* 두 칸 균등 */
+    min-height: 240px;          /* 세로로 길게 */
     display: flex;
-    flex-direction: row;        /* 아이콘 + 텍스트 가로, 버튼은 크게 */
+    flex-direction: column;     /* 아이콘 위 · 텍스트 아래 */
     align-items: center;
     justify-content: center;
     gap: 16px;
-    padding: 26px 20px;
+    padding: 28px 16px;
     background: #fff;
     border: 1.5px solid var(--neutral-200, #e2ded8);
     border-radius: 18px;
@@ -273,12 +274,12 @@
 .paymod__output-btn:active { transform: scale(0.98); border-color: var(--primary-500, #e8600a); background: var(--primary-50, #fff3ec); }
 .paymod__output-ic {
     flex: 0 0 auto;
-    width: 56px; height: 56px;
+    width: 72px; height: 72px;
     display: flex; align-items: center; justify-content: center;
-    border-radius: 14px; font-size: 30px;
+    border-radius: 18px; font-size: 38px;
     background: var(--primary-50, #fff3ec); color: var(--primary-600, #cf5208);
 }
-.paymod__output-txt { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; }
+.paymod__output-txt { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 4px; }
 .paymod__output-t { font-size: 20px; font-weight: 800; color: var(--neutral-900, #1e1915); }
 .paymod__output-d { font-size: 13px; color: var(--color-text-secondary, #6b6259); }
 

--- a/src/main/resources/static/front/css/common/payment-modal.css
+++ b/src/main/resources/static/front/css/common/payment-modal.css
@@ -236,34 +236,51 @@
 .paymod__failx   { background: #dc3545; }
 @keyframes paymodPop { from { transform: scale(0.3); opacity: 0; } to { transform: scale(1); opacity: 1; } }
 
-/* ── 영수증/번호표 선택 ── */
+/* ── 결제수단별 진행 애니메이션 (기존 P03/P04/P07 비주얼을 모달 안에서 사용) ── */
+.paymod__anim {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    transform: scale(0.92);
+    margin: -4px 0 2px;
+}
+.paymod__anim .p03,
+.paymod__anim .p04,
+.paymod__anim .p07 { padding: 0; }
+
+/* ── 영수증/번호표 선택 — 세로 큰 버튼 2개 (QA R3) ── */
 .paymod__output {
     display: flex;
-    gap: 12px;
-    margin-top: 10px;
+    flex-direction: column;     /* 세로 2개 */
+    gap: 14px;
+    margin-top: 14px;
 }
 .paymod__output-btn {
-    flex: 1 1 0;
+    width: 100%;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;        /* 아이콘 + 텍스트 가로, 버튼은 크게 */
     align-items: center;
-    gap: 6px;
-    padding: 20px 12px;
+    justify-content: center;
+    gap: 16px;
+    padding: 26px 20px;
     background: #fff;
     border: 1.5px solid var(--neutral-200, #e2ded8);
-    border-radius: 16px;
+    border-radius: 18px;
     cursor: pointer;
     transition: border-color .12s ease, background .12s ease, transform .12s ease;
 }
-.paymod__output-btn:active { transform: scale(0.97); border-color: var(--primary-500, #e8600a); background: var(--primary-50, #fff3ec); }
+.paymod__output-btn:active { transform: scale(0.98); border-color: var(--primary-500, #e8600a); background: var(--primary-50, #fff3ec); }
 .paymod__output-ic {
-    width: 46px; height: 46px;
+    flex: 0 0 auto;
+    width: 56px; height: 56px;
     display: flex; align-items: center; justify-content: center;
-    border-radius: 12px; font-size: 24px;
+    border-radius: 14px; font-size: 30px;
     background: var(--primary-50, #fff3ec); color: var(--primary-600, #cf5208);
 }
-.paymod__output-t { font-size: 16px; font-weight: 800; color: var(--neutral-900, #1e1915); }
-.paymod__output-d { font-size: 12px; color: var(--color-text-secondary, #6b6259); }
+.paymod__output-txt { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; }
+.paymod__output-t { font-size: 20px; font-weight: 800; color: var(--neutral-900, #1e1915); }
+.paymod__output-d { font-size: 13px; color: var(--color-text-secondary, #6b6259); }
 
 @media (prefers-reduced-motion: reduce) {
     .paymod, .paymod__box { transition: none; }

--- a/src/main/resources/static/front/js/common/payment-modal.js
+++ b/src/main/resources/static/front/js/common/payment-modal.js
@@ -251,13 +251,22 @@
     function _setTip(t)     { const e = _root.querySelector('[data-paymod-htip]'); if (e) e.textContent = t; }
 
     /* ---------- 승인 처리 ---------- */
+    // 백엔드 승인이 즉시 끝나도 진행 애니메이션이 최소 이만큼은 보이도록 보장.
+    const MIN_PROCESSING_MS = 2600;
+
     async function _runApprove() {
         _renderProcessing();
+        const startedAt = Date.now();
         let r;
         try {
             r = _opts.approve ? await _opts.approve() : { ok: true };
         } catch (e) {
             r = { ok: false, reason: (e && e.reason) || 'payment_failed' };
+        }
+        // 애니메이션이 너무 빨리 사라지지 않게 최소 표시 시간 확보
+        const elapsed = Date.now() - startedAt;
+        if (elapsed < MIN_PROCESSING_MS) {
+            await new Promise((res) => setTimeout(res, MIN_PROCESSING_MS - elapsed));
         }
         if (!_root) return;             // 그새 닫힘
         if (r && r.ok) _renderDone();

--- a/src/main/resources/static/front/js/common/payment-modal.js
+++ b/src/main/resources/static/front/js/common/payment-modal.js
@@ -114,13 +114,79 @@
         `);
     }
 
+    /* ---------- 결제수단별 진행 애니메이션 (기존 P03/P04/P07 비주얼 그대로 재사용) ---------- */
+    function _animHtml(method) {
+        if (method === 'vein') {
+            return `
+            <div class="paymod__anim">
+              <div class="p03" data-state="scanning">
+                <div class="p03__scanner" aria-hidden="true">
+                  <span class="p03__pulse p03__pulse--1"></span>
+                  <span class="p03__pulse p03__pulse--2"></span>
+                  <span class="p03__pulse p03__pulse--3"></span>
+                  <div class="p03__frame">
+                    <svg class="p03__palm" viewBox="0 0 200 200" fill="none" stroke="currentColor"
+                         stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M72 92V44a11 11 0 0 1 22 0v48"/>
+                      <path d="M94 92V36a11 11 0 0 1 22 0v56"/>
+                      <path d="M116 92V42a11 11 0 0 1 22 0v50"/>
+                      <path d="M138 92V74a11 11 0 0 1 22 0v72c0 24-18 42-42 42h-18c-11 0-21-4-29-12l-28-30c-5-6-4-14 2-18 6-4 14-2 18 3l9 9"/>
+                      <path class="p03__vein p03__vein--1" d="M82 130c10 7 28 7 38 0"/>
+                      <path class="p03__vein p03__vein--2" d="M92 150c7 4 16 4 23 0"/>
+                      <path class="p03__vein p03__vein--3" d="M98 168c5 2.5 10 2.5 15 0"/>
+                    </svg>
+                    <span class="p03__scanline" aria-hidden="true"></span>
+                  </div>
+                </div>
+              </div>
+            </div>`;
+        }
+        if (method === 'barcode') {
+            return `
+            <div class="paymod__anim">
+              <div class="p07" data-state="waiting">
+                <div class="p07__scanner" aria-hidden="true">
+                  <span class="p07__pulse p07__pulse--1"></span>
+                  <span class="p07__pulse p07__pulse--2"></span>
+                  <span class="p07__pulse p07__pulse--3"></span>
+                  <div class="p07__frame">
+                    <div class="p07__card">
+                      <div class="p07__card-head"><span class="p07__card-brand">kakaopay</span></div>
+                      <div class="p07__barcode" aria-hidden="true">${'<span></span>'.repeat(20)}</div>
+                    </div>
+                    <span class="p07__scanline" aria-hidden="true"></span>
+                  </div>
+                </div>
+              </div>
+            </div>`;
+        }
+        // ic (기본) — 카드 삽입 + 슬롯 스피너
+        return `
+            <div class="paymod__anim">
+              <div class="p04" data-state="processing">
+                <div class="p04__visual" aria-hidden="true">
+                  <div class="p04__card">
+                    <div class="p04__card-chip" aria-hidden="true">${'<span></span>'.repeat(6)}</div>
+                    <div class="p04__card-stripe"></div>
+                    <span class="p04__card-brand">NUNCHI</span>
+                  </div>
+                  <div class="p04__slot">
+                    <span class="p04__slot-mouth"></span>
+                    <span class="p04__slot-label">IC CARD</span>
+                    <span class="p04__spinner" role="status" aria-label="결제 처리 중"><i></i></span>
+                  </div>
+                </div>
+              </div>
+            </div>`;
+    }
+
     /* ---------- 단계 ② processing ---------- */
     function _renderProcessing() {
         const m = METHOD[_opts.method] || METHOD.ic;
         _setTip('잠시만 기다려 주세요');
         _body(`
             <div class="paymod__state">
-                <div class="paymod__spinner" aria-hidden="true"></div>
+                ${_animHtml(_opts.method)}
                 <strong class="paymod__state-title">승인 요청 중…</strong>
                 <span class="paymod__state-desc">${esc(m.tip)}</span>
                 <div class="paymod__state-amount">${won(_opts.totalAmount || 0)} · 일시불</div>
@@ -142,17 +208,21 @@
             <div class="paymod__output">
                 <button type="button" class="paymod__output-btn" data-output="receipt">
                     <span class="paymod__output-ic"><i class="xi-print"></i></span>
-                    <span class="paymod__output-t">영수증 출력</span>
-                    <span class="paymod__output-d">결제 영수증을 받아요</span>
+                    <span class="paymod__output-txt">
+                        <span class="paymod__output-t">영수증 출력</span>
+                        <span class="paymod__output-d">결제 영수증을 받아요</span>
+                    </span>
                 </button>
                 <button type="button" class="paymod__output-btn" data-output="ticket">
                     <span class="paymod__output-ic"><i class="xi-document"></i></span>
-                    <span class="paymod__output-t">번호표 출력</span>
-                    <span class="paymod__output-d">대기번호표를 받아요</span>
+                    <span class="paymod__output-txt">
+                        <span class="paymod__output-t">번호표 출력</span>
+                        <span class="paymod__output-d">대기번호표를 받아요</span>
+                    </span>
                 </button>
             </div>
         `);
-        _actions(`<button type="button" class="paymod__btn paymod__btn--ghost" data-output="none">출력 없이 완료</button>`);
+        _actions('');   // '출력 없이 완료' 버튼 제거 — 영수증/번호표 둘 중 하나 선택 (QA R3)
     }
 
     /* ---------- 단계 ④ fail ---------- */
@@ -173,7 +243,11 @@
 
     /* ---------- 슬롯 헬퍼 ---------- */
     function _body(html)    { _root.querySelector('[data-paymod-body]').innerHTML = html; }
-    function _actions(html) { _root.querySelector('[data-paymod-actions]').innerHTML = html; }
+    function _actions(html) {
+        const el = _root.querySelector('[data-paymod-actions]');
+        el.innerHTML = html || '';
+        el.style.display = html ? '' : 'none';   // 비면 하단 바 자체를 숨김
+    }
     function _setTip(t)     { const e = _root.querySelector('[data-paymod-htip]'); if (e) e.textContent = t; }
 
     /* ---------- 승인 처리 ---------- */

--- a/src/main/resources/static/front/js/common/receipt.js
+++ b/src/main/resources/static/front/js/common/receipt.js
@@ -167,7 +167,7 @@
   .r-item { display: flex; justify-content: space-between; gap: 8px; margin-top: 4px; }
   .r-item-name { flex: 1; font-weight: 700; word-break: break-all; }
   .r-item-fig  { display: flex; gap: 10px; white-space: nowrap; }
-  .r-qty { width: 22px; text-align: center; }
+  .r-qty { width: 34px; text-align: center; white-space: nowrap; }
   .r-amt { min-width: 62px; text-align: right; font-variant-numeric: tabular-nums; }
   .r-opt { font-size: 10.5px; color: #222; padding-left: 6px; }
 
@@ -203,7 +203,7 @@
   <hr class="r-hr">
   <div class="r-row" style="font-weight:700;">
     <span>상품명</span>
-    <span style="display:flex; gap:10px;"><span style="width:22px; text-align:center;">수량</span><span style="min-width:62px; text-align:right;">금액</span></span>
+    <span style="display:flex; gap:10px;"><span style="width:34px; text-align:center; white-space:nowrap;">수량</span><span style="min-width:62px; text-align:right;">금액</span></span>
   </div>
   <hr class="r-hr">
   ${itemRows(data.items)}
@@ -238,8 +238,132 @@
 </html>`;
     }
 
-    // 숨긴 iframe 에 영수증 문서를 써서 그 안에서만 인쇄 → 키오스크 본 화면은 그대로.
-    function print(data) {
+    /* ======================================================
+       하드웨어 감열 프린터 출력 (로컬 프린트 에이전트 — 127.0.0.1:9100)
+       - 브라우저 window.print(크롬 인쇄) 대신, 로컬 프린트 에이전트로 텍스트 양식을 보내
+         실제 영수증(감열) 프린터로 출력한다.
+       - 감열 프린터는 텍스트(CP949) 출력이라 한글 1자 = 2칸. 폭을 계산해 정렬한다.
+       - 프린터 1줄 폭(글자수)은 LINE_W 로 조정한다. (58mm 기준 보통 32)
+       ====================================================== */
+    const AGENT_URL = 'http://127.0.0.1:9100/print';
+    const LINE_W = 32;
+
+    function _charW(ch) {
+        const c = ch.codePointAt(0);
+        // 한글/CJK/전각 = 2칸
+        if ((c >= 0x1100 && c <= 0x115F) || (c >= 0x2E80 && c <= 0xA4CF) ||
+            (c >= 0xAC00 && c <= 0xD7A3) || (c >= 0xF900 && c <= 0xFAFF) ||
+            (c >= 0xFE30 && c <= 0xFE4F) || (c >= 0xFF00 && c <= 0xFF60) ||
+            (c >= 0xFFE0 && c <= 0xFFE6)) return 2;
+        return 1;
+    }
+    function _w(s) { let n = 0; for (const ch of String(s)) n += _charW(ch); return n; }
+    function _trunc(s, w) {
+        let out = '', n = 0;
+        for (const ch of String(s)) { const cw = _charW(ch); if (n + cw > w) break; out += ch; n += cw; }
+        return out;
+    }
+    function _center(s, w) {
+        s = String(s); const d = _w(s);
+        if (d >= w) return _trunc(s, w);
+        const l = Math.floor((w - d) / 2);
+        return ' '.repeat(l) + s + ' '.repeat(w - d - l);
+    }
+    function _lr(l, r, w) {
+        l = String(l); r = String(r);
+        const gap = w - _w(l) - _w(r);
+        return gap > 0 ? l + ' '.repeat(gap) + r : _trunc(l, Math.max(0, w - _w(r) - 1)) + ' ' + r;
+    }
+    const _hr = (w) => '-'.repeat(w);
+    const _wonT = (n) => nf.format(Math.max(0, Math.round(n || 0))) + '원';
+
+    // 영수증 텍스트 양식 (감열 프린터용) — HTML 양식과 동일한 정보 구성
+    function buildReceiptLines(data) {
+        data = data || {};
+        const W = LINE_W;
+        const total = data.totalAmount || 0;
+        const supply = Math.round(total / (1 + VAT_RATE));
+        const vat = total - supply;
+        const orderType = data.orderType === 'TAKEOUT' ? '포장'
+                        : data.orderType === 'DINE_IN' ? '매장' : '';
+        const L = [];
+        L.push(_center(data.storeName || STORE_INFO.bizName, W));
+        L.push(_center(STORE_INFO.ceo, W));
+        L.push(_center('사업자 ' + STORE_INFO.bizNo, W));
+        L.push(_center('TEL ' + STORE_INFO.tel, W));
+        L.push(_hr(W));
+        L.push(_center('영 수 증', W));
+        L.push(_lr('주문일시', data.orderTime || fmtTime(), W));
+        if (orderType) L.push(_lr('식사구분', orderType, W));
+        if (data.orderId != null) L.push(_lr('주문번호', String(data.orderId), W));
+        L.push(_hr(W));
+        L.push(_lr('상품명', '금액', W));
+        L.push(_hr(W));
+        (data.items || []).forEach((it) => {
+            const qty = it.quantity || 1;
+            const amt = _wonT(it.itemTotal != null ? it.itemTotal : (it.unitPrice || 0) * qty);
+            L.push(_trunc(it.menuName || '', W));
+            L.push(_lr('  x' + qty, amt, W));
+            (it.options || []).filter((o) => o && o.optionName).forEach((o) => {
+                const ex = o.extraPrice ? ' (+' + _wonT(o.extraPrice) + ')' : '';
+                L.push(_trunc('   - ' + o.optionName + ex, W));
+            });
+        });
+        L.push(_hr(W));
+        L.push(_lr('공급가액', _wonT(supply), W));
+        L.push(_lr('부가세(10%)', _wonT(vat), W));
+        L.push(_lr('합계', _wonT(total), W));
+        L.push(_hr(W));
+        L.push(_lr('결제수단', data.methodLabel || '', W));
+        L.push(_hr(W));
+        L.push(_center('대기번호', W));
+        L.push(_center(data.orderNo || '-', W));
+        L.push(_center('번호 호출 시 카운터로 와주세요', W));
+        L.push('');
+        L.push(_center('이용해 주셔서 감사합니다', W));
+        return L;
+    }
+
+    // 번호표 텍스트 양식
+    function buildTicketLines(data) {
+        data = data || {};
+        const W = LINE_W;
+        const L = [];
+        L.push(_center(data.storeName || STORE_INFO.bizName, W));
+        L.push(_hr(W));
+        L.push(_center('대 기 번 호 표', W));
+        L.push('');
+        L.push(_center('대기번호', W));
+        L.push(_center(data.orderNo || '-', W));
+        L.push('');
+        L.push(_center(data.orderTime || fmtTime(), W));
+        L.push(_hr(W));
+        L.push(_center('번호가 호출되면', W));
+        L.push(_center('카운터로 와주세요', W));
+        return L;
+    }
+
+    // 로컬 프린트 에이전트로 전송 → 실제 감열 프린터 출력
+    function printHardware(data) {
+        data = data || {};
+        const kind = (data.docKind === 'ticket') ? 'ticket' : 'receipt';
+        const lines = (kind === 'ticket') ? buildTicketLines(data) : buildReceiptLines(data);
+        return fetch(AGENT_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type: kind, orderNumber: String(data.orderNo || '-'), lines: lines }),
+        }).then((res) => {
+            if (!res.ok) throw new Error('print agent HTTP ' + res.status);
+            return true;
+        }).catch((e) => {
+            console.warn('[Receipt] 하드웨어 인쇄 실패 — 프린트 에이전트(127.0.0.1:9100) 실행 여부 확인', e);
+            return false;
+        });
+    }
+
+    // (디버그/미리보기용) 브라우저 인쇄 — 숨긴 iframe 에 HTML 양식을 그려 window.print.
+    // 기본 출력 경로는 printHardware. 양식 레이아웃 확인용으로만 직접 호출한다.
+    function printPreview(data) {
         try {
             const html = buildHtml(data || {});
             const iframe = document.createElement('iframe');
@@ -259,19 +383,23 @@
                 } catch (e) {
                     console.warn('[Receipt] 인쇄 실패', e);
                 }
-                // 인쇄 대화/처리 후 정리
                 setTimeout(() => { try { document.body.removeChild(iframe); } catch (_) {} }, 1500);
             };
 
-            // 폰트/레이아웃 안정화 후 인쇄
             if (iframe.contentWindow.document.readyState === 'complete') setTimeout(fire, 250);
             else iframe.onload = () => setTimeout(fire, 250);
             return true;
         } catch (e) {
-            console.warn('[Receipt] 출력 준비 실패', e);
+            console.warn('[Receipt] 미리보기 준비 실패', e);
             return false;
         }
     }
 
-    window.NunchiReceipt = { print, buildHtml };
+    // 기본 출력 = 하드웨어 감열 프린터 (크롬 인쇄 X)
+    function print(data) { return printHardware(data); }
+
+    window.NunchiReceipt = {
+        print, printHardware, printPreview,
+        buildHtml, buildTicketHtml, buildReceiptLines, buildTicketLines,
+    };
 })();

--- a/src/main/resources/static/front/js/flowP/P02-payment.js
+++ b/src/main/resources/static/front/js/flowP/P02-payment.js
@@ -142,9 +142,40 @@
     // 백엔드 결제 메서드 enum 매핑
     const PAY_ENUM = { ic: 'IC_CARD', vein: 'VEIN_AUTH' };
 
+    // 데모 모드(?demo=1): 결제 백엔드 없이 승인 성공 처리 → 완료 화면/영수증 출력까지 플로우 확인용. (QA)
+    const DEMO_PAY = /[?&]demo=1\b/.test(location.search);
+
+    // 카트(또는 샘플)로 영수증/완료 화면용 orderSummary 를 만들어 둔다. (데모 출력 검증용)
+    function seedDemoSummary() {
+        const items = (cartItems && cartItems.length) ? cartItems : [
+            { menuName: '아메리카노(ICE)', quantity: 2, unitPrice: 3000, itemTotal: 6000, options: [] },
+            { menuName: '카페라떼',        quantity: 1, unitPrice: 2500, itemTotal: 2500, options: [] },
+        ];
+        const total = items.reduce((s, it) =>
+            s + (it.itemTotal != null ? it.itemTotal : (it.unitPrice || 0) * (it.quantity || 1)), 0);
+        try {
+            sessionStorage.setItem('orderId', '9999');
+            sessionStorage.setItem('orderSummary', JSON.stringify({
+                orderId: 9999,
+                orderType: sessionStorage.getItem('dineOption') === 'takeout' ? 'TAKEOUT' : 'DINE_IN',
+                totalAmount: total,
+                itemCount: items.length,
+                firstName: (items[0] && items[0].menuName) || '',
+                totalQty: items.reduce((s, it) => s + (it.quantity || 0), 0),
+                items: items,
+            }));
+            sessionStorage.setItem('paymentStatus', 'approved');
+        } catch (_) {}
+    }
+
     // 모달 "승인 요청" 시 호출 — 결제 3단계(주문확정→결제생성→성공)를 한 번에 처리. (QA R2-16)
     //   반환: { ok:true } | { ok:false, reason }
     async function approvePayment() {
+        if (DEMO_PAY) {
+            console.info('[P02] 데모 결제(?demo=1) — 백엔드 호출 없이 승인 성공 처리');
+            seedDemoSummary();
+            return { ok: true };
+        }
         const sid = getSessionId();
         if (!sid) return { ok: false, reason: 'payment_failed' };
         try {

--- a/src/main/resources/templates_front/flowP/P02-payment.html
+++ b/src/main/resources/templates_front/flowP/P02-payment.html
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="/css/components.css">
     <link rel="stylesheet" href="/css/flowP/P02-payment.css">
     <link rel="stylesheet" href="/css/common/payment-modal.css">
+    <!-- 결제 모달 진행 애니메이션(IC/정맥/바코드) — 기존 결제 화면 비주얼 재사용 (QA R3) -->
+    <link rel="stylesheet" href="/css/flowP/P03-vein.css">
+    <link rel="stylesheet" href="/css/flowP/P04-processing.css">
+    <link rel="stylesheet" href="/css/flowP/P07-barcode.css">
 </head>
 <body>
 <main class="page-bg">


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- 3차 QA 피드백 일괄 반영(단일 이슈 없음). base 는 fix/qa-round2 (round2 위에 쌓음). -->

## 📝 Summary

3차 QA 3건 + 실기기 확인 보강 + QA 테스트용 데모 모드를 반영했습니다. (프론트 + 로컬 프린트 에이전트 / 백엔드 변경 없음)

### 1. 결제 진행(로딩) 화면을 결제수단별 기존 애니메이션으로
승인 요청 후 결제 처리 중일 때, 그냥 도는 스피너 대신 **기존 결제 화면의 애니메이션**을 보여줍니다.
- **`js/common/payment-modal.js`** — `_animHtml(method)` 추가, `_renderProcessing`에서 사용.
  - `ic` → 카드 삽입 + 슬롯 스피너(P04 비주얼)
  - `vein` → 손바닥 정맥 스캔(P03 비주얼, 스캔라인·정맥 라인 애니메이션)
  - `barcode` → 카카오 바코드 스캔(P07 비주얼, 스캔라인·펄스)
  - 기존 `.p03/.p04/.p07` 마크업을 그대로 모달 본문에 렌더 → 같은 CSS가 그대로 적용.
  - **(보강)** 백엔드 승인이 즉시 끝나도 애니메이션이 너무 빨리 지나가지 않도록 **최소 표시 시간(`MIN_PROCESSING_MS = 2600ms`)** 보장. (승인이 더 오래 걸리면 그만큼 더 표시)
- **`templates_front/flowP/P02-payment.html`** — `P03-vein.css / P04-processing.css / P07-barcode.css` 로드(세 파일 모두 `.p0x` 스코프라 P02 레이아웃에 영향 없음).
- **`css/common/payment-modal.css`** — `.paymod__anim` 래퍼(가운데 정렬·약간 축소).

### 2. 영수증/번호표 → 크롬 인쇄 X, 실제 감열 프린터(로컬 에이전트)로 출력
"크롬 인쇄로 빠지던" 걸 다시 하드웨어 프린터 경로로 돌리고, 양식은 유지했습니다.
- **`js/common/receipt.js`**
  - `window.print` → **`printHardware()`** (`POST http://127.0.0.1:9100/print`)로 변경. `print()`의 기본 경로가 하드웨어 출력입니다. (크롬 인쇄는 `printPreview()`로만 남겨 디버그용)
  - 감열 프린터는 텍스트 출력이라 **한글 1자=2칸 폭을 계산해 정렬**하는 텍스트 양식 빌더(`buildReceiptLines / buildTicketLines`, 폭 `LINE_W=32`) 추가. HTML 양식과 같은 구성(가맹점/품목·금액/공급가·부가세/합계/대기번호).
  - **"수량" 헤더가 세로 두 줄로 깨지던 문제 수정** — 칼럼 폭 22→34px + `nowrap`.
- **`scripts/print_server.py`** — 보내주신 프린트 에이전트를 업데이트. 프론트가 만든 `lines` 양식이 오면 **그대로 CP949 인쇄**(없으면 기존 기본 양식으로 폴백). 포트/경로/배치파일(9100, ticket.txt, print_ticket.bat)은 그대로.
- **`scripts/kiosk-launch.sh`** — 인쇄 안내 주석을 하드웨어 에이전트 방식으로 정정.

### 3. 출력 선택: '출력 없이 완료' 제거 + 영수증/번호표 버튼
- **`js/common/payment-modal.js`** — done 단계에서 `출력 없이 완료` 버튼 제거. 하단 액션 바가 비면 숨기도록 `_actions()` 보강.
- **`css/common/payment-modal.css`** — `.paymod__output`을 **2열 나란히 + 세로로 길게**(`min-height: 240px`, 아이콘 위·텍스트 아래, 아이콘/글자 키움). 영수증/번호표 둘 중 하나를 선택.

### 4. (QA 전용) 결제 데모 모드 — 백엔드 없이 완료/출력 플로우 확인
실제 승인은 백엔드 3연속 호출(주문확정→결제생성→성공)이라 세션/카트가 없으면 "승인 실패"가 납니다. 그 뒤 플로우(완료 화면·영수증/번호표 출력)를 확인하려고 데모 모드를 넣었습니다.
- **`js/flowP/P02-payment.js`** — URL 에 `?demo=1` 이면 `approvePayment` 가 백엔드 호출 없이 승인 성공 처리하고, 카트(또는 샘플)로 `orderSummary` 를 채웁니다. → 완료 화면(P05)에서 **실제 감열 프린터로 영수증/번호표 출력까지** 그대로 확인 가능.
- 사용: 결제수단 화면을 `…/payment?demo=1` 로 열고 → 결제수단 선택 → 결제하기 → (애니메이션) → 영수증/번호표 선택.
- 프린터만 빠르게 보려면(결제 불필요) 콘솔에서 `NunchiReceipt.printHardware({ … , docKind:'receipt' })`.
- ⚠️ QA 검증용이라 운영 머지 전 제거 검토 가능.

## 🙏 Question & PR point

- **프린트 에이전트 재배포 필요** — 키오스크 PC(Windows)의 `print_server.py`를 이 PR의 `scripts/print_server.py`로 교체하고 실행해야 새 양식이 적용됩니다. `print_ticket.bat`은 기존 그대로 사용.
- **포트는 9100** — 보내주신 서버 코드 기준(`PORT = 9100`)으로 맞췄습니다. (말씀하신 9300이 아니라 9100)
- **프린터 1줄 폭** — 우선 58mm 기준 `LINE_W=32`로 잡았습니다. 실제 프린터 폭이 다르면 `receipt.js` 상단 `LINE_W` 한 값만 바꾸면 됩니다.
- **튜닝 포인트** — 애니메이션 표시 시간은 `payment-modal.js`의 `MIN_PROCESSING_MS`, 출력 버튼 높이는 `payment-modal.css`의 `.paymod__output-btn { min-height }` 로 조정.
- **테스트 한계** — 감열 프린터/Windows 에이전트는 이 환경에서 직접 못 돌려, 프론트 로직·양식 정렬·파이썬 문법까지만 검증했습니다. 실제 출력 폭/한글은 키오스크 PC에서 확인 필요.
- **base = fix/qa-round2** — round2(#139) 위에 쌓은 브랜치라 base를 round2로 뒀습니다. round2가 dev에 머지되면 자동으로 dev 대상이 됩니다.

## 📬 Postman

- 프론트 + 로컬 프린트 에이전트 변경이라 백엔드 신규 API 없음.
