### PR TITLE
[Release] 터치 담기 회귀 핫픽스 → main

### DIFF
--- a/src/main/resources/static/front/css/common/low-posture.css
+++ b/src/main/resources/static/front/css/common/low-posture.css
@@ -10,7 +10,9 @@
     position: fixed;
     right: 16px;
     bottom: 16px;
-    z-index: 2147483000;
+    /* 모달·다이얼로그(≥1100, 확인모달 9999)보다 낮게 → 모달이 뜨면 자연히 저자세 토글을 덮는다.
+       일반 페이지 콘텐츠(z-index ≤100)보다는 위라 평소엔 떠 있다. */
+    z-index: 999;
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -35,23 +37,13 @@
 .lpost-toggle:active { transform: scale(0.97); }
 
 /* 모달/오버레이가 열려 있으면 저자세 토글을 숨긴다 (일반·저자세 모드 공통).
-   토글 z-index 가 매우 높아, 안 숨기면 모달(상세/옵션/눈치 추천/AI 추천)
-   오른쪽 아래로 토글이 겹쳐 떠 보인다. 모달을 닫으면 다시 나타난다. */
+   토글(z-index 999)은 모달(≥1100)보다 낮아 어차피 가려지지만, 깔끔하게 완전히 숨겨 둔다.
+   모달을 닫으면 다시 나타난다. */
 body:has(.n02__detail:not([hidden])) .lpost-toggle,
 body:has(.n02-opt:not([hidden])) .lpost-toggle,
 body:has(.n02-nunchi:not([hidden])) .lpost-toggle,
 body:has(.n02-rec:not([hidden])) .lpost-toggle {
     display: none;
-}
-
-/* 모달·옵션·팝업(상세/옵션/눈치 추천/AI 추천)은 항상 최상위 레이어로 올려,
-   저자세 토글(♿, z-index 2147483000)과 저자세 UI 를 완전히 덮는다(저자세가 가려짐).
-   토글 숨김과 함께 이중으로 보장 — 모달이 뜨면 무조건 그 위에 아무것도 안 보이게. */
-.n02__detail:not([hidden]),
-.n02-opt:not([hidden]),
-.n02-nunchi:not([hidden]),
-.n02-rec:not([hidden]) {
-    z-index: 2147483600;
 }
 
 /* 저자세 ON 일 때만 살짝 따뜻하게 강조 (튀지 않게) */


### PR DESCRIPTION
## 📝 Summary
프로덕션 핫픽스: 옵션 메뉴 터치 담기가 안 되던 회귀 수정(저자세 토글 z-index 낮춰 '네, 담기' 확인모달 복구).

## 📬 Postman
- 해당 없음 (프론트 CSS)