### PR TITLE
[Feat] 눌러서 말하기 — 자동 청취 폐지로 턴테이킹 안정화

### DIFF
--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -468,7 +468,7 @@
         runner(signal).then(() => {
             if (signal.aborted) return;
             if (state.engineStarted && window.ConvEngine && window.ConvEngine.isActive()) {
-                window.ConvEngine.endTurn();
+                window.ConvEngine.rest();
             }
         }).catch((e) => {
             if (!e || e.name !== 'AbortError') console.warn('[A01] FSM runner error', e);
@@ -533,7 +533,7 @@
     async function handleUserUtterance(text, { silent = false } = {}) {
         if (state.aiSessionId == null) {
             showToast('AI 세션이 없어요. 새로고침 해주세요.');
-            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
             return;
         }
 
@@ -669,7 +669,7 @@
                 showToast(msg);
             }
             setAvatar('idle');
-            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
             return;
         }
 
@@ -678,14 +678,14 @@
             showToast(errorMsg);
             appendLog('ai', errorMsg);
             ttsQueue.then(() => setAvatar('idle'));
-            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
             return;
         }
 
         // done 없음 또는 빈 응답 — 폴백 멘트 추가 금지, 청취만 재개
         if (!doneRes || (!fullText && !(doneRes && doneRes.reply))) {
             setAvatar('idle');
-            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
             return;
         }
 
@@ -755,7 +755,7 @@
                 .then(() => sleep(400, signal))
                 .then(() => {
                     setAvatar('idle');
-                    if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+                    if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
                 })
                 .catch(() => {
                     setAvatar('idle');
@@ -810,7 +810,7 @@
         };
         const onCancel = () => {
             state.recommendCtx = null;
-            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+            if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
         };
 
         // 시트 열려있는 동안 음성 매칭에 사용할 컨텍스트 등록
@@ -889,7 +889,7 @@
                 );
             },
             onCancel: () => {
-                if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
+                if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.rest();
             }
         });
         // 마이크는 여기서 즉시 열지 않는다 — 응답 TTS 가 아직 재생 중이라 마이크를 켜면
@@ -1251,6 +1251,12 @@
             return;
         }
 
+        if (mode === 'READY') {
+            // 눌러서 말하기 — 한 턴만 청취 시작 (열림음 → 마이크 ON)
+            window.ConvEngine.endTurn();
+            return;
+        }
+
         if (mode === 'AI_SPEAKING' || mode === 'THINKING') {
             // 눈치가 말하거나 응답 대기 중 — 사용자가 바로 말하고 싶을 때.
             // AI 즉시 멈추고 LISTENING 으로 전환.
@@ -1259,8 +1265,8 @@
         }
 
         if (mode === 'LISTENING') {
-            // 듣는 중 마이크 클릭 → 대화 종료
-            window.ConvEngine.stop();
+            // 듣는 중 다시 누르면 청취 취소 → 대기(READY)
+            window.ConvEngine.rest();
         }
     }
 
@@ -1294,6 +1300,14 @@
             bubbleHint = null; // 텍스트 대신 점점점(…) 애니메이션으로 표시
             ariaPressed = 'false';
             ariaLabel = 'AI 응답 중';
