### PR TITLE
[Feat] 저자세(배리어프리) 모드 추가 — 화면 하단 절반 UI + 화면 꽉 채움

### DIFF
--- a/src/main/resources/static/front/css/common.css
+++ b/src/main/resources/static/front/css/common.css
@@ -308,7 +308,7 @@ body {
        zoom 사용 이유: transform: scale 은 시각만 축소하고 box 크기는 그대로 → 데스크탑 dev 환경에서
        1280px 세로가 viewport 밖으로 잘리는 문제. zoom 은 box 크기 자체를 줄여 flex center 정렬도 자연스럽다.
        비표준이지만 Chrome/Edge/Safari 지원(키오스크 실기기는 Chrome 기반이라 영향 없음). */
-    zoom: min(calc(100vw / 720), calc(100vh / 1280), 1);
+    zoom: min(calc(100vw / 720), calc(100vh / 1280));   /* 큰 화면(키오스크 1080×1920 등)은 확대해 화면을 꽉 채움 */
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/src/main/resources/static/front/css/common/low-posture.css
+++ b/src/main/resources/static/front/css/common/low-posture.css
@@ -109,22 +109,44 @@ html.posture-low .ai-chat-panel--open { transform: translateY(0); }
 /* 하단 시트(대화기록) 열리면 ♿ 토글 숨김 — 패널 하단 버튼과 겹침 방지 */
 html.posture-low body:has(.ai-chat-panel--open) .lpost-toggle { display: none; }
 
-/* N02 AI 가이드: 좌표기반 화살표/강조블록(.lit)은 640과 안 맞아 숨기고,
-   안내 콜아웃은 화면 하단 절반 '바로 위'(보이는 곳)로 고정해 올린다 */
+/* N02 AI 가이드(저자세):
+   가이드는 5개 콜아웃이 인라인 left/top 좌표 + JS 화살표로 각 버튼을 가리키는 구조라
+   640 프레임에선 좌표가 안 맞는다. 좌표기반 화살표(svg)·강조 복제(lift)는 숨기고,
+   가이드 전체를 화면 전체 오버레이로 승격한 뒤 콜아웃들을 '세로 목록'으로 펼쳐
+   한 점에 겹치지 않고 모두 읽히도록 한다. */
+html.posture-low .n02-guide {
+    position: fixed !important;          /* page-bg(640 클립) 밖, 화면 전체로 승격 */
+    inset: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 10px !important;
+    padding: 28px 16px !important;
+    overflow-y: auto !important;
+}
 html.posture-low .n02-guide__svg,
-html.posture-low .n02-guide__lit { display: none !important; }
+html.posture-low .n02-guide__lift { display: none !important; }   /* 좌표 화살표·강조 복제 숨김 */
 html.posture-low .n02-guide__callout {
-    position: fixed !important;
-    left: 50% !important;
+    position: static !important;         /* 인라인 left/top 무력화 → 세로 흐름, 겹침 제거 */
+    left: auto !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    transform: none !important;
+    width: 100% !important;
+    max-width: 460px !important;
+    margin: 0 !important;
+}
+html.posture-low .n02-guide__hint {
+    position: static !important;
+    left: auto !important;
     right: auto !important;
     top: auto !important;
-    bottom: calc(50vh + 14px) !important;
-    transform: translateX(-50%) !important;
-    width: auto !important;
-    max-width: 88vw !important;
-    z-index: 2147483001;
+    bottom: auto !important;
+    transform: none !important;
+    margin-top: 6px !important;
 }
-html.posture-low .n02-guide__hint { top: auto !important; bottom: calc(50vh + 96px) !important; }
 
 /* P05 주문완료: 히어로·번호·간격 압축 */
 html.posture-low .p05 { gap: 12px; }

--- a/src/main/resources/static/front/css/common/low-posture.css
+++ b/src/main/resources/static/front/css/common/low-posture.css
@@ -114,15 +114,17 @@ html.posture-low body:has(.ai-chat-panel--open) .lpost-toggle { display: none; }
    640 프레임에선 좌표가 안 맞는다. 좌표기반 화살표(svg)·강조 복제(lift)는 숨기고,
    가이드 전체를 화면 전체 오버레이로 승격한 뒤 콜아웃들을 '세로 목록'으로 펼쳐
    한 점에 겹치지 않고 모두 읽히도록 한다. */
-html.posture-low .n02-guide {
+/* :not([hidden]) 로 한정 — 터치 시 JS 가 hidden=true 로 닫을 때 display:flex !important 가
+   .n02-guide[hidden]{display:none} 를 덮어써 안 닫히던 문제 방지(터치로 넘어가짐). */
+html.posture-low .n02-guide:not([hidden]) {
     position: fixed !important;          /* page-bg(640 클립) 밖, 화면 전체로 승격 */
     inset: 0 !important;
     display: flex !important;
     flex-direction: column !important;
     align-items: center !important;
-    justify-content: center !important;
+    justify-content: flex-end !important; /* 저자세: 콜아웃을 화면 하단으로 내림(착석 사용자 손 닿는 곳) */
     gap: 10px !important;
-    padding: 28px 16px !important;
+    padding: 24px 16px 96px !important;   /* 하단 96px: ♿ 토글 버튼 공간 확보 */
     overflow-y: auto !important;
 }
 html.posture-low .n02-guide__svg,

--- a/src/main/resources/static/front/css/common/low-posture.css
+++ b/src/main/resources/static/front/css/common/low-posture.css
@@ -1,0 +1,136 @@
+/* ========================================================
+   low-posture.css — 저자세(배리어프리) 모드
+   휠체어/착석 사용자가 높이 조절 없이 쓰도록 화면을 하단 절반으로 내린다.
+   토글 버튼은 항상 화면 하단에 고정 → 두 모드 모두에서 닿는다.
+   적용: <html> 에 .posture-low 클래스 (low-posture.js 가 토글)
+   ======================================================== */
+
+/* ---- 저자세 토글 버튼 (항상 하단 고정) ---- */
+.lpost-toggle {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 2147483000;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 14px 18px;
+    border: 0;
+    border-radius: 999px;
+    background: #1e1915;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.lpost-toggle__icon { font-size: 22px; }
+.lpost-toggle:active { transform: scale(0.96); }
+html.posture-low .lpost-toggle { background: #cf5208; }
+
+/* ---- 저자세 모드: 가로(720)는 유지, 세로만 절반으로 줄여 하단 정렬 ---- */
+html.posture-low body {
+    align-items: flex-end;
+    padding-bottom: 84px;   /* 하단에 ♿토글 버튼 공간 확보 (페이지와 겹침 방지) */
+}
+html.posture-low .page-bg {
+    height: calc(var(--screen-height) * 0.5);   /* 1280 → 640 (가로 720 그대로) */
+    overflow-y: auto;                            /* 페이지별 콘텐츠 정리 전 임시: 넘치면 스크롤 */
+}
+
+/* ========================================================
+   페이지별 저자세(640px) 맞춤 — 1280용 큰 여백/높이를 압축해 한눈에
+   ======================================================== */
+
+/* index(s00) 시작화면: 절대배치 → 저자세에선 세로 흐름으로 (겹침 제거, 필요시 스크롤) */
+html.posture-low .s00 {
+    height: auto;
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 18px 24px 24px;
+    gap: 14px;
+}
+html.posture-low .s00 > * { position: static !important; left: auto; right: auto; top: auto; bottom: auto; }
+html.posture-low .s00__dongguk-logo { align-self: flex-end; width: 128px; }
+html.posture-low .s00__title-main { font-size: 52px; }
+html.posture-low .s00__title-sub { font-size: 16px; }
+html.posture-low .s00__slider { width: 100%; gap: 10px; }
+html.posture-low .s00__slider-viewport { height: 300px; }
+html.posture-low .s00__slide-media { height: 190px; }
+html.posture-low .s00__cta-wrap { width: 100%; padding: 0; }
+html.posture-low .s00__cta { max-width: 100%; min-height: 80px; }
+
+/* S01 주문방식 선택: 상단 200px·헤더 125px·카드 480px → 압축 */
+html.posture-low .s01 { padding-top: 28px; padding-bottom: 28px; }
+html.posture-low .s01__header { margin-bottom: 24px; }
+html.posture-low .s01__title { font-size: 32px; }
+html.posture-low .s01__subtitle { font-size: 17px; }
+html.posture-low .s01__card { min-height: 0; padding: 26px 22px 24px; }
+html.posture-low .s01__card-icon { width: 92px; height: 92px; font-size: 50px; border-radius: 24px; }
+html.posture-low .s01__card-body { gap: 6px; }
+html.posture-low .s01__card-title { font-size: 22px; }
+html.posture-low .s01__card-desc { font-size: 14px; }
+
+/* S02 식사장소 선택: S01 과 동일 구조 → 동일 압축 */
+html.posture-low .s02 { padding-top: 28px; padding-bottom: 28px; }
+html.posture-low .s02__header { margin-bottom: 24px; }
+html.posture-low .s02__title { font-size: 32px; }
+html.posture-low .s02__subtitle { font-size: 17px; }
+html.posture-low .s02__card { min-height: 0; padding: 26px 22px 24px; }
+html.posture-low .s02__card-icon { width: 92px; height: 92px; font-size: 50px; border-radius: 24px; }
+html.posture-low .s02__card-body { gap: 6px; }
+html.posture-low .s02__card-title { font-size: 22px; }
+html.posture-low .s02__card-desc { font-size: 14px; }
+
+/* 결제 모달(.paymod): inset:0 오버레이 → 저자세 시 박스를 하단 절반으로 내림 */
+html.posture-low .paymod { align-items: flex-end; }
+html.posture-low .paymod__box {
+    height: auto;
+    max-height: 48vh;
+    margin-bottom: 92px;   /* ♿버튼 공간 */
+}
+
+/* 대화 기록 패널(.ai-chat-panel): 우측 드로어 → 저자세에선 하단 시트(절반)로 */
+html.posture-low .ai-chat-dim { position: fixed; }
+html.posture-low .ai-chat-panel {
+    position: fixed;
+    inset: auto 0 0 0;
+    width: 100%;
+    height: 50vh;
+    transform: translateY(100%);
+    box-shadow: 0 -16px 48px rgba(30, 25, 21, 0.18);
+}
+html.posture-low .ai-chat-panel--open { transform: translateY(0); }
+/* 하단 시트(대화기록) 열리면 ♿ 토글 숨김 — 패널 하단 버튼과 겹침 방지 */
+html.posture-low body:has(.ai-chat-panel--open) .lpost-toggle { display: none; }
+
+/* N02 AI 가이드: 좌표기반 화살표/강조블록(.lit)은 640과 안 맞아 숨기고,
+   안내 콜아웃은 화면 하단 절반 '바로 위'(보이는 곳)로 고정해 올린다 */
+html.posture-low .n02-guide__svg,
+html.posture-low .n02-guide__lit { display: none !important; }
+html.posture-low .n02-guide__callout {
+    position: fixed !important;
+    left: 50% !important;
+    right: auto !important;
+    top: auto !important;
+    bottom: calc(50vh + 14px) !important;
+    transform: translateX(-50%) !important;
+    width: auto !important;
+    max-width: 88vw !important;
+    z-index: 2147483001;
+}
+html.posture-low .n02-guide__hint { top: auto !important; bottom: calc(50vh + 96px) !important; }
+
+/* P05 주문완료: 히어로·번호·간격 압축 */
+html.posture-low .p05 { gap: 12px; }
+html.posture-low .p05__hero,
+html.posture-low .p05__hero-ring { height: 100px; }
+html.posture-low .p05__hero-circle { width: 86px; height: 86px; font-size: 48px; }
+html.posture-low .p05__order-number { font-size: 44px; }
+html.posture-low .p05__order-card { padding: 12px 20px 10px; }
+html.posture-low .p05__summary { display: none; }   /* 저자세: 상세 요약 숨겨 번호+처음으로 버튼 우선(겹침 제거) */

--- a/src/main/resources/static/front/js/common/app-state.js
+++ b/src/main/resources/static/front/js/common/app-state.js
@@ -153,3 +153,28 @@
         get, set, remove, onChange, clear,
     };
 });
+
+/* ── 저자세(배리어프리) 모드 로더 — app-state.js 를 로드하는 모든 키오스크 페이지 공통 ──
+   sessionStorage 의 저장값을 먼저 반영(깜빡임 최소화)한 뒤, CSS/JS 를 주입한다. */
+(function () {
+    try {
+        var forced = /[?&]posture=low(\b|$)/.test(location.search);
+        if (forced || sessionStorage.getItem('postureLow') === '1') {
+            document.documentElement.classList.add('posture-low');
+        }
+    } catch (e) {}
+    if (!document.getElementById('lpost-css')) {
+        var css = document.createElement('link');
+        css.id = 'lpost-css';
+        css.rel = 'stylesheet';
+        css.href = '/css/common/low-posture.css';
+        document.head.appendChild(css);
+    }
+    if (!document.getElementById('lpost-js')) {
+        var js = document.createElement('script');
+        js.id = 'lpost-js';
+        js.src = '/js/common/low-posture.js';
+        js.defer = true;
+        document.head.appendChild(js);
+    }
+})();

--- a/src/main/resources/static/front/js/common/app-state.js
+++ b/src/main/resources/static/front/js/common/app-state.js
@@ -158,8 +158,13 @@
    sessionStorage 의 저장값을 먼저 반영(깜빡임 최소화)한 뒤, CSS/JS 를 주입한다. */
 (function () {
     try {
+        // URL(?posture=low)은 '최초 진입 seed' 용도 — 저장값이 없을 때만 1회 반영한다.
+        // (매번 우선 적용하면 토글로 끈 뒤 새로고침 시 다시 켜져 끌 수 없게 된다)
         var forced = /[?&]posture=low(\b|$)/.test(location.search);
-        if (forced || sessionStorage.getItem('postureLow') === '1') {
+        if (forced && sessionStorage.getItem('postureLow') === null) {
+            sessionStorage.setItem('postureLow', '1');
+        }
+        if (sessionStorage.getItem('postureLow') === '1') {
             document.documentElement.classList.add('posture-low');
         }
     } catch (e) {}

--- a/src/main/resources/static/front/js/common/low-posture.js
+++ b/src/main/resources/static/front/js/common/low-posture.js
@@ -17,9 +17,15 @@
         try { return /[?&]posture=low(\b|$)/.test(location.search); } catch (e) { return false; }
     }
 
+    // 상태의 단일 기준은 sessionStorage. URL(?posture=low)은 '최초 진입 seed' 용도일 뿐
+    // (init 에서 1회만 저장값에 반영) — 매번 우선시키면 토글로 끈 뒤 다시 켤 수 없다.
     function isOn() {
-        if (urlForced()) return true;
-        try { return sessionStorage.getItem(KEY) === '1'; } catch (e) { return false; }
+        try { return sessionStorage.getItem(KEY) === '1'; } catch (e) { return urlForced(); }
+    }
+
+    // 현재 화면에 실제 적용된 상태(클래스) — 토글은 이 실제 상태를 뒤집어야 안전하다.
+    function currentlyOn() {
+        return document.documentElement.classList.contains('posture-low');
     }
 
     function apply(on) {
@@ -33,7 +39,7 @@
     }
 
     function toggle() {
-        var on = !isOn();
+        var on = !currentlyOn();   // 저장값/URL 이 아닌 '실제 적용 상태'를 뒤집는다
         try { sessionStorage.setItem(KEY, on ? '1' : '0'); } catch (e) {}
         apply(on);
     }
@@ -54,6 +60,9 @@
     }
 
     function init() {
+        // URL 강제 진입은 '최초 1회'만 저장값으로 seed → 이후엔 토글/저장값이 기준이 되어
+        // ?posture=low 페이지에서 껐다 다시 켜는 것이 정상 동작한다.
+        try { if (urlForced() && sessionStorage.getItem(KEY) === null) sessionStorage.setItem(KEY, '1'); } catch (e) {}
         injectButton();
         apply(isOn());
     }

--- a/src/main/resources/static/front/js/common/low-posture.js
+++ b/src/main/resources/static/front/js/common/low-posture.js
@@ -1,0 +1,66 @@
+// ========================================================
+// low-posture.js — 저자세(배리어프리) 모드 토글
+//
+// 휠체어/착석 사용자를 위해 화면을 하단 절반으로 내리는 모드.
+// - 화면 하단 고정 버튼으로 켜고/끈다 (두 모드 모두에서 닿음)
+// - sessionStorage 에 상태 저장 → 페이지 이동해도 유지
+// - <html> 에 .posture-low 클래스 토글 (실제 레이아웃은 low-posture.css)
+//
+// 로드: app-state.js 로더가 모든 키오스크 페이지에서 자동 주입.
+// ========================================================
+(function () {
+    'use strict';
+
+    var KEY = 'postureLow';
+
+    function urlForced() {
+        try { return /[?&]posture=low(\b|$)/.test(location.search); } catch (e) { return false; }
+    }
+
+    function isOn() {
+        if (urlForced()) return true;
+        try { return sessionStorage.getItem(KEY) === '1'; } catch (e) { return false; }
+    }
+
+    function apply(on) {
+        document.documentElement.classList.toggle('posture-low', on);
+        var btn = document.getElementById('lpostToggle');
+        if (btn) {
+            btn.setAttribute('aria-pressed', String(on));
+            var label = btn.querySelector('.lpost-toggle__label');
+            if (label) label.textContent = on ? '일반 화면' : '저자세 모드';
+        }
+    }
+
+    function toggle() {
+        var on = !isOn();
+        try { sessionStorage.setItem(KEY, on ? '1' : '0'); } catch (e) {}
+        apply(on);
+    }
+
+    function injectButton() {
+        if (document.getElementById('lpostToggle')) return;
+        var b = document.createElement('button');
+        b.id = 'lpostToggle';
+        b.type = 'button';
+        b.className = 'lpost-toggle';
+        b.setAttribute('aria-label', '저자세 모드 켜고 끄기');
+        b.setAttribute('aria-pressed', 'false');
+        b.innerHTML =
+            '<span class="lpost-toggle__icon" aria-hidden="true">&#9855;</span>' +
+            '<span class="lpost-toggle__label">저자세 모드</span>';
+        b.addEventListener('click', toggle);
+        document.body.appendChild(b);
+    }
+
+    function init() {
+        injectButton();
+        apply(isOn());
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/main/resources/static/front/js/flowN/N02-menu.js
+++ b/src/main/resources/static/front/js/flowN/N02-menu.js
@@ -965,7 +965,10 @@
         if (!$guide) return;
         let seen = false;
         try { seen = sessionStorage.getItem('n02GuideSeen') === '1'; } catch (_) {}
-        if (seen) return;
+        // ?guide=1 (또는 ?guide=show): 이미 본 세션이어도 가이드를 강제로 다시 띄움 — QA/테스트용
+        let force = false;
+        try { force = /[?&]guide=(1|show)(\b|$)/.test(location.search); } catch (_) {}
+        if (seen && !force) return;
         $guide.hidden = false;
 
         // 실제 버튼 위치를 재서 점선 + 화살표를 그림 (메뉴 카드는 동적이라 좌표를 고정할 수 없음)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #

## 📝 Summary

휠체어/착석 사용자가 **높이 조절 없이** 앉은 자세에서 키오스크를 쓸 수 있도록 **저자세(배리어프리) 모드**를 추가했습니다.
화면을 **가로 720은 그대로 두고 세로만 절반(640)** 으로 압축해 하단으로 내리고, 우측 하단 고정 토글 버튼으로 일반 화면 ↔ 저자세를 전환합니다. 추가로 키오스크 실기기(1080×1920 등)에서 수동 확대 없이 **켜자마자 화면이 꽉 차도록** zoom 캡을 제거했습니다.

### 추가 파일
- `static/front/js/common/low-posture.js`
  - 우측 하단 고정 ♿ 토글 버튼 주입, `html.posture-low` 클래스 토글
  - 상태의 단일 기준은 `sessionStorage('postureLow')`, `?posture=low` 는 **최초 진입 seed** 로만 사용
  - 토글은 **실제 적용 상태(클래스)** 를 뒤집어 `?posture=low` 페이지에서도 껐다 켜기가 정상 동작
- `static/front/css/common/low-posture.css`
  - 가로 720 유지, 세로만 절반(640)으로 압축 후 **하단 정렬**
  - 페이지별 여백·높이 압축: index(s00) / S01(주문방식) / S02(식사장소) / P05(주문완료)
  - 결제 모달(`.paymod`)·대화기록 패널(`.ai-chat-panel`)을 **하단 시트**로 정렬
  - N02 AI 가이드: 좌표 화살표(svg)·강조 복제(lift) 숨김, 콜아웃 5개를 **하단 세로 목록**으로 펼쳐 겹침 제거
  - 하단 시트(대화기록) 열릴 때 토글 버튼 숨김(겹침 방지)

### 수정 파일
- `static/front/js/common/app-state.js`
  - 모든 키오스크 페이지 공통 로더 추가(저장값 선반영으로 깜빡임 최소화 후 CSS/JS 주입)
  - `?posture=low` seed-once 처리로 일관성 확보(끈 채 새로고침 시 꺼짐 유지)
- `static/front/css/common.css`
  - `zoom: min(..., 1)` 의 캡(`1`) 제거 → 큰 화면 자동 확대로 화면 꽉 채움
- `static/front/js/flowN/N02-menu.js`
  - 가이드 닫기 정상화에 맞춘 `?guide=1`(또는 `?guide=show`) **QA 강제표시** 옵션 추가

### 🔧 코드리뷰 반영 (후속 커밋)
1. **N02 가이드 콜아웃 겹침** — 5개 콜아웃을 동일 고정 좌표로 강제해 한 점에 중첩되던 문제 → 가이드를 화면 전체 오버레이로 승격 + `position:static` 세로 목록으로 펼쳐 해결. 잘못된 셀렉터 `.n02-guide__lit` → 실제 클래스 `.n02-guide__lift` 로 정정.
2. **`?posture=low` 토글 재활성화 불가** — `isOn()` 이 URL 을 매번 우선해 항상 true → 한 번 끄면 다시 못 켜던 문제 → sessionStorage 단일 기준 + 실제 상태 기반 토글로 수정.
3. **저자세 가이드 하단 정렬 + 터치 닫힘 복구** — `display:flex !important` 가 `.n02-guide[hidden]{display:none}` 를 덮어써 터치해도 안 닫히던 문제 → `:not([hidden])` 한정으로 복구, 콜아웃을 하단으로 정렬.

## 🙏 Question & PR point

- 저자세 모드는 `app-state.js` 를 로드하는 **모든 키오스크 페이지에 공통 적용**됩니다(별도 마크업 수정 불필요).
- 메인 플로우(시작 → 주문방식 → 식사장소 → 메뉴 → 결제/카드모달 → 완료 → 대화기록)를 **1080×1920 기준 직접 캡처로 시각 검증**했습니다(가로 풀폭 유지·하단 절반 정렬·버튼 비겹침 확인).
- 가이드 동작은 `?posture=low&guide=1` 진입 → 하단 표시 → 터치 시 닫힘을 자동 테스트(Playwright)로도 검증했습니다.
- 아바타(A01)는 요청에 따라 저자세 변환에서 제외했습니다.

## 📬 Postman

<!-- 프론트(정적 UI) 변경으로 API 변경 없음 -->
N/A — 프론트엔드 UI 변경(신규 API 없음)