### PR TITLE
[Fix] silent 알림 응답에서 옵션/추천 시트 재오픈 차단 (옵션 재호출 루프·TTS 씹힘)

### DIFF
--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -755,14 +755,17 @@
         };
 
         // 옵션 시트는 즉시 열고 TTS 끝나면 청취 재개
-        if (doneRes.menu_options) {
+        // silent 알림(담기 완료 등)은 사용자가 새로 요청한 게 아니므로 시트를 재오픈하지 않는다.
+        // → AI 가 menu_options 를 다시 돌려줘도 옵션 시트 재오픈 루프 / 중복 담기 / TTS 씹힘(즉시 endTurn 레이스) 방지.
+        // (reply·suggestions·TTS·step·cart 갱신은 그대로 받는다)
+        if (!silent && doneRes.menu_options) {
             openOptionSheet(doneRes.menu_options);
             finalize();
             return;
         }
 
-        // 추천 시트도 즉시 열고 TTS 끝나면 마이크 ON 유지
-        if (Array.isArray(doneRes.recommendations) && doneRes.recommendations.length > 0) {
+        // 추천 시트도 즉시 열고 TTS 끝나면 마이크 ON 유지 (silent 알림은 재오픈 안 함)
+        if (!silent && Array.isArray(doneRes.recommendations) && doneRes.recommendations.length > 0) {
             openRecommendSheet(doneRes.recommendations);
             finalize();
             return;


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- PR #145(완료형+silent 문구) 후속. 머지 타이밍상 가드 커밋이 #145에 못 실려 별도 PR. base: dev -->

## 📝 Summary

PR #145에서 옵션 담기 후 알림을 완료형+`silent` 로 바꿨지만, **AI(`order_node.py`)가 그 알림을 새 주문으로 오인해 응답에 `menu_options`(또는 `recommendations`)를 다시 채워 보내면** 프론트가 옵션/추천 시트를 **재오픈**하는 문제가 남아 있었습니다. (프론트 변경만 / 백엔드·AI 서버 변경 없음)

### 재현 (배포 환경, Playwright)
추천 → 철판치즈돈가스 담기 → 옵션 선택 → **담기** 시:
- `POST /ai/api/order/cart/add` 1회(정상) 후 `POST /ai/order/chat/stream` 응답이
  `reply: "철판치즈돈가스 담겼어요!"` 인데 **`menu_options` 가 null 이 아님** →
- `handleUserUtterance` 의 `if (doneRes.menu_options) openOptionSheet(...)` 가 **같은 메뉴 옵션 시트를 재오픈**.

이게 두 증상을 모두 유발:
1. **중복 호출 루프** — 재오픈 시트에서 또 담기 → `cart/add` 또 발사 → 또 `menu_options` → 반복.
2. **TTS 한 번 씹힘** — `openOptionSheet()` 가 즉시 `ConvEngine.endTurn()`(마이크 ON)을 호출 → 방금 큐에 들어간 "담겼어요" TTS와 레이스로 잘림.

### 변경 — `js/flowA/A01-avatar.js`
`handleUserUtterance` 의 시트 오픈 분기 두 곳을 `!silent` 로 가드:

```js
if (!silent && doneRes.menu_options) { openOptionSheet(...); ... }                         // 옵션 시트
if (!silent && Array.isArray(doneRes.recommendations) && ...) { openRecommendSheet(...); } // 추천 시트
```

- silent 알림(담기 완료)은 사용자가 새로 요청한 게 아니므로 **옵션/추천 시트를 재오픈하지 않음**.
- `reply`·`suggestions`·TTS·step·cart 갱신은 그대로 유지.
- silent 일 땐 `openOptionSheet()` 자체가 안 불려 **즉시 endTurn 레이스도 사라져 TTS 씹힘까지 해결**.
- 일반 흐름(추천카드 `담아줘` 등 non-silent)은 영향 없음.

## 🙏 Question & PR point

- **근본 해결은 AI repo 병행 권장** — `order_node.py` 에서 "○○ 장바구니에 담겼어" 완료 알림엔 `menu_options: null` 반환하도록 하면 깔끔. 이 PR은 **그게 없어도 프론트 단독으로 루프/TTS 씹힘을 막는 방어선**입니다.
- **검증** — JS 구문 검사(`node --check`) 통과. 배포본(수정 전)에서 재오픈 재현 확인 후 가드 추가. 수정본의 음성 플로우 최종 확인은 배포 후 키오스크에서 권장.

## 📬 Postman

- 프론트 변경만이라 백엔드 신규 API 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)