### PR TITLE
[Fix/CI] CD 배포 신뢰성 — SHA 고정태그 + 겹침 방지 (배포돼도 서버 안 바뀜 해결)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# 배포 겹침 방지 — 같은 ref 의 이전 배포가 돌고 있으면 취소하고 최신 것만 실행.
+# (동시 실행이 latest 태그를 서로 덮어써 옛 이미지가 뜨던 문제 방지)
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -47,10 +53,13 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: latest
+          IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          # 커밋 SHA 고정태그(불변) + latest(편의) 둘 다 push.
+          # 배포는 SHA 태그 이미지를 쓰므로 "latest pull 했는데 옛 이미지" 문제가 사라진다.
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Deploy on EC2
@@ -65,12 +74,14 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: ECR_IMAGE,ECR_REGISTRY,AWS_REGION
           script: |
+            set -e
             aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
             cd /home/ubuntu/nunchi
             export ECR_IMAGE=$ECR_IMAGE
+            # SHA 태그 이미지를 받아 app 만 강제 재생성 (DB/redis/nginx 는 건드리지 않음)
             docker compose pull app
-            docker compose down
-            docker compose up -d
+            docker compose up -d --force-recreate app
+            docker image prune -f
 
   notify-discord:
     needs: deploy


### PR DESCRIPTION
## 📣 Related Issue

- close #
<!-- dev→main 머지 + CD success 인데도 서버에 새 프론트 빌드가 안 올라오는 문제. -->

## 📝 Summary

`#157`을 머지하고 CD가 **success** 떴는데도 서버는 계속 옛 빌드(#156, `Last-Modified: 11:32`)를 서빙 — 재배포·클린 재실행을 3번 해도 동일. 코드/머지는 정상(main HEAD 에 #157 포함)이고, **배포 파이프라인이 새 이미지를 안 올리는** 게 원인.

### 원인
이미지를 **`latest` 가변태그**로만 push 하고 EC2 에서 `docker compose pull` 하는 구조:
- 연속/동시 배포가 `latest` 를 서로 덮어쓰거나,
- `pull` 이 같은 `latest` 의 새 digest 를 확실히 끌어오지 못해 **옛 이미지로 그대로 `up`** → "CI success 인데 서버 안 바뀜"이 비결정적으로 발생.
- 게다가 EC2 스크립트에 `set -e` 가 없어 `pull` 실패해도 그냥 진행.

### 변경 — `.github/workflows/cd.yml`
- **이미지 태그: `latest` → `${{ github.sha }}`** (불변 고정태그). `latest` 도 병행 push 유지.
- 배포는 **SHA 태그 이미지**를 pull → 매번 고유·불변이라 "latest 인데 옛 이미지" 원천 차단.
- EC2: `down`(전체) 제거하고 **`docker compose up -d --force-recreate app`** (app 만 확실히 교체, postgres/redis/nginx 는 유지 → 다운타임↓) + **`set -e`**(실패 즉시 중단) + `docker image prune -f`.
- **`concurrency`**(`cd-<ref>`, `cancel-in-progress`) 로 겹친 배포 실행 취소.

## 🙏 Question & PR point

- **이 PR 이 main 에 도달하는 순간부터** 새 cd.yml 이 적용됩니다. main 에는 이미 #157 코드가 있으니, 이 PR 머지(dev→main) 시 도는 CD 가 **SHA 태그로 깨끗이 배포** → #157(눌러서 말하기 워딩·매 턴 카트 재조회)까지 한 번에 반영될 것으로 기대.
- **즉시 수동 확인/복구가 필요하면**(EC2 접근 가능 시):
  ```bash
  cd /home/ubuntu/nunchi
  docker inspect nunchi-app --format '{{.Image}} {{.Created}}'   # 현재 app 이미지 시각
  docker compose pull app && docker compose up -d --force-recreate app
  ```
  그래도 옛 빌드면 ECR `latest` 자체에 #157 이미지가 없다는 뜻(빌드/푸시 점검 필요).
- EC2 의 실제 docker-compose 가 repo 와 다를 수 있음(nginx·mcp·fastapi 등 추가 서비스 확인됨). `app` 서비스가 `${ECR_IMAGE}` 를 쓰는지만 맞으면 이 변경과 호환.

## 📬 Postman

- CI 설정 변경이라 API 변화 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 배포 프로세스 안정성 강화 및 자동화 개선
  * 중복 배포 방지 메커니즘 추가
  * 배포 실패 안전성 및 리소스 정리 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->