+        } else if (next === 'READY') {
+            // 눌러서 말하기 대기 — 마이크 OFF, 사용자가 누를 때까지 어떤 소리도 안 들음
+            micClass = 'a01__btn-mic--inactive';
+            statusText = '대기';
+            placeholder = '마이크를 눌러 말씀하세요';
+            bubbleHint = '🎤 눌러서 말하기';
+            ariaPressed = 'false';
+            ariaLabel = '마이크를 눌러 말하기';
         } else { // INACTIVE
             micClass = 'a01__btn-mic--inactive';
             statusText = '대기';
@@ -1485,9 +1499,9 @@
         await startAiSession();
         if (state.sessionId) await refreshCart();
 
-        // 자동 청취 시작 — ConvEngine.start() 가 AI_SPEAKING 으로 진입,
-        // greeting 발화 끝나면 endTurn() 으로 LISTENING 전환 (마이크 권한 팝업).
-        // 사용자가 마이크 버튼으로 끄기 전까지 자동으로 듣고 끊고 응답.
+        // 세션 시작 — ConvEngine.start() 가 AI_SPEAKING 으로 진입해 greeting 발화,
+        // 끝나면 rest() 로 READY(눌러서 말하기) 대기. 마이크는 사용자가 버튼을 누를 때만
+        // 한 턴씩 열린다(자동 청취 X — 주변 소음/대화 오작동 방지).
         if (window.ConvEngine.isSupported()) {
             state.engineStarted = true;
             window.ConvEngine.start();
@@ -1495,7 +1509,7 @@
                 await window.ConvEngine.say(state.bootGreeting);
             }
             state.greetedOnBoot = true;
-            window.ConvEngine.endTurn();
+            window.ConvEngine.rest();
         } else {
             // 브라우저 미지원 — 텍스트 입력으로 폴백
             showToast('이 브라우저는 음성 입력을 지원하지 않아요. 텍스트로 입력해주세요.');

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -748,11 +748,11 @@
         renderChips(doneRes.suggestions);
 
         // TTS 큐 끝나면 아바타 idle + 청취 재개.
-        // 200ms 잔향 가드: 스피커 음향이 마이크로 되돌아오는 echo 안정화 시간.
+        // 400ms 잔향/차분 가드: 스피커 음향이 마이크로 되돌아오는 echo 안정화 + 턴 사이 텀.
         // (abort 시엔 sleep 이 reject → catch 로 흡수, endTurn 호출 안 함)
         const finalize = () => {
             ttsQueue
-                .then(() => sleep(200, signal))
+                .then(() => sleep(400, signal))
                 .then(() => {
                     setAvatar('idle');
                     if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
@@ -818,10 +818,9 @@
 
         window.RecommendSheet.open({ menus, onPick, onAnother, onCancel });
 
-        // 시트가 뜨면 즉시 LISTENING 전환 — 음성+터치 둘 다 받게 마이크 ON 유지
-        if (state.engineStarted && window.ConvEngine.isActive()) {
-            window.ConvEngine.endTurn();
-        }
+        // 마이크는 여기서 즉시 열지 않는다 — 응답 TTS 가 아직 재생 중이라 마이크를 켜면
+        // AI 자기 목소리를 STT 가 주워듣는 echo 루프가 생긴다. 마이크는 finalize() 가
+        // 발화 끝난 뒤 한 번만 연다(터치 선택은 마이크와 무관하게 가능).
     }
 
     /**
@@ -893,10 +892,9 @@
                 if (state.engineStarted && window.ConvEngine.isActive()) window.ConvEngine.endTurn();
             }
         });
-        // 시트 뜨면 즉시 LISTENING — 음성+터치 둘 다 받게 마이크 ON
-        if (state.engineStarted && window.ConvEngine.isActive()) {
-            window.ConvEngine.endTurn();
-        }
+        // 마이크는 여기서 즉시 열지 않는다 — 응답 TTS 가 아직 재생 중이라 마이크를 켜면
+        // AI 자기 목소리를 STT 가 주워듣는 echo 루프가 생긴다. 마이크는 finalize() 가
+        // 발화 끝난 뒤 한 번만 연다(터치 선택은 마이크와 무관하게 가능).
     }
 
     /** 카트 추가 — 작업 1 에서 제거됐던 함수 재도입 (추천 시트 onPick 용). */

--- a/src/main/resources/static/front/js/flowA/conversation-engine.js
+++ b/src/main/resources/static/front/js/flowA/conversation-engine.js
@@ -39,6 +39,7 @@
     const CUE_URL = { open: '/audio/cue-open.wav', close: '/audio/cue-close.wav' };
     const CUE_VOLUME = 0.7;      // 효과음 볼륨 (0~1)
     const CUE_MAX_MS = 700;      // 안전망 — 효과음이 안 울려도 이 시간 뒤 다음 단계 진행
+    const CUE_SETTLE_MS = 200;   // 열림음 끝난 뒤 마이크 ON 까지 텀 — 효과음 꼬리 echo 차단
 
     let handlers = {
         speak: null,             // async (text, signal) => void
@@ -363,18 +364,22 @@
     function endTurn() {
         if (!state.wantsRunning) return;
         if (state.mode === MODE.INACTIVE) return;
+        if (state.mode === MODE.LISTENING) return;   // 이미 청취 중 — 중복 endTurn 무시(중복 효과음/마이크 재시작 방지)
         setMode(MODE.LISTENING);
         state.finalAccum = '';
         state.interimAccum = '';
         state.listenStartedAt = Date.now();   // 발화 대기 타이머 기준점
         if (state.supported) {
             _ensureRecognition();
-            // 열림음 먼저 재생 → 끝난 뒤 마이크 ON (효과음이 STT 로 새지 않도록)
+            // 열림음 재생 → (settle 텀) → 마이크 ON. 효과음/꼬리가 STT 로 새지 않도록.
             _playCue('open').then(() => {
                 if (!state.wantsRunning || state.mode !== MODE.LISTENING) return;  // 그새 전환되면 취소
-                state.listenStartedAt = Date.now();   // 효과음 길이만큼 대기 타이머 기준 갱신
-                _scheduleStart();
-                _startSilenceTimer();
+                setTimeout(() => {
+                    if (!state.wantsRunning || state.mode !== MODE.LISTENING) return;
+                    state.listenStartedAt = Date.now();   // 효과음+텀 만큼 대기 타이머 기준 갱신
+                    _scheduleStart();
+                    _startSilenceTimer();
+                }, CUE_SETTLE_MS);
             });
         } else {
             _startSilenceTimer();

--- a/src/main/resources/static/front/js/flowA/conversation-engine.js
+++ b/src/main/resources/static/front/js/flowA/conversation-engine.js
@@ -28,7 +28,8 @@
         INACTIVE: 'INACTIVE',
         AI_SPEAKING: 'AI_SPEAKING',
         LISTENING: 'LISTENING',
-        THINKING: 'THINKING'
+        THINKING: 'THINKING',
+        READY: 'READY'        // AI 턴 종료 후 대기 — 마이크 끔, 사용자가 누르면 청취(눌러서 말하기)
     };
 
     const SILENCE_MS = 1000;     // 침묵 1초 → 누적 텍스트 있으면 즉시 final, 없으면 onSilencePrompt 콜백
@@ -242,9 +243,9 @@
             // (발화 시작했으면 onresult 에서 listenStartedAt 갱신되어 여기 통과 안 함)
             if (listenTimeoutMs && state.listenStartedAt &&
                 Date.now() - state.listenStartedAt >= listenTimeoutMs) {
-                console.log(LOG, '⏱️ 발화 시작 대기 시간 초과 → 자동 종료', listenTimeoutMs, 'ms');
+                console.log(LOG, '⏱️ 발화 시작 대기 시간 초과 → 대기(READY) 복귀', listenTimeoutMs, 'ms');
                 _clearSilenceTimer();
-                stop();
+                rest();   // 세션 종료 대신 '눌러서 말하기' 대기로 복귀
                 if (handlers.onListenTimeout) {
                     try { handlers.onListenTimeout(); }
                     catch (e) { console.warn(LOG, 'onListenTimeout 처리 실패', e); }
@@ -386,6 +387,21 @@
         }
     }
 
+    /**
+     * AI 턴 종료 후 '눌러서 말하기' 대기 상태.
+     * 마이크를 끄고 READY 로 두어, 사용자가 마이크를 누를 때까지 어떤 소리도 듣지 않는다.
+     * (자동 청취가 주변 소음/대화에 계속 반응하던 문제 → 의도적 발화만 받도록)
+     */
+    function rest() {
+        if (!state.wantsRunning) return;
+        if (state.mode === MODE.INACTIVE || state.mode === MODE.READY) return;
+        _clearSilenceTimer();
+        _stopRecognition();
+        state.finalAccum = '';
+        state.interimAccum = '';
+        setMode(MODE.READY);
+    }
+
     /** 텍스트 입력 폴백 — 음성 우회. */
     function submitText(text) {
         const t = (text || '').trim();
@@ -446,7 +462,7 @@
 
     window.ConvEngine = {
         MODE,
-        init, start, stop, say, endTurn, submitText, beginThinking, bargeIn,
+        init, start, stop, say, endTurn, rest, submitText, beginThinking, bargeIn,
         isActive, getMode, isSupported
     };
 })();


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- 실기기 콘솔 로그로 확인: 자동 청취가 주변 대화에 계속 반응 → 매 발화마다 chatStream + 효과음 무한루프("띵똥댕동"). -->

## 📝 Summary

실기기 로그에서 **자동 청취(매 AI 발화 후 마이크 재개)가 주변 소음/대화를 계속 주워들어** 문장마다 chatStream을 쏘고 → 대부분 OOD("메뉴 관련만") 응답 → 또 마이크 재개 → 열림/닫힘 효과음이 매번 → **"띵똥댕동" 무한 루프**가 확인됨. (프론트 변경만)

근본 원인은 코드 버그가 아니라 **항상 켜진 마이크** 설계라, **눌러서 말하기(Push-to-talk)** 로 전환합니다.

### 동작 변경
| | 이전(자동 청취) | 이후(눌러서 말하기) |
|---|---|---|
| AI 발화 후 | 마이크 자동 재개(LISTENING) | **READY 대기**(마이크 OFF, "🎤 눌러서 말하기") |
| 마이크 ON | 매 턴 자동 | **사용자가 버튼 누른 한 턴만** |
| 효과음 | 매(스푸리어스) 턴마다 | **사용자가 누른 진짜 턴에만 1회씩** |
| 주변 소음 | 계속 반응 | **무시**(누를 때만 들음) |

### 변경 — `conversation-engine.js`
- `MODE.READY` + `rest()` 추가: AI 턴 종료 후 마이크 끄고 READY 대기.
- 발화 대기 타임아웃: `stop()`(세션 종료) → `rest()`(READY 복귀) — 세션 안 죽임.

### 변경 — `A01-avatar.js`
- 모든 자동 `endTurn()`(부팅 greeting 후 / 응답 `finalize` 후 / 시트 취소 / 에러 복귀) → **`rest()`**.
- `endTurn()`(= 한 턴 청취 시작)은 **마이크 버튼 탭(READY)에서만** 호출.
- `onMicClick`: READY→청취 시작, LISTENING→청취 취소(rest).
- `onConvModeChange`: READY UI("🎤 눌러서 말하기").

### 1차 안정화(같은 PR, 선행 커밋)
- `openOptionSheet/openRecommendSheet`의 **즉시 endTurn 제거** — 응답 TTS 재생 중 마이크가 켜져 AI 자기 목소리를 STT가 주워듣던 echo 제거.
- `endTurn` **재진입 가드** + 열림음 후 **settle 텀(200ms)** + finalize **400ms**(차분 텀).

## 🙏 Question & PR point

- **재배포 필요** — 정적 리소스/JS 번들이 jar에 포함되므로 dev 재빌드·재배포 후 키오스크에서 확인.
- **AI 서버는 별개 이슈** — 응답에 `menu_options`가 OOD/"담겼어요"에도 붙어 오거나, reply 안에 JSON이 통째로 새어 들어오는 건 `order_node.py`(별도 repo) 출력 버그. 프론트는 silent 가드(#148)로 시트 오작동은 막지만, 근본은 AI 측 수정 필요.
- **검증** — 두 파일 `node --check` 통과 + 전 경로 로직 자가검증. 마이크/효과음 실동작은 실기기 필요(헤드리스 불가).

## 📬 Postman

- 프론트 변경만이라 백엔드 신규 API 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 음성 인식 시 배경음 간섭 감소를 위해 안정화 지연 시간을 증가했습니다.
  * 침묵 인식 시 세션이 종료되지 않고 대기 상태로 복귀하도록 개선했습니다.

* **Refactor**
  * 마이크 청취 패턴을 자동 청취에서 사용자의 수동 버튼 클릭 방식으로 변경했습니다.
  * 대화 엔진의 턴 전환 메커니즘을 재구성하여 더 명확한 상태 관리 흐름을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->