### PR TITLE
[Fix] READY 안내 문구 + 매 턴 카트 재조회 (PTT 후속)

### DIFF
--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -724,10 +724,11 @@
             window.AiAction.handle(act);
         }
 
-        // 카트 변경 키워드 → 카트 재조회
-        if (window.ReplyKeywords && window.ReplyKeywords.replyHasCartChange(reply)) {
-            await refreshCart();
-        }
+        // 매 턴 카트 재조회 — AI 가 서버사이드(MCP 툴)로 담거나 뺐을 수 있으므로
+        // 응답 문구와 무관하게 항상 Spring 카트를 다시 가져와 미니카트를 동기화한다.
+        // (이전엔 reply 키워드 "담았어요" 등에 의존 → "담겼어요"·"추가했어요" 같은 표현은
+        //  누락돼 서버엔 담겼는데 미니카트가 안 바뀌던 문제. 카트 GET 은 가벼워 항상 호출 OK)
+        await refreshCart();
 
         // 결제 라우팅 — CHECKOUT 진입 또는 완료 키워드
         // 아바타가 마지막 말을 끝까지 들려준 뒤(TTS 큐 완료), 0.7초 텀을 두고 결제 화면으로.

--- a/src/main/resources/static/front/js/flowA/A01-avatar.js
+++ b/src/main/resources/static/front/js/flowA/A01-avatar.js
@@ -1301,11 +1301,12 @@
             ariaPressed = 'false';
             ariaLabel = 'AI 응답 중';
         } else if (next === 'READY') {
-            // 눌러서 말하기 대기 — 마이크 OFF, 사용자가 누를 때까지 어떤 소리도 안 들음
+            // 눌러서 말하기 대기 — 마이크 OFF, 사용자가 누를 때까지 어떤 소리도 안 들음.
+            // AI 발화가 끝날 때마다 이 안내가 떠서 다음 차례를 명확히 알려준다.
             micClass = 'a01__btn-mic--inactive';
-            statusText = '대기';
-            placeholder = '마이크를 눌러 말씀하세요';
-            bubbleHint = '🎤 눌러서 말하기';
+            statusText = '눌러서 말하기';
+            placeholder = '🎤 마이크를 눌러 말씀해 주세요';
+            bubbleHint = '🎤 마이크를 눌러 말씀해 주세요';
             ariaPressed = 'false';
             ariaLabel = '마이크를 눌러 말하기';
         } else { // INACTIVE


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- PR #154(눌러서 말하기) 후속 2건. 머지 타이밍상 #154에 못 실려 별도 PR. base: dev -->

## 📝 Summary

PR #154(눌러서 말하기) 직후 추가한 2건. (프론트 변경만)

### 1. READY 안내 문구 명확화 — `A01-avatar.js`
AI 발화가 끝날 때마다(READY) 다음 차례를 명확히 안내:
- 말풍선/입력창: `"눌러서 말하기"` → **`"🎤 마이크를 눌러 말씀해 주세요"`**
- 상단 상태: `대기` → `눌러서 말하기`

### 2. 매 턴 카트 재조회 — 미니카트 동기화 견고화 — `A01-avatar.js`
순수 음성 `"담아줘"`/추천카드 담기는 AI 가 서버사이드(MCP 툴)로 카트를 바꾸고, 프론트는 reply 키워드로만 재조회했음:
```js
// 이전: CART_PATTERN(담았어요|비웠어요|장바구니|담아드렸어요) 매칭 시에만
if (ReplyKeywords.replyHasCartChange(reply)) await refreshCart();
// 이후: 항상
await refreshCart();
```
→ AI 가 **"담겼어요"·"추가했어요"·"넣어드렸어요"** 등으로 답하면 서버엔 담겼는데 미니카트가 안 바뀌던 누락 해소. (카트 GET 은 가벼워 매 턴 호출 부담 없음. 옵션 시트 직접 `cartAdd` 경로와도 충돌 없음 — 같은 상태 재확인)

## 🙏 Question & PR point

- **재배포 필요** — 정적 번들이라 dev 재빌드·재배포 후 키오스크 확인.
- **검증** — `node --check` 통과. 마이크 UI/카트 반영 실동작은 재배포 후 실기기 확인.

## 📬 Postman

- 프론트 변경만이라 백엔드 신규 API 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)