### PR TITLE
[Fix] 터치 발화 시 마이크 echo 로 응답 TTS 끊김 방지 (beginThinking)

### DIFF
--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -561,6 +561,14 @@
             state.recommendCtx = null;
         }
 
+        // 터치로 들어온 직접 호출(시트 담기/추천카드/칩)은 엔진이 LISTENING(마이크 ON)인 채라,
+        // 이어지는 응답 TTS 가 스피커→마이크 echo 로 되돌아와 끊긴다. 요청 전에 마이크를 끄고
+        // THINKING 으로 내린다. (음성/텍스트 경로는 이미 THINKING 이라 no-op)
+        if (state.engineStarted && window.ConvEngine && window.ConvEngine.isActive()
+                && typeof window.ConvEngine.beginThinking === 'function') {
+            window.ConvEngine.beginThinking();
+        }
+
         // 이전 발화 abort (barge-in) + 새 signal
         if (state.speechAbort) {
             try { state.speechAbort.abort(); } catch (_) {}

--- a/src/main/resources/static/front/js/flowA/conversation-engine.js
+++ b/src/main/resources/static/front/js/flowA/conversation-engine.js
@@ -359,6 +359,23 @@
     }
 
     /**
+     * 외부 입력 진입 — 추천/옵션 시트 담기, 칩 클릭 등 호스트가 엔진을 거치지 않고
+     * 직접 발화를 보낼 때 호출. LISTENING(마이크 ON) 상태면 마이크를 끄고 THINKING 으로
+     * 내려, 이어지는 응답·TTS 동안 스피커 음성이 STT 로 되돌아와(echo) 발화가 끊기는 것을 방지.
+     * 음성/텍스트 경로는 이미 THINKING(또는 AI_SPEAKING)이라 no-op 으로 안전하게 통과.
+     */
+    function beginThinking() {
+        if (!state.wantsRunning) return;
+        if (state.mode !== MODE.LISTENING) return;   // LISTENING 일 때만 마이크 정리
+        console.log(LOG, '🤫 외부 입력 — 마이크 끄고 THINKING 전환 (echo 컷 방지)');
+        _clearSilenceTimer();
+        _stopRecognition();
+        state.finalAccum = '';
+        state.interimAccum = '';
+        setMode(MODE.THINKING);
+    }
+
+    /**
      * 명시적 바지인 — 마이크 버튼 클릭 등 사용자 의도가 명확한 경우.
      * AI 발화 즉시 중단 + LISTENING 으로 전환 + recognition 시작.
      */
@@ -385,7 +402,7 @@
 
     window.ConvEngine = {
         MODE,
-        init, start, stop, say, endTurn, submitText, bargeIn,
+        init, start, stop, say, endTurn, submitText, beginThinking, bargeIn,
         isActive, getMode, isSupported
     };
 })();


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- 옵션 담기 후 "○○ 담겼어요" 음성이 안 나오는 문제. 같은 원인이 추천담기/다른거/칩 에도 존재. -->

## 📝 Summary

옵션 시트 담기 후 AI 가 `"○○ 담겼어요"` reply 를 돌려주는데 **음성(TTS)이 안 나오는** 문제. 원인은 시트 재오픈(별도 PR)이 아니라 **마이크 echo 로 인한 자기 발화 끊김**이었습니다. (프론트 변경만)

### 원인
입력 경로별로 발화 직전 마이크 처리가 달랐습니다.

| 경로 | 엔진 상태 | 마이크 |
|---|---|---|
| 음성 발화 | `onresult` 이 `_stopRecognition`+THINKING | 꺼짐 ✅ |
| 텍스트 입력 | `submitText` 가 `_stopRecognition`+THINKING | 꺼짐 ✅ |
| **추천카드 담기 / "다른 거 추천" / 옵션 담기 / 제안 칩** | `handleUserUtterance` **직접 호출** | **LISTENING(켜짐)** ❌ |

터치 경로는 엔진을 거치지 않고 `handleUserUtterance` 를 직접 부른다 → 엔진이 **LISTENING(마이크 ON)** 인 채로 응답 TTS 가 재생됨 → 스피커 소리가 마이크로 되돌아와(echo) `rec.onresult` 가 **새 사용자 발화로 오인**(`mode !== AI_SPEAKING`) → THINKING 전환 + 새 `handleUserUtterance` 발생 → 직전 `speechAbort` abort → **"담겼어요" TTS 가 끊김**.

배포 환경(Playwright) 로그상 옵션 담기 시점 엔진이 `LISTENING` 이었던 것으로 재현 확인.

### 변경
- **`conversation-engine.js`** — `beginThinking()` 공개 메서드 추가. `LISTENING` 일 때만 마이크(`_stopRecognition`)를 끄고 `THINKING` 으로 전환. 음성/텍스트 경로는 이미 THINKING 이라 no-op.
- **`A01-avatar.js`** — `handleUserUtterance` 진입부(요청 직전)에서 엔진 활성 시 `beginThinking()` 호출.

단일 choke point 라 **터치 직접호출 4경로(추천카드 담기 · "다른 거 추천" · 옵션 담기 · 제안 칩)** 가 한 번에 커버됩니다. 응답 종료 후엔 기존 `finalize()` 의 `endTurn()` 으로 다시 LISTENING.

## 🙏 Question & PR point

- **전수 점검 결과** — 같은 echo-컷 위험은 옵션 담기 외에 추천카드 담기·"다른 거 추천"·칩 클릭에도 있었고, 이 PR 이 네 곳 모두 막습니다. 음성/텍스트 경로는 영향 없음(no-op).
- **별개 메커니즘** — 부팅 인사말은 `AI_SPEAKING`(의도된 바지인 설계)이라 이 수정 범위 밖. 실제 echo 발생은 하드웨어 에코캔슬에 의존.
- **검증** — 두 파일 `node --check` 통과. 실제 음성 echo-컷은 마이크 동작이 필요해 헤드리스로는 코드 경로까지만 확인, 최종 확인은 키오스크 실기기 권장.
- **순서** — 시트 재오픈 가드(#148, 머지됨)와 독립. 함께 적용 시 옵션 담기 흐름이 "담겼어요 발화 + 칩 → LISTENING" 으로 정상화.

## 📬 Postman

- 프론트 변경만이라 백엔드 신규 API 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자의 직접 입력(추천 카드, 칩 터치)에 대한 엔진 상태 관리 개선
  * 대화 엔진의 리스닝에서 사고 모드로의 전환 처리 강화

* **개선 사항**
  * 엔진 활성 상태에서 사용자 음성 입력 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->